### PR TITLE
fix: 修复 AskUserQuestion 自动确认 bug

### DIFF
--- a/apps/daemon/src/core/runtimes/claude.ts
+++ b/apps/daemon/src/core/runtimes/claude.ts
@@ -26,7 +26,10 @@ export const claudeAgentDef: RuntimeAgentDef = {
     if (options.model && options.model !== 'default') {
       args.push('--model', options.model);
     }
-    args.push('--permission-mode', 'bypassPermissions');
+    args.push('--permission-mode', 'acceptEdits');
+    // Pre-approve autonomous operation tools — but NOT AskUserQuestion,
+    // which must remain interactive so the user can respond.
+    args.push('--allowedTools', 'Bash', 'Edit', 'Write', 'NotebookEdit', 'WebFetch', 'WebSearch');
     return args;
   },
 

--- a/apps/daemon/test/claude-permission-mode.test.ts
+++ b/apps/daemon/test/claude-permission-mode.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { claudeAgentDef } from '../src/core/runtimes/claude.js';
+
+/**
+ * Error-driven test: AskUserQuestion must not be auto-confirmed.
+ *
+ * Bug: --permission-mode bypassPermissions causes the Claude CLI to
+ * auto-answer AskUserQuestion before the user has a chance to respond.
+ * The fix is to use acceptEdits + --allowedTools for autonomous tools,
+ * leaving AskUserQuestion interactive.
+ */
+
+describe('Claude runtime permission mode', () => {
+  it('should NOT use bypassPermissions (auto-confirms AskUserQuestion)', () => {
+    const args = claudeAgentDef.buildArgs('test prompt', {}, {});
+    const permIdx = args.indexOf('--permission-mode');
+    assert.ok(permIdx !== -1, 'should have --permission-mode flag');
+    const mode = args[permIdx + 1];
+    assert.notEqual(mode, 'bypassPermissions',
+      'bypassPermissions auto-answers AskUserQuestion — use acceptEdits + allowedTools instead');
+  });
+
+  it('should use acceptEdits permission mode', () => {
+    const args = claudeAgentDef.buildArgs('test prompt', {}, {});
+    const permIdx = args.indexOf('--permission-mode');
+    assert.ok(permIdx !== -1, 'should have --permission-mode flag');
+    assert.equal(args[permIdx + 1], 'acceptEdits');
+  });
+
+  it('should include --allowedTools for autonomous operation', () => {
+    const args = claudeAgentDef.buildArgs('test prompt', {}, {});
+    const toolsIdx = args.indexOf('--allowedTools');
+    assert.ok(toolsIdx !== -1, 'should have --allowedTools flag');
+    // The tools following --allowedTools should include common autonomous tools
+    const toolsStr = args.slice(toolsIdx + 1).join(' ');
+    assert.ok(toolsStr.includes('Bash'), 'should allow Bash');
+    assert.ok(toolsStr.includes('Edit'), 'should allow Edit');
+    assert.ok(toolsStr.includes('Write'), 'should allow Write');
+  });
+
+  it('should NOT include AskUserQuestion in allowedTools', () => {
+    const args = claudeAgentDef.buildArgs('test prompt', {}, {});
+    const toolsIdx = args.indexOf('--allowedTools');
+    assert.ok(toolsIdx !== -1, 'should have --allowedTools flag');
+    // Collect all args after --allowedTools until the next flag (starts with -)
+    const tools: string[] = [];
+    for (let i = toolsIdx + 1; i < args.length; i++) {
+      if (args[i]!.startsWith('-')) break;
+      tools.push(args[i]!);
+    }
+    const toolsStr = tools.join(' ');
+    assert.ok(!toolsStr.includes('AskUserQuestion'),
+      'AskUserQuestion must NOT be in allowedTools — it needs user interaction');
+  });
+});


### PR DESCRIPTION
## 问题

当 agent 调用 `AskUserQuestion` 工具向用户提问时，系统会在用户未提交的情况下自动确认信息并继续执行。

## 根因

`claude.ts` 中使用 `--permission-mode bypassPermissions` 启动 Claude CLI，导致 CLI 自动回答 `AskUserQuestion`，而不是等待宿主应用转发用户的真实回答。

## 修复

- 将 `bypassPermissions` 改为 `acceptEdits`
- 添加 `--allowedTools Bash Edit Write NotebookEdit WebFetch WebSearch` 预批准常规自主操作工具
- `AskUserQuestion` 不在 allowedTools 列表中，CLI 保持交互模式等待用户回答

## 测试

- 新增 `claude-permission-mode.test.ts`（4 条错误驱动测试用例）
- 全部 128 条测试通过

Closes #2