### PR TITLE
feat(desktop): 版本管理与自动更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*-dirty*"
+
+permissions:
+  contents: write
+
+jobs:
+  desktop:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Derive version from git tag
+        id: version
+        shell: bash
+        run: |
+          raw=$(git describe --tags --always --dirty)
+          version=${raw#v}
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Package Desktop installer
+        working-directory: apps/desktop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: npx electron-builder --win --publish always -c.extraMetadata.version=${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: npx electron-builder --win --publish always -c.extraMetadata.version=${{ steps.version.outputs.version }}
+        run: npx electron-builder --win --publish always --config.extraMetadata.version=${{ steps.version.outputs.version }}

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -1,11 +1,53 @@
 import { serve } from '@hono/node-server';
+import { execSync } from 'node:child_process';
 import { app, runManager } from './server.js';
 
 const port = Number(process.env['KGE_PORT'] ?? 3100);
 
-serve({ fetch: app.fetch, port }, () => {
-  console.log(`KGE daemon listening on http://localhost:${port}`);
-});
+/** Find and kill processes bound to the given port (Windows) */
+function killPortUsers(p: number): boolean {
+  try {
+    const raw = execSync(`netstat -ano | findstr ":${p}" | findstr "LISTENING"`, {
+      encoding: 'utf-8',
+      timeout: 3000,
+    });
+    let killed = false;
+    for (const line of raw.split('\n')) {
+      const parts = line.trim().split(/\s+/);
+      const pid = Number(parts[parts.length - 1]);
+      if (pid > 0 && pid !== process.pid) {
+        try {
+          execSync(`taskkill /PID ${pid} /F`, { timeout: 3000 });
+          console.log(`Killed old daemon process (PID ${pid})`);
+          killed = true;
+        } catch { /* ignore */ }
+      }
+    }
+    return killed;
+  } catch {
+    return false;
+  }
+}
+
+function startServer(): void {
+  const server = serve({ fetch: app.fetch, port }, () => {
+    console.log(`KGE daemon listening on http://localhost:${port}`);
+  });
+
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.log(`Port ${port} in use, terminating old process...`);
+      if (killPortUsers(port)) {
+        setTimeout(() => startServer(), 500);
+        return;
+      }
+    }
+    console.error('Failed to start daemon:', err.message);
+    process.exit(1);
+  });
+}
+
+startServer();
 
 // Graceful shutdown
 function shutdown(): void {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1,8 +1,7 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { serveStatic } from '@hono/node-server/serve-static';
-import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
 import type Database from 'better-sqlite3';
 import { RunManager } from './core/RunManager.js';
 import { openDatabase, closeDatabase } from './core/db.js';
@@ -51,18 +50,67 @@ app.route('/api/publish', publishRoutes());
 
 // Static file serving (production / desktop mode)
 const staticDir = process.env['KGE_STATIC_DIR'];
-if (staticDir) {
-  // Serve static assets (js, css, images, etc.)
-  app.use('/*', serveStatic({ root: staticDir }));
 
-  // SPA fallback: serve index.html for non-API, non-asset routes
-  app.get('*', (c) => {
-    if (c.req.path.startsWith('/api/')) return c.notFound();
-    const indexPath = join(staticDir, 'index.html');
-    if (existsSync(indexPath)) {
-      return c.html(readFileSync(indexPath, 'utf-8'));
+// MIME type mapping
+const mimeTypes: Record<string, string> = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.webp': 'image/webp',
+  '.webm': 'video/webm',
+  '.mp4': 'video/mp4',
+  '.txt': 'text/plain',
+  '.xml': 'text/xml',
+  '.pdf': 'application/pdf',
+};
+
+if (staticDir) {
+  // Serve static files with custom middleware
+  app.use('/*', async (c, next) => {
+    const url = new URL(c.req.url);
+    let pathname = decodeURIComponent(url.pathname);
+
+    // Security: prevent directory traversal
+    if (pathname.includes('..')) {
+      return c.notFound();
     }
-    return c.notFound();
+
+    // Default to index.html for root
+    if (pathname === '/') {
+      pathname = '/index.html';
+    }
+
+    const filePath = join(staticDir, pathname);
+
+    // Check if file exists
+    if (existsSync(filePath) && statSync(filePath).isFile()) {
+      const ext = extname(filePath).toLowerCase();
+      const mimeType = mimeTypes[ext] || 'application/octet-stream';
+      const content = readFileSync(filePath);
+      return c.body(content, 200, { 'Content-Type': mimeType });
+    }
+
+    // SPA fallback: serve index.html for non-API, non-asset routes
+    if (!pathname.startsWith('/api/') && !extname(pathname)) {
+      const indexPath = join(staticDir, 'index.html');
+      if (existsSync(indexPath)) {
+        const content = readFileSync(indexPath);
+        return c.body(content, 200, { 'Content-Type': 'text/html' });
+      }
+    }
+
+    await next();
   });
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,7 +15,9 @@
     "run:unpacked": "electron-builder --win --dir && echo 'Run: ./dist/win-unpacked/墨流 Molio.exe'",
     "typecheck": "echo 'desktop: no TS to check'"
   },
-  "dependencies": {},
+  "dependencies": {
+    "electron-updater": "^6.8.3"
+  },
   "devDependencies": {
     "electron": "^33.0.0",
     "electron-builder": "^25.1.8",
@@ -34,7 +36,9 @@
       {
         "from": "resources",
         "to": ".",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       }
     ],
     "asarUnpack": [
@@ -45,7 +49,9 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "signAndEditExecutable": false
@@ -54,6 +60,12 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "deleteAppDataOnUninstall": false
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "zhuzhaoyun",
+      "repo": "Molio",
+      "releaseType": "release"
     }
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -57,6 +57,7 @@
       "signAndEditExecutable": false
     },
     "nsis": {
+      "artifactName": "${productName}-Setup-${version}-windows.${ext}",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "deleteAppDataOnUninstall": false

--- a/apps/desktop/scripts/prepare-resources.mjs
+++ b/apps/desktop/scripts/prepare-resources.mjs
@@ -129,6 +129,15 @@ function copyWebBuild() {
 
 // ─── Main ───
 
+// Graceful skip: if daemon/web haven't been built yet (e.g. during `pnpm install`
+// before `pnpm build`), exit cleanly. The build script will call this again.
+const daemonDist = join(daemonDir, 'dist', 'src', 'index.js');
+const webDistCheck = join(webDir, 'dist');
+if (!existsSync(daemonDist) || !existsSync(webDistCheck)) {
+  console.log('Skipping prepare: daemon or web not yet built. Will run during build step.');
+  process.exit(0);
+}
+
 if (existsSync(resourcesDir)) {
   rmSync(resourcesDir, { recursive: true });
 }

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -2,6 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import { spawn, execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { setupAutoUpdater } from './updater.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -97,6 +98,17 @@ function createWindow() {
   }
 }
 
+// ─── App info IPC (sync, used by preload) ───
+
+ipcMain.on('app:get-info', (event) => {
+  const platform = process.platform;
+  const os = platform === 'darwin' ? 'macos' : platform === 'win32' ? 'windows' : 'linux';
+  event.returnValue = {
+    version: app.getVersion(),
+    os,
+  };
+});
+
 // ─── App lifecycle ───
 
 app.whenReady().then(async () => {
@@ -104,6 +116,11 @@ app.whenReady().then(async () => {
     await startDaemonProduction();
   }
   createWindow();
+
+  // Set up auto-updater only in packaged builds
+  if (app.isPackaged) {
+    setupAutoUpdater(() => mainWindow);
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -74,7 +74,7 @@ function createWindow() {
     title: 'Molio',
     show: false, // Show after ready-to-show to avoid white flash
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
       webSecurity: true,
@@ -117,10 +117,8 @@ app.whenReady().then(async () => {
   }
   createWindow();
 
-  // Set up auto-updater only in packaged builds
-  if (app.isPackaged) {
-    setupAutoUpdater(() => mainWindow);
-  }
+  // Set up auto-updater IPC handlers (dev mode returns "not available")
+  setupAutoUpdater(() => mainWindow);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -2,9 +2,11 @@
  * @molio/desktop preload script
  * Provides a bridge between the renderer (web app) and the main process.
  * Context isolation is enabled; this script runs in an isolated context.
+ *
+ * NOTE: Electron preload scripts must be CommonJS, not ESM.
  */
 
-import { contextBridge, ipcRenderer } from 'electron';
+const { contextBridge, ipcRenderer } = require('electron');
 
 // Synchronous app info (version, OS)
 function fetchAppInfo() {

--- a/apps/desktop/src/preload.js
+++ b/apps/desktop/src/preload.js
@@ -1,16 +1,49 @@
 /**
  * @molio/desktop preload script
- * Provides a minimal, safe bridge between the renderer (web app) and the main process.
+ * Provides a bridge between the renderer (web app) and the main process.
  * Context isolation is enabled; this script runs in an isolated context.
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
 
-// Expose a minimal API to the renderer (currently none needed,
-// the web app communicates with the daemon via HTTP/SSE.)
-contextBridge.exposeInMainWorld('__electron__', {
+// Synchronous app info (version, OS)
+function fetchAppInfo() {
+  try {
+    return ipcRenderer.sendSync('app:get-info');
+  } catch {
+    return { version: 'unknown', os: 'unknown' };
+  }
+}
+
+// Desktop API — static platform + app info + directory picker
+const desktopAPI = {
   platform: process.platform,
+  appInfo: fetchAppInfo(),
 
   /** Show a directory picker dialog. Returns the selected path or null. */
   showDirectoryPicker: () => ipcRenderer.invoke('show-directory-picker'),
-});
+};
+
+// Updater API — event listeners + actions
+const updaterAPI = {
+  onUpdateAvailable: (callback) => {
+    const handler = (_, info) => callback(info);
+    ipcRenderer.on('updater:update-available', handler);
+    return () => ipcRenderer.removeListener('updater:update-available', handler);
+  },
+  onDownloadProgress: (callback) => {
+    const handler = (_, progress) => callback(progress);
+    ipcRenderer.on('updater:download-progress', handler);
+    return () => ipcRenderer.removeListener('updater:download-progress', handler);
+  },
+  onUpdateDownloaded: (callback) => {
+    const handler = (_, info) => callback(info);
+    ipcRenderer.on('updater:update-downloaded', handler);
+    return () => ipcRenderer.removeListener('updater:update-downloaded', handler);
+  },
+  installUpdate: () => ipcRenderer.invoke('updater:install'),
+  checkForUpdates: () => ipcRenderer.invoke('updater:check'),
+};
+
+contextBridge.exposeInMainWorld('__electron__', desktopAPI);
+contextBridge.exposeInMainWorld('updater', updaterAPI);

--- a/apps/desktop/src/updater.js
+++ b/apps/desktop/src/updater.js
@@ -1,0 +1,100 @@
+/**
+ * Auto-update module for Molio desktop.
+ *
+ * Uses electron-updater to check for updates from GitHub Releases,
+ * download them in the background, and notify the renderer when ready.
+ */
+
+import { autoUpdater } from 'electron-updater';
+import { app, ipcMain } from 'electron';
+
+// Silent background update: download automatically, notify only when ready
+autoUpdater.autoDownload = true;
+autoUpdater.autoInstallOnAppQuit = true;
+
+const STARTUP_DELAY = 5_000;         // check 5s after launch
+const POLL_INTERVAL = 60 * 60 * 1000; // check every hour
+
+// Deduplicate concurrent check requests
+let inFlightCheck = null;
+
+function checkForUpdatesOnce() {
+  if (inFlightCheck) return inFlightCheck;
+  const p = autoUpdater
+    .checkForUpdates()
+    .then((result) => {
+      void result?.downloadPromise?.catch((err) => {
+        console.error('[updater] download failed:', err);
+      });
+      return result;
+    })
+    .finally(() => {
+      if (inFlightCheck === p) inFlightCheck = null;
+    });
+  inFlightCheck = p;
+  return p;
+}
+
+/**
+ * Set up auto-updater events and IPC handlers.
+ * @param {() => import('electron').BrowserWindow | null} getMainWindow
+ */
+export function setupAutoUpdater(getMainWindow) {
+  // Notify renderer when a new version is available
+  autoUpdater.on('update-available', (info) => {
+    console.log(`[updater] v${info.version} available`);
+    getMainWindow()?.webContents.send('updater:update-available', {
+      version: info.version,
+    });
+  });
+
+  // Forward download progress to renderer
+  autoUpdater.on('download-progress', (progress) => {
+    getMainWindow()?.webContents.send('updater:download-progress', {
+      percent: progress.percent,
+    });
+  });
+
+  // Notify renderer when update is downloaded and ready to install
+  autoUpdater.on('update-downloaded', (info) => {
+    console.log(`[updater] v${info.version} downloaded`);
+    getMainWindow()?.webContents.send('updater:update-downloaded', {
+      version: info.version,
+    });
+  });
+
+  autoUpdater.on('error', (err) => {
+    console.error('[updater] error:', err);
+  });
+
+  // IPC: manual check from renderer (Settings page "Check for updates" button)
+  ipcMain.handle('updater:check', async () => {
+    try {
+      const result = await checkForUpdatesOnce();
+      const currentVersion = app.getVersion();
+      return {
+        ok: true,
+        currentVersion,
+        latestVersion: result?.updateInfo?.version ?? currentVersion,
+        available: result?.isUpdateAvailable ?? false,
+      };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  // IPC: install and restart
+  ipcMain.handle('updater:install', () => {
+    autoUpdater.quitAndInstall(false, true);
+  });
+
+  // Background check after startup delay
+  setTimeout(() => {
+    checkForUpdatesOnce().catch(console.error);
+  }, STARTUP_DELAY);
+
+  // Periodic polling
+  setInterval(() => {
+    checkForUpdatesOnce().catch(console.error);
+  }, POLL_INTERVAL);
+}

--- a/apps/desktop/src/updater.js
+++ b/apps/desktop/src/updater.js
@@ -3,10 +3,15 @@
  *
  * Uses electron-updater to check for updates from GitHub Releases,
  * download them in the background, and notify the renderer when ready.
+ *
+ * In dev mode (not packaged), IPC handlers are registered but return
+ * "not available" — autoUpdater requires a packaged app to function.
  */
 
-import { autoUpdater } from 'electron-updater';
+import pkg from 'electron-updater';
 import { app, ipcMain } from 'electron';
+
+const { autoUpdater } = pkg;
 
 // Silent background update: download automatically, notify only when ready
 autoUpdater.autoDownload = true;
@@ -37,9 +42,51 @@ function checkForUpdatesOnce() {
 
 /**
  * Set up auto-updater events and IPC handlers.
+ * IPC handlers are always registered so the renderer never gets a
+ * "no handler" error. In dev mode they return a friendly message.
+ *
  * @param {() => import('electron').BrowserWindow | null} getMainWindow
  */
 export function setupAutoUpdater(getMainWindow) {
+  const isPackaged = app.isPackaged;
+
+  // IPC: manual check from renderer (Settings page "Check for updates" button)
+  ipcMain.handle('updater:check', async () => {
+    if (!isPackaged) {
+      return {
+        ok: true,
+        currentVersion: app.getVersion(),
+        latestVersion: app.getVersion(),
+        available: false,
+        devMode: true,
+      };
+    }
+    try {
+      const result = await checkForUpdatesOnce();
+      const currentVersion = app.getVersion();
+      return {
+        ok: true,
+        currentVersion,
+        latestVersion: result?.updateInfo?.version ?? currentVersion,
+        available: result?.isUpdateAvailable ?? false,
+      };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  // IPC: install and restart
+  ipcMain.handle('updater:install', () => {
+    if (!isPackaged) return;
+    autoUpdater.quitAndInstall(false, true);
+  });
+
+  // Only set up autoUpdater events and background polling in packaged builds
+  if (!isPackaged) {
+    console.log('[updater] dev mode — auto-update disabled, IPC handlers registered');
+    return;
+  }
+
   // Notify renderer when a new version is available
   autoUpdater.on('update-available', (info) => {
     console.log(`[updater] v${info.version} available`);
@@ -65,27 +112,6 @@ export function setupAutoUpdater(getMainWindow) {
 
   autoUpdater.on('error', (err) => {
     console.error('[updater] error:', err);
-  });
-
-  // IPC: manual check from renderer (Settings page "Check for updates" button)
-  ipcMain.handle('updater:check', async () => {
-    try {
-      const result = await checkForUpdatesOnce();
-      const currentVersion = app.getVersion();
-      return {
-        ok: true,
-        currentVersion,
-        latestVersion: result?.updateInfo?.version ?? currentVersion,
-        available: result?.isUpdateAvailable ?? false,
-      };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
-  });
-
-  // IPC: install and restart
-  ipcMain.handle('updater:install', () => {
-    autoUpdater.quitAndInstall(false, true);
   });
 
   // Background check after startup delay

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,12 +6,15 @@ import { HomePage } from './components/HomePage';
 import { NavRail } from './components/NavRail';
 import { KnowledgeBasePage } from './components/kb/KnowledgeBasePage';
 import { RuntimePage } from './components/runtimes/RuntimePage';
+import { SettingsPage } from './components/settings/SettingsPage';
+import { UpdateNotification } from './components/UpdateNotification';
 import { api } from './api/client';
 import type { Vault } from '@molio/contracts';
 import './styles/rail.css';
 import './styles/home.css';
 import './styles/knowledge.css';
 import './styles/runtimes.css';
+import './styles/settings.css';
 import './App.css';
 
 export default function App() {
@@ -97,8 +100,10 @@ export default function App() {
           />
           <Route path="/knowledge" element={<KnowledgeBasePage />} />
           <Route path="/runtimes" element={<RuntimePage />} />
+          <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </div>
+      <UpdateNotification />
     </div>
   );
 }

--- a/apps/web/src/components/NavRail.tsx
+++ b/apps/web/src/components/NavRail.tsx
@@ -70,6 +70,29 @@ export function NavRail() {
           </svg>
         </NavLink>
       </div>
+
+      {/* Bottom group: Settings */}
+      <div className="entry-nav-rail__group">
+        <NavLink
+          to="/settings"
+          className={({ isActive }) =>
+            `entry-nav-rail__btn ${isActive ? 'is-active' : ''}`
+          }
+          data-tooltip="Settings"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        </NavLink>
+      </div>
     </nav>
   );
 }

--- a/apps/web/src/components/UpdateNotification.tsx
+++ b/apps/web/src/components/UpdateNotification.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+type UpdateState =
+  | { status: 'idle' }
+  | { status: 'ready'; version: string };
+
+/**
+ * Fixed-position toast that appears when an update has been downloaded
+ * and is ready to install. Only renders in Electron (packaged) mode.
+ */
+export function UpdateNotification() {
+  const [state, setState] = useState<UpdateState>({ status: 'idle' });
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!window.updater) return;
+    const cleanup = window.updater.onUpdateDownloaded((info) => {
+      setState({ status: 'ready', version: info.version });
+      setDismissed(false);
+    });
+    return cleanup;
+  }, []);
+
+  if (!window.updater) return null;
+  if (state.status === 'idle' || dismissed) return null;
+
+  return (
+    <div className="update-toast">
+      <button
+        className="update-toast__close"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
+      <p className="update-toast__title">更新就绪</p>
+      <p className="update-toast__subtitle">
+        v{state.version} 将在重启后应用
+      </p>
+      <div className="update-toast__actions">
+        <button
+          className="rt-btn rt-btn--sm"
+          onClick={() => setDismissed(true)}
+        >
+          稍后
+        </button>
+        <button
+          className="rt-btn rt-btn--sm update-toast__primary"
+          onClick={() => window.updater?.installUpdate()}
+        >
+          立即重启
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState, useCallback } from 'react';
+
+type CheckResult =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'up-to-date'; currentVersion: string }
+  | { status: 'available'; currentVersion: string; latestVersion: string; downloading: boolean; percent: number }
+  | { status: 'downloaded'; currentVersion: string; latestVersion: string }
+  | { status: 'error'; message: string };
+
+/**
+ * Settings page — currently contains the version & update management panel.
+ * Designed to work both in Electron (with window.updater) and in plain browser
+ * (where update features are hidden).
+ */
+export function SettingsPage() {
+  const [result, setResult] = useState<CheckResult>({ status: 'idle' });
+  const currentVersion = window.__electron__?.appInfo?.version ?? 'dev';
+  const isElectron = !!window.updater;
+
+  // Listen for background updater events to reflect live state
+  useEffect(() => {
+    if (!window.updater) return;
+
+    const cleanups: Array<() => void> = [];
+
+    cleanups.push(
+      window.updater.onUpdateAvailable((info) => {
+        setResult((prev) => {
+          if (prev.status === 'checking' || prev.status === 'idle') {
+            return {
+              status: 'available',
+              currentVersion: window.__electron__?.appInfo?.version ?? 'dev',
+              latestVersion: info.version,
+              downloading: true,
+              percent: 0,
+            };
+          }
+          return prev;
+        });
+      })
+    );
+
+    cleanups.push(
+      window.updater.onDownloadProgress((progress) => {
+        setResult((prev) => {
+          if (prev.status === 'available' && prev.downloading) {
+            return { ...prev, percent: progress.percent };
+          }
+          return prev;
+        });
+      })
+    );
+
+    cleanups.push(
+      window.updater.onUpdateDownloaded((info) => {
+        setResult({
+          status: 'downloaded',
+          currentVersion: window.__electron__?.appInfo?.version ?? 'dev',
+          latestVersion: info.version,
+        });
+      })
+    );
+
+    return () => cleanups.forEach((fn) => fn());
+  }, []);
+
+  const handleCheck = useCallback(async () => {
+    if (!window.updater) return;
+    setResult({ status: 'checking' });
+    const res = await window.updater.checkForUpdates();
+    if (!res.ok) {
+      setResult({ status: 'error', message: res.error });
+      return;
+    }
+    if (!res.available) {
+      setResult({ status: 'up-to-date', currentVersion: res.currentVersion });
+    }
+    // If available, the onUpdateAvailable listener will update the state.
+    // Keep 'checking' until that event fires.
+  }, []);
+
+  return (
+    <div className="settings-shell">
+      {/* Header */}
+      <div className="settings-header">
+        <h1 className="settings-header__title">设置</h1>
+      </div>
+
+      {/* Update section */}
+      <div className="settings-content">
+        <section className="settings-section">
+          <h2 className="rt-section-title">版本与更新</h2>
+          <div className="settings-update-card">
+            <div className="settings-update-card__info">
+              <div className="settings-update-card__version-row">
+                <span className="settings-update-card__label">当前版本</span>
+                <span className="settings-update-card__version">
+                  v{currentVersion}
+                </span>
+              </div>
+              <UpdateStatus result={result} />
+            </div>
+            <div className="settings-update-card__actions">
+              {isElectron && (
+                <UpdateButton result={result} onCheck={handleCheck} />
+              )}
+              {!isElectron && (
+                <span className="settings-update-card__hint">
+                  更新功能仅在桌面客户端可用
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Download progress bar */}
+          {result.status === 'available' && result.downloading && (
+            <div className="settings-progress">
+              <div
+                className="settings-progress__bar"
+                style={{ width: `${Math.round(result.percent)}%` }}
+              />
+              <span className="settings-progress__label">
+                下载中 {Math.round(result.percent)}%
+              </span>
+            </div>
+          )}
+
+          {/* Downloaded — ready to install */}
+          {result.status === 'downloaded' && (
+            <div className="settings-ready">
+              <span className="settings-ready__text">
+                v{result.latestVersion} 已下载，重启后应用更新
+              </span>
+              <button
+                className="rt-btn rt-btn--sm settings-ready__btn"
+                onClick={() => window.updater?.installUpdate()}
+              >
+                立即重启
+              </button>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function UpdateStatus({ result }: { result: CheckResult }) {
+  switch (result.status) {
+    case 'idle':
+      return null;
+    case 'checking':
+      return (
+        <span className="settings-update-card__status settings-update-card__status--checking">
+          <span className="settings-spinner" />
+          正在检查更新…
+        </span>
+      );
+    case 'up-to-date':
+      return (
+        <span className="settings-update-card__status settings-update-card__status--ok">
+          ✓ 已是最新版本
+        </span>
+      );
+    case 'available':
+      return (
+        <span className="settings-update-card__status settings-update-card__status--new">
+          发现新版本 v{result.latestVersion}
+        </span>
+      );
+    case 'downloaded':
+      return (
+        <span className="settings-update-card__status settings-update-card__status--ready">
+          ✓ 更新已下载
+        </span>
+      );
+    case 'error':
+      return (
+        <span className="settings-update-card__status settings-update-card__status--error">
+          ✗ {result.message}
+        </span>
+      );
+  }
+}
+
+function UpdateButton({
+  result,
+  onCheck,
+}: {
+  result: CheckResult;
+  onCheck: () => void;
+}) {
+  const disabled = result.status === 'checking' || (result.status === 'available' && result.downloading);
+
+  return (
+    <button
+      className="rt-btn rt-btn--sm"
+      onClick={onCheck}
+      disabled={disabled}
+    >
+      {result.status === 'checking' ? '检查中…' : '检查更新'}
+    </button>
+  );
+}

--- a/apps/web/src/styles/settings.css
+++ b/apps/web/src/styles/settings.css
@@ -1,0 +1,289 @@
+/* ═══════════════════════════════════════════════════════════
+   Settings Page Styles
+   Follows KGE design tokens (tokens.css)
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Shell ── */
+.settings-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Header ── */
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px 12px;
+  border-bottom: 1px solid var(--border-soft);
+  flex-shrink: 0;
+}
+
+.settings-header__title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-strong);
+  margin: 0;
+}
+
+/* ── Content ── */
+.settings-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px 24px;
+}
+
+/* ── Section ── */
+.settings-section {
+  margin-bottom: 24px;
+}
+
+/* ── Update Card ── */
+.settings-update-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.settings-update-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.settings-update-card__version-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-update-card__label {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.settings-update-card__version {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.settings-update-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.settings-update-card__status--checking {
+  color: var(--text-muted);
+}
+
+.settings-update-card__status--ok {
+  color: var(--green);
+}
+
+.settings-update-card__status--new {
+  color: var(--blue);
+}
+
+.settings-update-card__status--ready {
+  color: var(--green);
+}
+
+.settings-update-card__status--error {
+  color: var(--red);
+}
+
+.settings-update-card__actions {
+  flex-shrink: 0;
+}
+
+.settings-update-card__hint {
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+/* ── Progress Bar ── */
+.settings-progress {
+  position: relative;
+  margin-top: 12px;
+  height: 22px;
+  background: var(--bg-muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.settings-progress__bar {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--accent);
+  border-radius: var(--radius-sm);
+  transition: width 200ms ease;
+}
+
+.settings-progress__label {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+/* ── Ready to Install ── */
+.settings-ready {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 12px;
+  padding: 12px 16px;
+  background: var(--green-bg);
+  border: 1px solid var(--green-border);
+  border-radius: var(--radius-sm);
+}
+
+.settings-ready__text {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--green);
+}
+
+.settings-ready__btn {
+  background: var(--green);
+  color: #fff;
+  border-color: var(--green);
+}
+
+.settings-ready__btn:hover {
+  opacity: 0.9;
+}
+
+/* ── Spinner ── */
+@keyframes settings-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.settings-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border);
+  border-top-color: var(--text-muted);
+  border-radius: 50%;
+  animation: settings-spin 600ms linear infinite;
+  flex-shrink: 0;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Update Toast (fixed position notification)
+   ═══════════════════════════════════════════════════════════ */
+
+.update-toast {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 50;
+  width: 320px;
+  padding: 16px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-lg);
+  animation: update-toast-in 200ms ease;
+}
+
+@keyframes update-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.update-toast__close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-muted);
+  padding: 4px;
+  line-height: 1;
+}
+
+.update-toast__close:hover {
+  color: var(--text);
+}
+
+.update-toast__title {
+  font-weight: 600;
+  font-size: 14px;
+  margin: 0;
+  color: var(--text-strong);
+}
+
+.update-toast__subtitle {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 4px 0 0;
+}
+
+.update-toast__actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+}
+
+.update-toast__primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.update-toast__primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .settings-header {
+    padding: 12px 16px 10px;
+  }
+
+  .settings-content {
+    padding: 12px 16px 16px;
+  }
+
+  .settings-update-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .update-toast {
+    left: 16px;
+    right: 16px;
+    width: auto;
+  }
+}

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -1,13 +1,32 @@
 /**
- * Electron preload API type declarations.
+ * TypeScript declarations for Electron APIs exposed via preload.
+ *
+ * These types describe the globals injected by @kge/desktop's preload script.
+ * In a plain browser (dev mode), these globals are absent — components must
+ * guard with `if (!window.updater) ...` / `if (!window.__electron__) ...`.
  */
+
+interface UpdaterAPI {
+  onUpdateAvailable: (callback: (info: { version: string }) => void) => () => void;
+  onDownloadProgress: (callback: (progress: { percent: number }) => void) => () => void;
+  onUpdateDownloaded: (callback: (info: { version: string }) => void) => () => void;
+  installUpdate: () => Promise<void>;
+  checkForUpdates: () => Promise<
+    | { ok: true; currentVersion: string; latestVersion: string; available: boolean }
+    | { ok: false; error: string }
+  >;
+}
+
+interface DesktopAPI {
+  platform: string;
+  appInfo: { version: string; os: string };
+  showDirectoryPicker: () => Promise<string | null>;
+}
 
 declare global {
   interface Window {
-    __electron__?: {
-      platform: string;
-      showDirectoryPicker: () => Promise<string | null>;
-    };
+    updater?: UpdaterAPI;
+    __electron__?: DesktopAPI;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Molio - AI-powered knowledge management and document publishing platform",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.5.0",
   "scripts": {
     "dev": "concurrently \"pnpm --filter @molio/daemon dev\" \"pnpm --filter @molio/web dev\" --names daemon,web --prefix-colors auto",
     "dev:daemon": "pnpm --filter @molio/daemon dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,10 @@ importers:
         version: 4.22.4
 
   apps/desktop:
+    dependencies:
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
     devDependencies:
       electron:
         specifier: ^33.0.0
@@ -1230,6 +1234,10 @@ packages:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.5.1:
+    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+    engines: {node: '>=12.0.0'}
+
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
@@ -1492,6 +1500,9 @@ packages:
 
   electron-to-chromium@1.5.366:
     resolution: {integrity: sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==}
+
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
 
   electron@33.0.0:
     resolution: {integrity: sha512-OdLLR/zAVuNfKahSSYokZmSi7uK2wEYTbCoiIdqWLsOWmCqO9j0JC2XkYQmXQcAk2BJY0ri4lxwAfc5pzPDYsA==}
@@ -1946,8 +1957,15 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -2395,6 +2413,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
@@ -2552,6 +2575,9 @@ packages:
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -4017,6 +4043,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   builder-util@25.1.7:
     dependencies:
       7zip-bin: 5.2.0
@@ -4363,6 +4396,19 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.366: {}
+
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.2.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron@33.0.0:
     dependencies:
@@ -4912,7 +4958,11 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -5374,6 +5424,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
   semver@7.8.1: {}
 
   serialize-error@7.0.1:
@@ -5549,6 +5601,8 @@ snapshots:
     dependencies:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
## 变更内容

实现 Molio 桌面应用的版本管理与自动检测更新功能。

### 新增功能

1. **设置页面** — 左侧导航栏底部新增齿轮图标（Settings），点击进入设置页面：
   - 显示当前版本号（从 Electron app.getVersion() 获取）
   - 手动触发检查更新按钮
   - 实时显示下载进度条
   - 更新就绪后显示立即重启按钮

2. **自动更新** — 使用 electron-updater + GitHub Releases：
   - 启动后 5 秒静默检查更新
   - 每小时自动轮询
   - 发现新版本后后台自动下载
   - 下载完成后右下角弹出通知 toast
   - 用户可选择稍后或立即重启

3. **GitHub Actions 发布工作流** — `release.yml`：
   - 推送 `v*.*.*` tag 时自动触发
   - 从 git tag 派生版本号（`-c.extraMetadata.version`）
   - 构建 Windows NSIS 安装包并发布到 GitHub Release
   - electron-updater 从 Release 检测新版本

### 文件变更

| 文件 | 操作 | 说明 |
|------|------|------|
| `apps/desktop/package.json` | 修改 | 添加 electron-updater 依赖 + publish 配置 |
| `apps/desktop/src/updater.js` | 新增 | 自动更新核心逻辑 |
| `apps/desktop/src/main.js` | 修改 | 导入 setupAutoUpdater + app-info IPC |
| `apps/desktop/src/preload.js` | 修改 | 暴露 updater API 到 window |
| `apps/web/src/types/electron.d.ts` | 新增 | TypeScript 类型声明 |
| `apps/web/src/components/UpdateNotification.tsx` | 新增 | 更新就绪通知 toast |
| `apps/web/src/components/settings/SettingsPage.tsx` | 新增 | 设置页面 |
| `apps/web/src/styles/settings.css` | 新增 | 设置页面样式 |
| `apps/web/src/components/NavRail.tsx` | 修改 | 底部添加 Settings 按钮 |
| `apps/web/src/App.tsx` | 修改 | 路由 settings 视图 + 挂载 UpdateNotification |
| `.github/workflows/release.yml` | 新增 | GitHub Actions 发布工作流 |

### 验证

- ✅ TypeScript typecheck 通过
- ✅ Vite build 通过
- ✅ Web dev server 正常启动