### PR TITLE
feat(web): 充分利用 doocs/md 上游能力

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,44 @@
+# Open Source License
+
+Molio is licensed under a modified version of the Apache License 2.0, with the following additional conditions:
+
+1. Molio may be utilized commercially, including as a backend service for
+   other applications or as a knowledge management platform for enterprises.
+   Should the conditions below be met, a commercial license must be obtained
+   from the producer:
+
+   a. Hosted or embedded service: Unless explicitly authorized by Molio
+      in writing, you may not use the Molio source code to provide a
+      hosted service to third parties, or embed Molio as a component of
+      a product or service that is sold, licensed, or otherwise
+      commercially distributed to third parties.
+
+      - This restriction applies to offering Molio (in whole or
+        substantial part) as a SaaS platform, a managed service, or as
+        an integrated component within another commercial offering.
+      - Internal use within a single organization (including multiple
+        workspaces) does not require a commercial license.
+
+   b. LOGO and copyright information: In the process of using Molio's
+      frontend, you may not remove or modify the LOGO or copyright
+      information in the Molio console or applications. This restriction
+      is inapplicable to uses of Molio that do not involve its frontend.
+
+      - Frontend Definition: For the purposes of this license, the
+        "frontend" of Molio includes all components located in the
+        `apps/web/` directory when running Molio from the raw source
+        code.
+
+2. As a contributor, you should agree that:
+
+   a. The producer can adjust the open-source agreement to be more strict
+      or relaxed as deemed necessary.
+
+   b. Your contributed code may be used for commercial purposes, including
+      but not limited to its cloud business operations.
+
+Apart from the specific conditions mentioned above, all other rights and
+restrictions follow the Apache License 2.0. Detailed information about the
+Apache License 2.0 can be found at http://www.apache.org/licenses/LICENSE-2.0.
+
+© 2025 Molio

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ Daemon 提供 REST API + SSE 事件流：
 - **WebUI First**：E2E 测试直接测 web 层，Electron 壳只测窗口管理
 - **用户偏好**：当用户已显式配置默认值时，系统不得静默回退到其他选项
 
+## 致谢
+
+Molio 的诞生离不开以下优秀开源项目的启发与支持：
+
+- **[WeKnora](https://github.com/Tencent/WeKnora)** — 知识库管理平台，为 Molio 的知识库管理模块提供了设计参考
+- **[multica](https://github.com/multica-ai/multica)** — 开源 Agent 管理平台，启发了 Molio 的多运行时编排与 Agent 交互设计
+- **[doocs/md](https://github.com/doocs/md)** — 微信 Markdown 编辑器，Molio 的文档排版与多平台格式化能力基于其核心渲染引擎 `@md/core` 构建
+
+感谢这些项目的作者和社区，让 Molio 能站在巨人的肩膀上快速成长。
+
 ## License
 
-MIT
+[Modified Apache 2.0](LICENSE) — 基于 Apache License 2.0，附加商业使用限制条款。内部使用和非商业场景完全免费，商业托管/嵌入需获取商业授权。

--- a/apps/daemon/CLAUDE.md
+++ b/apps/daemon/CLAUDE.md
@@ -50,7 +50,8 @@ test/
 ## 命令
 
 ```bash
-pnpm dev          # tsx watch src/index.ts (热重载)
+pnpm dev          # tsx src/index.ts
+pnpm dev:watch    # tsx watch src/index.ts (热重载，独立开发用)
 pnpm build        # tsc 编译到 dist/
 pnpm test         # tsc && node --test "dist/test/**/*.test.js"
 pnpm typecheck    # tsc --noEmit

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "dist/src/index.js",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx src/index.ts",
+    "dev:watch": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/src/index.js",
     "test": "tsc && node --test \"dist/test/**/*.test.js\"",

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -37,7 +37,6 @@ src/
       KnowledgeBasePage.tsx  知识库页面（文件面板 + 主内容区）
       KbFilePanel.tsx         文件树面板（搜索、文件列表、vault 切换）
       KbMainContent.tsx       主内容区（渲染 + 排版模式）
-      KbActionBar.tsx         右侧操作栏（预留）
       KbModals.tsx            模态框（vault 创建/切换/导入）
       MdRenderer.tsx          doocs/md 渲染引擎封装
       MdTypesetEditor.tsx     左右分栏排版编辑器

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/search": "^6.7.0",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.0",
     "@molio/contracts": "workspace:*",
     "es-toolkit": "^1.47.0",
     "fflate": "^0.8.3",

--- a/apps/web/scripts/update-doocs-md.sh
+++ b/apps/web/scripts/update-doocs-md.sh
@@ -41,12 +41,14 @@ rm -rf "$VENDOR_DIR/themes"
 mkdir -p "$VENDOR_DIR/themes"
 cp -r "$TEMP_DIR/packages/shared/src/configs/theme-css/"* "$VENDOR_DIR/themes/"
 
-# Copy shared dependencies (types and utils that @md/core imports)
+# Copy shared dependencies (types, utils, configs, editor that @md/core imports)
 echo "Copying shared dependencies → $VENDOR_DIR/shared/"
 rm -rf "$VENDOR_DIR/shared"
 mkdir -p "$VENDOR_DIR/shared"
 cp -r "$TEMP_DIR/packages/shared/src/types" "$VENDOR_DIR/shared/" 2>/dev/null || true
 cp -r "$TEMP_DIR/packages/shared/src/utils" "$VENDOR_DIR/shared/" 2>/dev/null || true
+cp -r "$TEMP_DIR/packages/shared/src/configs" "$VENDOR_DIR/shared/" 2>/dev/null || true
+cp -r "$TEMP_DIR/packages/shared/src/editor" "$VENDOR_DIR/shared/" 2>/dev/null || true
 
 # Update version in package.json
 if [ -n "$VERSION" ]; then

--- a/apps/web/src/components/kb/KbActionBar.tsx
+++ b/apps/web/src/components/kb/KbActionBar.tsx
@@ -1,8 +1,0 @@
-/**
- * Right action bar — reserved for future use.
- * Currently renders empty, matching the prototype.
- */
-
-export function KbActionBar() {
-  return <aside className="kb-action-bar">{/* reserved */}</aside>;
-}

--- a/apps/web/src/components/kb/KbMainContent.tsx
+++ b/apps/web/src/components/kb/KbMainContent.tsx
@@ -2,7 +2,7 @@
  * Main content area — doocs/md rendering with optional typeset mode.
  *
  * Default mode: Direct doocs/md rendering
- * Typeset mode: Left-right split editor with live preview
+ * Typeset mode: Three-column editor (editor | preview | style panel)
  */
 
 import type { FileContent } from '@molio/contracts';
@@ -14,10 +14,8 @@ interface KbMainContentProps {
   fileContent: FileContent | null;
   selectedFile: string | null;
   isTypesetMode: boolean;
-  showStylePanel: boolean;
   themeConfig: ThemeConfig;
   onToggleTypeset: () => void;
-  onToggleStylePanel: () => void;
   onThemeConfigChange: (config: ThemeConfig) => void;
   onContentChange: (content: string) => void;
   onCopy: () => void;
@@ -28,11 +26,8 @@ export function KbMainContent({
   fileContent,
   selectedFile,
   isTypesetMode,
-  showStylePanel,
   themeConfig,
   onToggleTypeset,
-  onToggleStylePanel,
-  onThemeConfigChange,
   onContentChange,
   onCopy,
   onPublish,
@@ -91,17 +86,6 @@ export function KbMainContent({
                 </svg>
                 <span>发布</span>
               </button>
-              <button
-                type="button"
-                className={`kb-btn ${showStylePanel ? 'is-active' : ''}`}
-                onClick={onToggleStylePanel}
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
-                  <circle cx="12" cy="12" r="3" />
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                </svg>
-                <span>样式</span>
-              </button>
             </>
           )}
         </div>
@@ -112,8 +96,6 @@ export function KbMainContent({
         <MdTypesetEditor
           initialContent={fileContent?.content ?? ''}
           onContentChange={onContentChange}
-          showStylePanel={showStylePanel}
-          onCloseStylePanel={onToggleStylePanel}
         />
       ) : (
         <div className="kb-content-area">

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -65,10 +65,8 @@ export function KnowledgeBasePage() {
         fileContent={kb.fileContent}
         selectedFile={kb.selectedFile}
         isTypesetMode={kb.isTypesetMode}
-        showStylePanel={kb.showStylePanel}
         themeConfig={kb.themeConfig}
         onToggleTypeset={kb.toggleTypesetMode}
-        onToggleStylePanel={kb.toggleStylePanel}
         onThemeConfigChange={kb.setThemeConfig}
         onContentChange={kb.setEditedContent}
         onCopy={kb.copyToClipboard}

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -1,12 +1,11 @@
 /**
- * Knowledge Base page — assembles file panel, main content, action bar, and modals.
+ * Knowledge Base page — assembles file panel, main content, and modals.
  */
 
 import { useCallback, useRef } from 'react';
 import { useKnowledge } from '../../hooks/useKnowledge';
 import { KbFilePanel } from './KbFilePanel';
 import { KbMainContent } from './KbMainContent';
-import { KbActionBar } from './KbActionBar';
 import { VaultSwitcherModal, AddVaultModal, ImportModal } from './KbModals';
 
 export function KnowledgeBasePage() {
@@ -75,9 +74,6 @@ export function KnowledgeBasePage() {
         onCopy={kb.copyToClipboard}
         onPublish={() => {/* TODO: publish flow */}}
       />
-
-      {/* Action Bar (reserved) */}
-      <KbActionBar />
 
       {/* Modals */}
       <VaultSwitcherModal

--- a/apps/web/src/components/kb/MdRenderer.tsx
+++ b/apps/web/src/components/kb/MdRenderer.tsx
@@ -6,6 +6,9 @@
  * - highlight.js code highlighting
  * - DOMPurify XSS sanitization
  * - Full theme system (CSS variables + theme CSS injection)
+ *
+ * Note: All styles are managed by doocs/md theme system (applyTheme).
+ * Do NOT add custom CSS here — use the theme system instead.
  */
 
 import { useEffect, useRef, useMemo, useState } from 'react';
@@ -38,13 +41,15 @@ const defaultOptions: IOpts = {
 
 /**
  * Build renderer options from themeConfig.
- * Maps theme-level booleans (isMacCodeBlock, isShowLineNumber) into IOpts fields.
+ * Maps theme-level booleans and config values into IOpts fields.
  */
 function buildRendererOptions(base: Partial<IOpts>, themeConfig?: ThemeConfig): IOpts {
   return {
     ...defaultOptions,
     ...base,
-    // Override with theme config if available
+    legend: themeConfig?.legend ?? base.legend ?? defaultOptions.legend,
+    citeStatus: themeConfig?.citeStatus ?? base.citeStatus ?? defaultOptions.citeStatus,
+    countStatus: themeConfig?.countStatus ?? base.countStatus ?? defaultOptions.countStatus,
     isMacCodeBlock: themeConfig?.isMacCodeBlock ?? base.isMacCodeBlock ?? defaultOptions.isMacCodeBlock,
     isShowLineNumber: themeConfig?.isShowLineNumber ?? base.isShowLineNumber ?? defaultOptions.isShowLineNumber,
   };
@@ -90,15 +95,9 @@ export function MdRenderer({
   }, [content, renderer]);
 
   // Apply theme CSS when themeConfig changes
+  // The doocs/md theme system handles all styles — do NOT inject styles manually
   useEffect(() => {
     if (!themeConfig) return;
-
-    // Build heading styles from theme config (can be extended later)
-    const headingStyles = themeConfig.themeName === 'grace'
-      ? { h1: 'default' as const, h2: 'default' as const, h3: 'default' as const, h4: 'default' as const, h5: 'default' as const, h6: 'default' as const }
-      : themeConfig.themeName === 'simple'
-        ? { h1: 'default' as const, h2: 'default' as const, h3: 'default' as const, h4: 'default' as const, h5: 'default' as const, h6: 'default' as const }
-        : { h1: 'default' as const, h2: 'default' as const, h3: 'default' as const, h4: 'default' as const, h5: 'default' as const, h6: 'default' as const };
 
     applyTheme({
       themeName: themeConfig.themeName,
@@ -108,18 +107,12 @@ export function MdRenderer({
         fontSize: themeConfig.fontSize,
         isUseIndent: themeConfig.isUseIndent,
         isUseJustify: themeConfig.isUseJustify,
-        headingStyles,
+        headingStyles: themeConfig.headingStyles,
       },
       customCSS: themeConfig.customCSS,
     }).catch((err) => {
       console.error('Failed to apply theme:', err);
     });
-
-    // Cleanup: remove theme style on unmount
-    return () => {
-      // ThemeInjector keeps a singleton; we don't remove on every config change
-      // because applyTheme reuses the same <style> tag. Only clean up if needed.
-    };
   }, [themeConfig]);
 
   return (

--- a/apps/web/src/components/kb/MdStylePanel.tsx
+++ b/apps/web/src/components/kb/MdStylePanel.tsx
@@ -1,25 +1,51 @@
 /**
  * MdStylePanel — Theme and style configuration panel for doocs/md rendering.
  *
- * Provides controls for:
+ * Embedded sidebar panel providing controls for:
  * - Theme selection (classic, graceful, simple)
- * - Font family
- * - Font size
- * - Primary color
- * - Display options (indent, justify, code styling)
+ * - Font family, font size, primary color
+ * - Code block theme (80+ highlight.js themes)
+ * - Heading styles (per-level: h1-h6)
+ * - Preview width (mobile 375px / desktop full)
+ * - Legend display mode
+ * - Toggle options (indent, justify, Mac code, line numbers, cite, count)
  */
 
 import { useCallback } from 'react';
+import type { IConfigOption } from '@molio/doocs-md/shared/types/common';
+import {
+  fontFamilyOptions,
+  fontSizeOptions,
+  colorOptions,
+  widthOptions,
+  codeBlockThemeOptions,
+  headingLevelOptions,
+  headingStyleOptions,
+  legendOptions,
+  type HeadingLevel,
+  type HeadingStyleType,
+  type HeadingStyles,
+} from '@molio/doocs-md/shared/configs/style';
+
+export type { HeadingLevel, HeadingStyleType, HeadingStyles };
 
 export interface ThemeConfig {
   /** Theme name: 'default' | 'grace' | 'simple' */
   themeName: string;
   /** Primary accent color */
   primaryColor: string;
-  /** Font family */
+  /** Font family CSS value */
   fontFamily: string;
   /** Font size (px) */
   fontSize: string;
+  /** Code block theme CSS URL */
+  codeBlockTheme: string;
+  /** Heading styles per level */
+  headingStyles: HeadingStyles;
+  /** Image legend display mode */
+  legend: string;
+  /** Preview width: mobile (375px) or desktop (full) */
+  previewWidth: 'mobile' | 'desktop';
   /** Enable paragraph first-line indent */
   isUseIndent: boolean;
   /** Enable text justify */
@@ -28,19 +54,29 @@ export interface ThemeConfig {
   isMacCodeBlock: boolean;
   /** Show line numbers in code blocks */
   isShowLineNumber: boolean;
+  /** Enable cite status */
+  citeStatus: boolean;
+  /** Enable count status */
+  countStatus: boolean;
   /** Custom CSS (optional) */
   customCSS?: string;
 }
 
 export const defaultThemeConfig: ThemeConfig = {
   themeName: 'default',
-  primaryColor: '#3b82f6',
-  fontFamily: '-apple-system, "Segoe UI", Roboto, sans-serif',
-  fontSize: '15px',
-  isUseIndent: true,
+  primaryColor: colorOptions[0]!.value,
+  fontFamily: fontFamilyOptions[0]!.value,
+  fontSize: fontSizeOptions[2]!.value,
+  codeBlockTheme: codeBlockThemeOptions[23]!.value, // 'github'
+  headingStyles: {},
+  legend: legendOptions[0]!.value,
+  previewWidth: 'mobile',
+  isUseIndent: false,
   isUseJustify: true,
   isMacCodeBlock: true,
   isShowLineNumber: false,
+  citeStatus: false,
+  countStatus: false,
 };
 
 export interface MdStylePanelProps {
@@ -48,10 +84,6 @@ export interface MdStylePanelProps {
   config: ThemeConfig;
   /** Callback when config changes */
   onChange: (config: ThemeConfig) => void;
-  /** Whether panel is visible */
-  visible: boolean;
-  /** Close panel callback */
-  onClose: () => void;
 }
 
 // Theme options
@@ -61,30 +93,7 @@ const THEMES = [
   { name: 'simple', label: '简洁', preview: '#fff' },
 ];
 
-// Font options
-const FONTS = [
-  { label: '无衬线 (Sans-serif)', value: '-apple-system, "Segoe UI", Roboto, sans-serif' },
-  { label: '衬线 (Serif)', value: 'Georgia, "Songti SC", serif' },
-  { label: '等宽 (Monospace)', value: '"SF Mono", "Fira Code", monospace' },
-];
-
-// Size options
-const SIZES = [
-  { label: '更小', value: '13px' },
-  { label: '稍小', value: '14px' },
-  { label: '推荐', value: '15px' },
-  { label: '稍大', value: '16px' },
-  { label: '更大', value: '17px' },
-];
-
-// Color options
-const COLORS = [
-  '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
-  '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
-  '#d97744', '#6b7280',
-];
-
-export function MdStylePanel({ config, onChange, visible, onClose }: MdStylePanelProps) {
+export function MdStylePanel({ config, onChange }: MdStylePanelProps) {
   const updateConfig = useCallback(
     (updates: Partial<ThemeConfig>) => {
       onChange({ ...config, ...updates });
@@ -92,15 +101,21 @@ export function MdStylePanel({ config, onChange, visible, onClose }: MdStylePane
     [config, onChange]
   );
 
-  if (!visible) return null;
+  const updateHeadingStyle = useCallback(
+    (level: HeadingLevel, style: HeadingStyleType) => {
+      const newHeadingStyles = { ...config.headingStyles };
+      if (style === 'default') {
+        delete newHeadingStyles[level];
+      } else {
+        (newHeadingStyles as Record<string, string>)[level] = style;
+      }
+      updateConfig({ headingStyles: newHeadingStyles as HeadingStyles });
+    },
+    [config.headingStyles, updateConfig]
+  );
 
   return (
-    <div className="kb-style-panel">
-      <div className="kb-style-panel-header">
-        <span>样式设置</span>
-        <button className="kb-style-close" onClick={onClose}>×</button>
-      </div>
-
+    <aside className="kb-style-panel">
       <div className="kb-style-panel-content">
         {/* Theme Selection */}
         <div className="kb-style-section">
@@ -119,17 +134,18 @@ export function MdStylePanel({ config, onChange, visible, onClose }: MdStylePane
           </div>
         </div>
 
-        {/* Font Selection */}
+        {/* Font Family */}
         <div className="kb-style-section">
           <div className="kb-style-section-title">字体</div>
           <div className="kb-font-list">
-            {FONTS.map((font) => (
+            {fontFamilyOptions.map((font) => (
               <div
                 key={font.value}
                 className={`kb-font-item ${config.fontFamily === font.value ? 'is-selected' : ''}`}
                 onClick={() => updateConfig({ fontFamily: font.value })}
               >
-                {font.label}
+                <span className="kb-font-label">{font.label}</span>
+                <span className="kb-font-desc">{font.desc}</span>
               </div>
             ))}
           </div>
@@ -139,13 +155,14 @@ export function MdStylePanel({ config, onChange, visible, onClose }: MdStylePane
         <div className="kb-style-section">
           <div className="kb-style-section-title">字号</div>
           <div className="kb-size-list">
-            {SIZES.map((size) => (
+            {fontSizeOptions.map((size) => (
               <div
                 key={size.value}
                 className={`kb-size-item ${config.fontSize === size.value ? 'is-selected' : ''}`}
                 onClick={() => updateConfig({ fontSize: size.value })}
               >
-                {size.label}
+                <span className="kb-size-label">{size.label}</span>
+                <span className="kb-size-desc">{size.desc}</span>
               </div>
             ))}
           </div>
@@ -155,20 +172,103 @@ export function MdStylePanel({ config, onChange, visible, onClose }: MdStylePane
         <div className="kb-style-section">
           <div className="kb-style-section-title">主题色</div>
           <div className="kb-color-grid">
-            {COLORS.map((color) => (
+            {colorOptions.map((color) => (
               <div
-                key={color}
-                className={`kb-color-option ${config.primaryColor === color ? 'is-selected' : ''}`}
-                style={{ background: color }}
-                onClick={() => updateConfig({ primaryColor: color })}
+                key={color.value}
+                className={`kb-color-option ${config.primaryColor === color.value ? 'is-selected' : ''}`}
+                style={{ background: color.value }}
+                title={`${color.label} — ${color.desc}`}
+                onClick={() => updateConfig({ primaryColor: color.value })}
               />
             ))}
           </div>
         </div>
 
+        {/* Code Block Theme */}
+        <div className="kb-style-section">
+          <div className="kb-style-section-title">代码块主题</div>
+          <select
+            className="kb-style-select"
+            value={config.codeBlockTheme}
+            onChange={(e) => updateConfig({ codeBlockTheme: e.target.value })}
+          >
+            {codeBlockThemeOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Heading Styles */}
+        <div className="kb-style-section">
+          <div className="kb-style-section-title">标题样式</div>
+          <div className="kb-heading-styles">
+            {headingLevelOptions.map((level) => {
+              const currentStyle = (config.headingStyles as Record<string, string>)[level.value] ?? 'default';
+              return (
+                <div key={level.value} className="kb-heading-row">
+                  <span className="kb-heading-level">{level.label}</span>
+                  <select
+                    className="kb-style-select kb-heading-select"
+                    value={currentStyle}
+                    onChange={(e) => updateHeadingStyle(level.value as HeadingLevel, e.target.value as HeadingStyleType)}
+                  >
+                    {headingStyleOptions.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div className="kb-style-section">
+          <div className="kb-style-section-title">图片说明</div>
+          <select
+            className="kb-style-select"
+            value={config.legend}
+            onChange={(e) => updateConfig({ legend: e.target.value })}
+          >
+            {legendOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Preview Width */}
+        <div className="kb-style-section">
+          <div className="kb-style-section-title">预览宽度</div>
+          <div className="kb-width-list">
+            {widthOptions.map((opt) => {
+              const isMobile = opt.value === 'w-[375px]';
+              const isSelected = isMobile
+                ? config.previewWidth === 'mobile'
+                : config.previewWidth === 'desktop';
+              return (
+                <div
+                  key={opt.value}
+                  className={`kb-width-item ${isSelected ? 'is-selected' : ''}`}
+                  onClick={() => updateConfig({ previewWidth: isMobile ? 'mobile' : 'desktop' })}
+                >
+                  <span className="kb-width-icon">{isMobile ? '📱' : '🖥️'}</span>
+                  <span className="kb-width-label">{opt.label}</span>
+                  <span className="kb-width-desc">{opt.desc}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
         {/* Options */}
         <div className="kb-style-section">
-          <div className="kb-style-section-title">选项</div>
+          <div className="kb-style-section-title">排版选项</div>
 
           <ToggleOption
             label="段落首行缩进"
@@ -190,9 +290,19 @@ export function MdStylePanel({ config, onChange, visible, onClose }: MdStylePane
             value={config.isShowLineNumber}
             onChange={(v) => updateConfig({ isShowLineNumber: v })}
           />
+          <ToggleOption
+            label="引用状态"
+            value={config.citeStatus}
+            onChange={(v) => updateConfig({ citeStatus: v })}
+          />
+          <ToggleOption
+            label="字数统计"
+            value={config.countStatus}
+            onChange={(v) => updateConfig({ countStatus: v })}
+          />
         </div>
       </div>
-    </div>
+    </aside>
   );
 }
 

--- a/apps/web/src/components/kb/MdTypesetEditor.tsx
+++ b/apps/web/src/components/kb/MdTypesetEditor.tsx
@@ -1,89 +1,305 @@
 /**
- * MdTypesetEditor — Left-right split editor for Markdown content.
+ * MdTypesetEditor — Three-column Markdown editor with live preview.
  *
- * Features:
- * - Left panel: Markdown source editor (textarea)
- * - Right panel: Live preview using MdRenderer
- * - Optional style panel overlay
+ * Layout:
+ * - Left: CodeMirror 6 Markdown editor (syntax highlighting, shortcuts)
+ * - Center: Live preview with mobile/desktop width toggle
+ * - Right: Embedded style panel (always visible)
+ *
+ * Uses vendored editor configs from @md/shared (doocs/md upstream).
+ * Features synchronized scrolling between editor and preview.
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { EditorView, keymap, placeholder } from '@codemirror/view';
+import { EditorState, Prec } from '@codemirror/state';
+import { defaultKeymap, history, historyKeymap, undo, redo } from '@codemirror/commands';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
+import { foldGutter, foldKeymap } from '@codemirror/language';
+import { highlightSelectionMatches, searchKeymap } from '@codemirror/search';
 import { MdRenderer } from './MdRenderer';
 import { MdStylePanel, defaultThemeConfig, type ThemeConfig } from './MdStylePanel';
+
+// ─── Markdown formatting helpers (from @md/shared/editor/format.ts) ───
+
+function toggleFormat(
+  view: EditorView,
+  prefix: string,
+  suffix: string,
+  cursorOffset = 0,
+): void {
+  const sel = view.state.selection.main;
+  const selected = view.state.doc.sliceString(sel.from, sel.to);
+  const isFormatted = selected.startsWith(prefix) && selected.endsWith(suffix);
+
+  if (isFormatted) {
+    const inner = selected.slice(prefix.length, selected.length - suffix.length);
+    view.dispatch(view.state.replaceSelection(inner));
+  } else {
+    const wrapped = `${prefix}${selected}${suffix}`;
+    view.dispatch(view.state.replaceSelection(wrapped));
+    if (cursorOffset !== 0) {
+      const newPos = view.state.selection.main.head + cursorOffset;
+      view.dispatch({ selection: { anchor: newPos } });
+    }
+  }
+}
+
+function applyHeading(view: EditorView, level: number): void {
+  const prefix = `${'#'.repeat(level)} `;
+  const range = view.state.selection.main;
+  const line = view.state.doc.lineAt(range.from);
+  const text = view.state.doc.sliceString(line.from, line.to);
+  const cleaned = text.replace(/^#{1,6}\s+/, '').trimStart();
+  view.dispatch({
+    changes: { from: line.from, to: line.to, insert: prefix + cleaned },
+    selection: { anchor: line.from + prefix.length },
+  });
+}
+
+const markdownKeymap = keymap.of([
+  { key: 'Mod-b', run: (v) => { toggleFormat(v, '**', '**', -2); return true; } },
+  { key: 'Mod-i', run: (v) => { toggleFormat(v, '*', '*', -1); return true; } },
+  { key: 'Mod-k', run: (v) => { toggleFormat(v, '[', ']()', -1); return true; } },
+  { key: 'Mod-e', run: (v) => { toggleFormat(v, '`', '`', -1); return true; } },
+  { key: 'Mod-d', run: (v) => { toggleFormat(v, '~~', '~~', -2); return true; } },
+  { key: 'Mod-1', run: (v) => { applyHeading(v, 1); return true; } },
+  { key: 'Mod-2', run: (v) => { applyHeading(v, 2); return true; } },
+  { key: 'Mod-3', run: (v) => { applyHeading(v, 3); return true; } },
+  { key: 'Mod-z', run: (v) => undo(v) },
+  { key: 'Mod-y', run: (v) => redo(v) },
+]);
+
+// ─── Editor theme (matches Claude design tokens) ───
+
+const editorTheme = EditorView.theme({
+  '&': {
+    fontSize: '13px',
+    fontFamily: 'var(--mono)',
+    backgroundColor: 'var(--bg-panel)',
+    color: 'var(--text)',
+    height: '100%',
+  },
+  '.cm-content': {
+    padding: '16px',
+    lineHeight: '1.7',
+    caretColor: 'var(--accent)',
+  },
+  '.cm-cursor': {
+    borderLeftColor: 'var(--accent)',
+  },
+  '&.cm-focused .cm-selectionBackground, ::selection': {
+    backgroundColor: 'var(--selected-soft)',
+  },
+  '.cm-gutters': {
+    backgroundColor: 'transparent',
+    borderRight: 'none',
+    color: 'var(--text-faint)',
+  },
+  '.cm-activeLineGutter': {
+    backgroundColor: 'transparent',
+    color: 'var(--text-muted)',
+  },
+  '.cm-activeLine': {
+    backgroundColor: 'var(--bg-subtle)',
+  },
+  '.cm-foldGutter': {
+    width: '10px',
+    overflow: 'hidden',
+  },
+  '.cm-foldGutter .cm-gutterElement': {
+    padding: '0',
+    width: '10px',
+  },
+  '.cm-foldGutter .cm-gutterElement span': {
+    opacity: '0',
+    transition: 'opacity 0.15s ease',
+  },
+  '.cm-gutters:hover .cm-foldGutter .cm-gutterElement span': {
+    opacity: '1',
+  },
+  // Markdown syntax highlighting
+  '.cm-heading': { fontWeight: '600', color: 'var(--text-strong)' },
+  '.cm-strong': { fontWeight: '600' },
+  '.cm-emphasis': { fontStyle: 'italic' },
+  '.cm-link': { color: 'var(--selected)', textDecoration: 'none' },
+  '.cm-url': { color: 'var(--text-muted)' },
+  '.cm-monospace': {
+    fontFamily: 'var(--mono)',
+    backgroundColor: 'var(--bg-subtle)',
+    borderRadius: '4px',
+    padding: '1px 3px',
+  },
+  '.cm-strikethrough': { textDecoration: 'line-through', color: 'var(--text-muted)' },
+});
+
+// ─── Component ───
 
 export interface MdTypesetEditorProps {
   /** Initial Markdown content */
   initialContent: string;
   /** Callback when content changes */
   onContentChange?: (content: string) => void;
-  /** Whether style panel is visible */
-  showStylePanel?: boolean;
-  /** Close style panel callback */
-  onCloseStylePanel?: () => void;
 }
 
 export function MdTypesetEditor({
   initialContent,
   onContentChange,
-  showStylePanel = false,
-  onCloseStylePanel,
 }: MdTypesetEditorProps) {
   const [content, setContent] = useState(initialContent);
   const [themeConfig, setThemeConfig] = useState<ThemeConfig>(defaultThemeConfig);
 
+  const editorContainerRef = useRef<HTMLDivElement>(null);
+  const editorViewRef = useRef<EditorView | null>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const syncingRef = useRef(false);
+
   // Sync initial content when it changes (e.g., file switch)
   useEffect(() => {
     setContent(initialContent);
+    // Also update the CodeMirror editor content
+    const view = editorViewRef.current;
+    if (view) {
+      const currentContent = view.state.doc.toString();
+      if (currentContent !== initialContent) {
+        view.dispatch({
+          changes: { from: 0, to: currentContent.length, insert: initialContent },
+        });
+      }
+    }
   }, [initialContent]);
 
-  const handleContentChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const newContent = e.target.value;
-      setContent(newContent);
-      onContentChange?.(newContent);
-    },
-    [onContentChange]
-  );
+  // Initialize CodeMirror editor
+  useEffect(() => {
+    if (!editorContainerRef.current) return;
+
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: initialContent,
+        extensions: [
+          // Markdown language support with code block highlighting
+          markdown({
+            base: markdownLanguage,
+            codeLanguages: languages,
+            addKeymap: true,
+          }),
+
+          // History (undo/redo)
+          history(),
+          highlightSelectionMatches(),
+          closeBrackets(),
+
+          // Fold gutter
+          foldGutter(),
+
+          // Custom Markdown shortcuts (high priority)
+          Prec.high(markdownKeymap),
+
+          // Default keymaps
+          keymap.of([
+            ...defaultKeymap,
+            ...historyKeymap,
+            ...closeBracketsKeymap,
+            ...foldKeymap,
+            ...searchKeymap,
+          ]),
+
+          // Editor config
+          EditorView.lineWrapping,
+          EditorState.allowMultipleSelections.of(true),
+          placeholder('在此输入 Markdown...'),
+
+          // Theme
+          editorTheme,
+
+          // Update listener for content changes
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+              const newContent = update.state.doc.toString();
+              setContent(newContent);
+              onContentChange?.(newContent);
+            }
+          }),
+        ],
+      }),
+      parent: editorContainerRef.current,
+    });
+
+    editorViewRef.current = view;
+
+    return () => {
+      view.destroy();
+      editorViewRef.current = null;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Synchronized scrolling between editor and preview
+  useEffect(() => {
+    const editorScroller = editorContainerRef.current?.querySelector('.cm-scroller') as HTMLElement | null;
+    const preview = previewRef.current;
+    if (!editorScroller || !preview) return;
+
+    const syncScroll = (source: HTMLElement, target: HTMLElement) => {
+      if (syncingRef.current) return;
+      syncingRef.current = true;
+
+      const sourceMax = source.scrollHeight - source.clientHeight;
+      const targetMax = target.scrollHeight - target.clientHeight;
+      if (sourceMax <= 0 || targetMax <= 0) {
+        syncingRef.current = false;
+        return;
+      }
+
+      const ratio = source.scrollTop / sourceMax;
+      target.scrollTop = ratio * targetMax;
+
+      requestAnimationFrame(() => {
+        syncingRef.current = false;
+      });
+    };
+
+    const handleEditorScroll = () => syncScroll(editorScroller, preview);
+    const handlePreviewScroll = () => syncScroll(preview, editorScroller);
+
+    editorScroller.addEventListener('scroll', handleEditorScroll);
+    preview.addEventListener('scroll', handlePreviewScroll);
+
+    return () => {
+      editorScroller.removeEventListener('scroll', handleEditorScroll);
+      preview.removeEventListener('scroll', handlePreviewScroll);
+    };
+  }, []);
 
   const handleThemeChange = useCallback((newConfig: ThemeConfig) => {
     setThemeConfig(newConfig);
   }, []);
 
+  const isMobilePreview = themeConfig.previewWidth === 'mobile';
+
   return (
     <div className="kb-typeset-editor">
-      {/* Left: Editor */}
+      {/* Left: CodeMirror Editor */}
       <div className="kb-typeset-left">
-        <div className="kb-typeset-header">
-          <span className="kb-editor-label">Markdown</span>
-          <span className="kb-editor-hint">实时保存</span>
-        </div>
-        <textarea
-          className="kb-typeset-textarea"
-          value={content}
-          onChange={handleContentChange}
-          placeholder="在此输入 Markdown..."
-          spellCheck={false}
-        />
+        <div ref={editorContainerRef} className="kb-typeset-cm" />
       </div>
 
-      {/* Right: Preview + Style Panel */}
-      <div className="kb-typeset-right">
-        <div className="kb-typeset-header">
-          <span className="kb-editor-label">Preview</span>
-          <span className="kb-editor-hint">doocs/md 渲染</span>
-        </div>
-        <div className="kb-typeset-preview">
+      {/* Center: Preview */}
+      <div className="kb-typeset-center">
+        <div
+          ref={previewRef}
+          className={`kb-typeset-preview ${isMobilePreview ? 'is-mobile' : 'is-desktop'}`}
+        >
           <MdRenderer content={content} themeConfig={themeConfig} />
         </div>
-
-        {/* Style Panel Overlay */}
-        <MdStylePanel
-          config={themeConfig}
-          onChange={handleThemeChange}
-          visible={showStylePanel}
-          onClose={onCloseStylePanel ?? (() => {})}
-        />
       </div>
+
+      {/* Right: Style Panel (embedded, always visible) */}
+      <MdStylePanel
+        config={themeConfig}
+        onChange={handleThemeChange}
+      />
     </div>
   );
 }

--- a/apps/web/src/hooks/useKnowledge.ts
+++ b/apps/web/src/hooks/useKnowledge.ts
@@ -8,6 +8,7 @@ import type { Vault, TreeNode, FileContent, KbHistoryEntry } from '@molio/contra
 import { api } from '../api/client';
 import type { ThemeConfig } from '../components/kb/MdStylePanel';
 import { defaultThemeConfig } from '../components/kb/MdStylePanel';
+import { copyHtml } from '@molio/doocs-md/shared/utils/clipboard';
 
 export type KbTab = 'preview'; // Simplified - only preview tab now
 
@@ -28,7 +29,6 @@ interface UseKnowledgeReturn {
 
   // Typeset mode state
   isTypesetMode: boolean;
-  showStylePanel: boolean;
   themeConfig: ThemeConfig;
   editedContent: string | null;
 
@@ -52,7 +52,6 @@ interface UseKnowledgeReturn {
 
   // Typeset actions
   toggleTypesetMode: () => void;
-  toggleStylePanel: () => void;
   setThemeConfig: (config: ThemeConfig) => void;
   setEditedContent: (content: string) => void;
   copyToClipboard: () => Promise<void>;
@@ -77,7 +76,6 @@ export function useKnowledge(): UseKnowledgeReturn {
 
   // Typeset mode state
   const [isTypesetMode, setIsTypesetMode] = useState(false);
-  const [showStylePanel, setShowStylePanel] = useState(false);
   const [themeConfig, setThemeConfig] = useState<ThemeConfig>(defaultThemeConfig);
   const [editedContent, setEditedContent] = useState<string | null>(null);
 
@@ -192,15 +190,8 @@ export function useKnowledge(): UseKnowledgeReturn {
   const toggleTypesetMode = useCallback(() => {
     setIsTypesetMode((prev) => {
       // When exiting typeset mode, also close style panel
-      if (prev) {
-        setShowStylePanel(false);
-      }
       return !prev;
     });
-  }, []);
-
-  const toggleStylePanel = useCallback(() => {
-    setShowStylePanel((prev) => !prev);
   }, []);
 
   const handleEditedContentChange = useCallback((content: string) => {
@@ -208,14 +199,19 @@ export function useKnowledge(): UseKnowledgeReturn {
   }, []);
 
   const copyToClipboard = useCallback(async () => {
-    const content = editedContent ?? fileContent?.content ?? '';
-    if (!content) return;
+    const markdownSource = editedContent ?? fileContent?.content ?? '';
+    if (!markdownSource) return;
 
-    try {
-      await navigator.clipboard.writeText(content);
-      // Could add a toast notification here
-    } catch (error) {
-      console.error('Failed to copy to clipboard:', error);
+    // Get the rendered HTML from the preview container (#output)
+    const outputEl = document.querySelector('#output');
+    const html = outputEl?.innerHTML ?? '';
+
+    if (html) {
+      // Copy rich HTML + plain text fallback (for WeChat/paste targets)
+      await copyHtml(html, markdownSource);
+    } else {
+      // Fallback: plain text only (no preview rendered yet)
+      await copyHtml('', markdownSource);
     }
   }, [editedContent, fileContent]);
 
@@ -231,7 +227,6 @@ export function useKnowledge(): UseKnowledgeReturn {
     searchQuery,
     loading,
     isTypesetMode,
-    showStylePanel,
     themeConfig,
     editedContent,
     showVaultSwitcher,
@@ -249,7 +244,6 @@ export function useKnowledge(): UseKnowledgeReturn {
     setShowAddVault,
     setShowImport,
     toggleTypesetMode,
-    toggleStylePanel,
     setThemeConfig,
     setEditedContent: handleEditedContentChange,
     copyToClipboard,

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -535,17 +535,6 @@
   max-width: 320px;
 }
 
-/* ══════════ Column 4: Action Bar ══════════ */
-.kb-action-bar {
-  width: 220px;
-  flex-shrink: 0;
-  background: var(--bg-panel);
-  border-left: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
 /* ══════════ Modals ══════════ */
 .kb-overlay {
   display: none;

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -776,121 +776,104 @@
   overflow-y: auto;
 }
 
-/* Typeset editor layout */
+/* ══════════ 3-Column Typeset Editor ══════════ */
+
 .kb-typeset-editor {
   display: flex;
   flex: 1;
   overflow: hidden;
 }
 
+/* Left: Markdown editor */
 .kb-typeset-left {
   flex: 1;
-  min-width: 0;
+  min-width: 280px;
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--border);
 }
 
-.kb-typeset-right {
+
+.kb-typeset-cm {
   flex: 1;
-  min-width: 0;
+  overflow: hidden;
+}
+
+.kb-typeset-cm .cm-editor {
+  height: 100%;
+}
+
+.kb-typeset-cm .cm-editor.cm-focused {
+  outline: none;
+}
+
+/* Center: Preview area */
+.kb-typeset-center {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  position: relative;
-}
-
-.kb-typeset-header {
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
-  font-size: 12px;
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: var(--bg-panel);
-}
-
-.kb-editor-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.kb-editor-hint {
-  font-size: 11px;
-  color: var(--text-faint);
-}
-
-.kb-typeset-textarea {
-  flex: 1;
-  padding: 16px;
-  font-family: var(--mono);
-  font-size: 13px;
-  line-height: 1.7;
-  border: none;
-  outline: none;
-  resize: none;
-  background: var(--bg-panel);
-  color: var(--text);
-  overflow-y: auto;
+  border-right: 1px solid var(--border);
 }
 
 .kb-typeset-preview {
   flex: 1;
   overflow-y: auto;
-  background: var(--bg);
+  background: #e8e8e8;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 24px;
 }
 
-/* ══════════ Style Panel ══════════ */
+/* Desktop preview: max-width centered */
+.kb-typeset-preview.is-desktop {
+  align-items: flex-start;
+}
+
+.kb-typeset-preview.is-desktop #output {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  background: #fff;
+  box-shadow: 0 0 16px rgba(0,0,0,0.1);
+  border-radius: 4px;
+  min-height: 100%;
+  padding: 32px;
+}
+
+/* Mobile preview: fixed 375px width */
+.kb-typeset-preview.is-mobile {
+  display: flex;
+  justify-content: center;
+  padding: 20px;
+}
+
+.kb-typeset-preview.is-mobile #output {
+  width: 375px;
+  flex-shrink: 0;
+  background: #fff;
+  box-shadow: 0 0 16px rgba(0,0,0,0.1);
+  border-radius: 4px;
+  min-height: 100%;
+  padding: 24px;
+}
+
+/* ══════════ Style Panel (Embedded Sidebar) ══════════ */
 
 .kb-style-panel {
-  position: absolute;
-  top: 41px;
-  right: 0;
   width: 280px;
-  max-height: calc(100% - 41px);
+  flex-shrink: 0;
   background: var(--bg-panel);
-  border-left: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  overflow-y: auto;
-  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.04);
-  z-index: 10;
-}
-
-.kb-style-panel-header {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-strong);
+  flex-direction: column;
+  overflow: hidden;
 }
 
-.kb-style-close {
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  border-radius: 4px;
-  cursor: pointer;
-  color: var(--text-muted);
-  font-size: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.kb-style-close:hover {
-  background: var(--bg-subtle);
-  color: var(--text);
-}
 
 .kb-style-panel-content {
   padding: 16px;
+  overflow-y: auto;
+  flex: 1;
 }
 
 .kb-style-section {
@@ -960,6 +943,9 @@
   font-size: 12px;
   color: var(--text);
   transition: all 120ms ease;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .kb-font-item:hover {
@@ -971,22 +957,34 @@
   background: var(--accent-tint);
 }
 
+.kb-font-label {
+  font-size: 12px;
+}
+
+.kb-font-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
 /* Size list */
 .kb-size-list {
   display: flex;
   gap: 4px;
+  flex-wrap: wrap;
 }
 
 .kb-size-item {
   flex: 1;
-  padding: 4px 0;
+  padding: 6px 4px;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 11px;
-  color: var(--text);
   text-align: center;
   transition: all 120ms ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .kb-size-item:hover {
@@ -996,6 +994,18 @@
 .kb-size-item.is-selected {
   border-color: var(--accent);
   background: var(--accent-tint);
+}
+
+.kb-size-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.kb-size-desc {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 1px;
 }
 
 /* Color grid */
@@ -1021,6 +1031,95 @@
 .kb-color-option.is-selected {
   border-color: var(--text);
   box-shadow: 0 0 0 2px var(--bg-panel), 0 0 0 4px var(--text);
+}
+
+/* Select dropdown */
+.kb-style-select {
+  width: 100%;
+  height: 32px;
+  padding: 0 8px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  cursor: pointer;
+  transition: border-color 120ms ease;
+}
+
+.kb-style-select:focus {
+  border-color: var(--accent);
+}
+
+/* Heading styles */
+.kb-heading-styles {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.kb-heading-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.kb-heading-level {
+  width: 72px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  flex-shrink: 0;
+}
+
+.kb-heading-select {
+  flex: 1;
+}
+
+/* Width options */
+.kb-width-list {
+  display: flex;
+  gap: 6px;
+}
+
+.kb-width-item {
+  flex: 1;
+  padding: 8px 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: center;
+  transition: all 120ms ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.kb-width-item:hover {
+  border-color: var(--border-strong);
+}
+
+.kb-width-item.is-selected {
+  border-color: var(--accent);
+  background: var(--accent-tint);
+}
+
+.kb-width-icon {
+  font-size: 18px;
+}
+
+.kb-width-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.kb-width-desc {
+  font-size: 10px;
+  color: var(--text-muted);
 }
 
 /* Toggle options */
@@ -1072,82 +1171,7 @@
   left: 18px;
 }
 
-/* ══════════ doocs/md Preview Styles ══════════ */
-
-.md-preview {
-  padding: 24px 32px;
-  max-width: 800px;
-  margin: 0 auto;
-  font-size: 15px;
-  line-height: 1.75;
-  color: var(--text);
-}
-
-.md-preview .h1 {
-  font-family: var(--serif);
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text-strong);
-  margin: 0 0 20px;
-  padding-bottom: 12px;
-  border-bottom: 2px solid var(--accent, #3b82f6);
-  text-align: center;
-}
-
-.md-preview .h2 {
-  font-family: var(--serif);
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-strong);
-  margin: 28px 0 14px;
-  padding-left: 12px;
-  border-left: 4px solid var(--accent, #3b82f6);
-}
-
-.md-preview .p {
-  margin: 0 0 16px;
-  text-indent: 2em;
-  text-align: justify;
-}
-
-.md-preview .blockquote {
-  margin: 16px 0;
-  padding: 12px 16px;
-  background: #f8f9fa;
-  border-left: 4px solid var(--accent, #3b82f6);
-  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-}
-
-.md-preview .blockquote .p {
-  text-indent: 0;
-  margin: 0;
-}
-
-.md-preview pre.hljs {
-  background: #f6f8fa;
-  padding: 16px;
-  border-radius: var(--radius-sm);
-  overflow-x: auto;
-  margin: 16px 0;
-  font-size: 13px;
-  line-height: 1.6;
-  font-family: var(--mono);
-}
-
-.md-preview .codespan {
-  font-family: var(--mono);
-  font-size: 13px;
-  background: #f6f8fa;
-  padding: 2px 6px;
-  border-radius: 3px;
-}
-
-.md-preview .ul,
-.md-preview .ol {
-  margin: 10px 0;
-  padding-left: 22px;
-}
-
-.md-preview .listitem {
-  margin: 6px 0;
-}
+/* ══════════ doocs/md Preview Styles ══════════
+   注意：所有 Markdown 渲染样式由 doocs/md 主题系统（applyTheme）动态注入，
+   这里不再定义任何 .md-preview 相关样式，避免与主题 CSS 冲突。
+   ══════════ */

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -1,78 +1,15 @@
 /**
- * Shared Markdown rendering utilities.
+ * Lightweight Markdown renderer for chat messages.
  *
- * `renderMarkdown` — lightweight renderer for chat messages.
- * `renderKnowledgeMarkdown` — enhanced renderer for knowledge base pages
- *   with frontmatter parsing and wiki-link support.
- */
-
-// ─── Frontmatter parsing ───
-
-export interface Frontmatter {
-  [key: string]: string | string[];
-}
-
-/**
- * Extract YAML frontmatter from a markdown string.
- * Returns { frontmatter, body } where body is the content after the frontmatter block.
- */
-export function parseFrontmatter(text: string): { frontmatter: Frontmatter | null; body: string } {
-  const match = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-  if (!match || match[1] == null || match[2] == null) return { frontmatter: null, body: text };
-
-  const yamlBlock: string = match[1];
-  const body: string = match[2];
-
-  const frontmatter: Frontmatter = {};
-  for (const line of yamlBlock.split('\n')) {
-    const colonIdx = line.indexOf(':');
-    if (colonIdx < 0) continue;
-    const key = line.slice(0, colonIdx).trim();
-    let value: string | string[] = line.slice(colonIdx + 1).trim();
-
-    // Parse simple YAML arrays: [a, b, c]
-    if (value.startsWith('[') && value.endsWith(']')) {
-      value = value
-        .slice(1, -1)
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean);
-    }
-
-    if (key) frontmatter[key] = value;
-  }
-
-  return { frontmatter, body };
-}
-
-/**
- * Render frontmatter as an HTML block.
- */
-export function renderFrontmatterHtml(fm: Frontmatter): string {
-  const lines = Object.entries(fm).map(([key, val]) => {
-    const display = Array.isArray(val) ? val.join(', ') : val;
-    return `<div class="kb-fm-line"><span class="kb-fm-key">${escapeHtml(key)}:</span><span class="kb-fm-val">${escapeHtml(display)}</span></div>`;
-  });
-  return `<div class="kb-frontmatter">${lines.join('')}</div>`;
-}
-
-/**
- * Render source tags from frontmatter sources field.
- */
-export function renderSourcesHtml(sources: string | string[]): string {
-  const list = Array.isArray(sources) ? sources : [sources];
-  const tags = list
-    .map((s) => `<a class="kb-source-tag" href="#">📄 ${escapeHtml(s)}</a>`)
-    .join('');
-  return `<div class="kb-sources"><h4>Sources</h4>${tags}</div>`;
-}
-
-// ─── Core markdown renderer ───
-
-/**
- * Lightweight Markdown renderer — handles common patterns without a full library.
- * Renders: paragraphs, code blocks, inline code, bold, italic, links, lists,
+ * Handles: paragraphs, code blocks, inline code, bold, italic, links, lists,
  * headers, blockquotes, tables, horizontal rules, wiki-links.
+ *
+ * For rich Markdown rendering (KaTeX, Mermaid, code highlighting, etc.),
+ * the Knowledge Base uses the full doocs/md pipeline via MdRenderer.
+ */
+
+/**
+ * Render Markdown text to HTML.
  */
 export function renderMarkdown(text: string): string {
   if (!text) return '';
@@ -161,38 +98,6 @@ export function renderMarkdown(text: string): string {
     .join('\n');
 
   return html;
-}
-
-/**
- * Enhanced markdown renderer for knowledge base pages.
- * Parses frontmatter, renders wiki-links, and appends sources.
- */
-export function renderKnowledgeMarkdown(text: string): string {
-  const { frontmatter, body } = parseFrontmatter(text);
-
-  let html = '';
-
-  // Render frontmatter block
-  if (frontmatter) {
-    html += renderFrontmatterHtml(frontmatter);
-  }
-
-  // Render body
-  html += renderMarkdown(body);
-
-  // Append sources if present in frontmatter
-  if (frontmatter?.sources) {
-    html += renderSourcesHtml(frontmatter.sources);
-  }
-
-  return html;
-}
-
-/**
- * Strip AskUserQuestion fallback text from content (used by chat).
- */
-export function suppressAskUserQuestionFallback(text: string): string {
-  return text.replace(/<ask-user-question[\s\S]*?<\/ask-user-question>/gi, '').trim();
 }
 
 function escapeHtml(text: string): string {

--- a/apps/web/vendor/doocs-md/shared/editor/basicSetup.ts
+++ b/apps/web/vendor/doocs-md/shared/editor/basicSetup.ts
@@ -1,0 +1,81 @@
+import type { Extension } from '@codemirror/state'
+import { acceptCompletion, autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete'
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
+import { bracketMatching, defaultHighlightStyle, foldGutter, foldKeymap, indentOnInput, syntaxHighlighting } from '@codemirror/language'
+import { lintKeymap } from '@codemirror/lint'
+import { highlightSelectionMatches, searchKeymap } from '@codemirror/search'
+import { EditorState } from '@codemirror/state'
+import { crosshairCursor, drawSelection, dropCursor, highlightActiveLine, highlightActiveLineGutter, highlightSpecialChars, keymap, rectangularSelection } from '@codemirror/view'
+import { indentationMarkers } from '@replit/codemirror-indentation-markers'
+
+// (The superfluous function calls around the list of extensions work
+// around current limitations in tree-shaking software.)
+
+/// This is an extension value that just pulls together a number of
+/// extensions that you might want in a basic editor. It is meant as a
+/// convenient helper to quickly set up CodeMirror without installing
+/// and importing a lot of separate packages.
+///
+/// Specifically, it includes...
+///
+///  - [the default command bindings](#commands.defaultKeymap)
+///  - [line numbers](#view.lineNumbers)
+///  - [special character highlighting](#view.highlightSpecialChars)
+///  - [the undo history](#commands.history)
+///  - [a fold gutter](#language.foldGutter)
+///  - [custom selection drawing](#view.drawSelection)
+///  - [drop cursor](#view.dropCursor)
+///  - [multiple selections](#state.EditorState^allowMultipleSelections)
+///  - [reindentation on input](#language.indentOnInput)
+///  - [the default highlight style](#language.defaultHighlightStyle) (as fallback)
+///  - [bracket matching](#language.bracketMatching)
+///  - [bracket closing](#autocomplete.closeBrackets)
+///  - [autocompletion](#autocomplete.autocompletion)
+///  - [rectangular selection](#view.rectangularSelection) and [crosshair cursor](#view.crosshairCursor)
+///  - [active line highlighting](#view.highlightActiveLine)
+///  - [active line gutter highlighting](#view.highlightActiveLineGutter)
+///  - [selection match highlighting](#search.highlightSelectionMatches)
+///  - [search](#search.searchKeymap)
+///  - [linting](#lint.lintKeymap)
+///
+/// (You'll probably want to add some language package to your setup
+/// too.)
+///
+/// This extension does not allow customization. The idea is that,
+/// once you decide you want to configure your editor more precisely,
+/// you take this package's source (which is just a bunch of imports
+/// and an array literal), copy it into your own code, and adjust it
+/// as desired.
+export const basicSetup: Extension = (() => [
+  // lineNumbers(), // 移除行号显示
+  highlightActiveLineGutter(),
+  highlightSpecialChars(),
+  history(),
+  foldGutter(),
+  drawSelection(),
+  dropCursor(),
+  EditorState.allowMultipleSelections.of(true),
+  indentOnInput(),
+  syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+  bracketMatching(),
+  closeBrackets(),
+  autocompletion(),
+  rectangularSelection(),
+  crosshairCursor(),
+  highlightActiveLine(),
+  highlightSelectionMatches(),
+  indentationMarkers(), // 添加缩进标记
+  keymap.of([
+    ...closeBracketsKeymap,
+    ...defaultKeymap,
+    ...searchKeymap,
+    ...historyKeymap,
+    ...foldKeymap,
+    ...completionKeymap,
+    ...lintKeymap,
+    { key: `Tab`, run: acceptCompletion }, // use tab to completion
+    indentWithTab,
+  ]),
+])()
+
+export { EditorView } from '@codemirror/view'

--- a/apps/web/vendor/doocs-md/shared/editor/css.ts
+++ b/apps/web/vendor/doocs-md/shared/editor/css.ts
@@ -1,0 +1,41 @@
+import { css } from '@codemirror/lang-css'
+import { EditorView, keymap } from '@codemirror/view'
+import { formatDoc } from '../utils/fileHelpers'
+import { basicSetup } from './basicSetup'
+
+/**
+ * CSS 格式化处理函数
+ */
+async function formatCSS(view: EditorView) {
+  const content = view.state.doc.toString()
+  const formatted = await formatDoc(content, `css`)
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: formatted },
+  })
+}
+
+/**
+ * CSS 编辑器的基础扩展集合
+ *
+ * 包含：
+ * - basicSetup（无行号、代码折叠、自动补全、括号匹配等完整功能）
+ * - 自动换行（无横向滚动）
+ * - CSS 语言支持
+ * - 格式化功能（Shift-Alt-f）
+ *
+ * basicSetup 包含的功能详见 ./basicSetup.ts
+ *
+ * 主题请使用统一的 theme() 函数，从 './themes' 导入
+ */
+export function cssSetup() {
+  return [
+    basicSetup,
+    css(),
+    // 自动换行，禁用横向滚动
+    EditorView.lineWrapping,
+    // 格式化快捷键
+    keymap.of([
+      { key: `Shift-Alt-f`, run: (view: EditorView) => { formatCSS(view); return true } },
+    ]),
+  ]
+}

--- a/apps/web/vendor/doocs-md/shared/editor/format.ts
+++ b/apps/web/vendor/doocs-md/shared/editor/format.ts
@@ -1,0 +1,193 @@
+import type { EditorView } from '@codemirror/view'
+import { redo, undo } from '@codemirror/commands'
+
+interface ToggleFormatOptions {
+  prefix: string
+  suffix: string
+  check?: (selected: string) => boolean
+  afterInsertCursorOffset?: number
+}
+
+/**
+ * 切换格式（加粗、斜体、删除线等）
+ */
+export function toggleFormat(
+  view: EditorView,
+  {
+    prefix,
+    suffix,
+    check,
+    afterInsertCursorOffset = 0,
+  }: ToggleFormatOptions,
+): void {
+  const selection = view.state.selection.main
+  const selected = view.state.doc.sliceString(selection.from, selection.to)
+  const isFormatted = check?.(selected) ?? false
+
+  let newText: string
+
+  if (isFormatted) {
+    // Remove formatting (e.g. **abc** -> abc)
+    newText = selected.slice(prefix.length, selected.length - suffix.length)
+    view.dispatch(view.state.replaceSelection(newText))
+  }
+  else {
+    // Apply formatting
+    newText = `${prefix}${selected}${suffix}`
+    view.dispatch(view.state.replaceSelection(newText))
+
+    // Optional cursor shift (e.g. for `]()` links)
+    if (afterInsertCursorOffset !== 0) {
+      const newSelection = view.state.selection.main
+      const newPos = newSelection.head + afterInsertCursorOffset
+      view.dispatch({ selection: { anchor: newPos } })
+    }
+  }
+}
+
+/**
+ * 应用标题级别
+ */
+export function applyHeading(view: EditorView, level: number) {
+  const ranges = view.state.selection.ranges
+  const changes: Array<{ from: number, to: number, insert: string }> = []
+  const headingPrefix = `${`#`.repeat(level)} `
+
+  ranges.forEach((range) => {
+    const fromLine = view.state.doc.lineAt(range.from)
+    const toLine = view.state.doc.lineAt(range.to)
+
+    for (let lineNum = fromLine.number; lineNum <= toLine.number; lineNum++) {
+      const line = view.state.doc.line(lineNum)
+      const text = view.state.doc.sliceString(line.from, line.to)
+      // 去掉已有的 # 前缀（1~6 个）+ 空格
+      const cleaned = text.replace(/^#{1,6}\s+/, ``).trimStart()
+      const heading = headingPrefix + cleaned
+
+      changes.push({
+        from: line.from,
+        to: line.to,
+        insert: heading,
+      })
+    }
+  })
+
+  if (changes.length > 0) {
+    const firstLine = view.state.doc.lineAt(ranges[0].from)
+    // 计算光标应该在的位置：行首 + 标题前缀长度（如 "# " = 2）
+    const newCursorPos = firstLine.from + headingPrefix.length
+
+    view.dispatch({
+      changes,
+      selection: { anchor: newCursorPos },
+    })
+  }
+}
+
+/**
+ * 便捷格式化函数
+ */
+export function formatBold(view: EditorView) {
+  toggleFormat(view, {
+    prefix: `**`,
+    suffix: `**`,
+    check: s => s.startsWith(`**`) && s.endsWith(`**`),
+    afterInsertCursorOffset: -2,
+  })
+}
+
+export function formatItalic(view: EditorView) {
+  toggleFormat(view, {
+    prefix: `*`,
+    suffix: `*`,
+    check: s => s.startsWith(`*`) && s.endsWith(`*`),
+    afterInsertCursorOffset: -1,
+  })
+}
+
+export function formatStrikethrough(view: EditorView) {
+  toggleFormat(view, {
+    prefix: `~~`,
+    suffix: `~~`,
+    check: s => s.startsWith(`~~`) && s.endsWith(`~~`),
+    afterInsertCursorOffset: -2,
+  })
+}
+
+export function formatLink(view: EditorView) {
+  toggleFormat(view, {
+    prefix: `[`,
+    suffix: `]()`,
+    check: s => s.startsWith(`[`) && s.endsWith(`]()`),
+    afterInsertCursorOffset: -1,
+  })
+}
+
+export function formatCode(view: EditorView) {
+  toggleFormat(view, {
+    prefix: `\``,
+    suffix: `\``,
+    check: s => s.startsWith(`\``) && s.endsWith(`\``),
+    afterInsertCursorOffset: -1,
+  })
+}
+
+/**
+ * 设置文字颜色
+ */
+export function formatColor(view: EditorView, color: string) {
+  const selection = view.state.selection.main
+  const selected = view.state.doc.sliceString(selection.from, selection.to)
+
+  const spanRegex = /^\s*<span\s+style="color:\s*([^"\s][^"]*)"\s*>([\s\S]*)<\/span>\s*$/i
+  const match = selected.match(spanRegex)
+
+  if (match) {
+    const content = match[2]
+    const insert = `<span style="color: ${color}">${content}</span>`
+    view.dispatch({
+      changes: { from: selection.from, to: selection.to, insert },
+      selection: { anchor: selection.from, head: selection.from + insert.length },
+    })
+  }
+  else {
+    const insert = `<span style="color: ${color}">${selected}</span>`
+    view.dispatch({
+      changes: { from: selection.from, to: selection.to, insert },
+      selection: { anchor: selection.from, head: selection.from + insert.length },
+    })
+  }
+}
+
+export function formatUnorderedList(view: EditorView) {
+  const selection = view.state.selection.main
+  const selected = view.state.doc.sliceString(selection.from, selection.to)
+  const lines = selected.split(`\n`)
+  const isList = lines.every(line => line.trim().startsWith(`- `))
+  const updated = isList
+    ? lines.map(line => line.replace(/^- +/, ``)).join(`\n`)
+    : lines.map(line => `- ${line}`).join(`\n`)
+  view.dispatch(view.state.replaceSelection(updated))
+}
+
+export function formatOrderedList(view: EditorView) {
+  const selection = view.state.selection.main
+  const selected = view.state.doc.sliceString(selection.from, selection.to)
+  const lines = selected.split(`\n`)
+  const isList = lines.every(line => /^\d+\.\s/.test(line.trim()))
+  const updated = isList
+    ? lines.map(line => line.replace(/^\d+\.\s+/, ``)).join(`\n`)
+    : lines.map((line, i) => `${i + 1}. ${line}`).join(`\n`)
+  view.dispatch(view.state.replaceSelection(updated))
+}
+
+/**
+ * 撤销/重做
+ */
+export function undoAction(view: EditorView): boolean {
+  return undo(view)
+}
+
+export function redoAction(view: EditorView): boolean {
+  return redo(view)
+}

--- a/apps/web/vendor/doocs-md/shared/editor/index.ts
+++ b/apps/web/vendor/doocs-md/shared/editor/index.ts
@@ -1,0 +1,6 @@
+export * from './basicSetup'
+export * from './css'
+export * from './format'
+export * from './javascript'
+export * from './markdown'
+export * from './themes'

--- a/apps/web/vendor/doocs-md/shared/editor/javascript.ts
+++ b/apps/web/vendor/doocs-md/shared/editor/javascript.ts
@@ -1,0 +1,39 @@
+import type { EditorView } from '@codemirror/view'
+import { javascript } from '@codemirror/lang-javascript'
+import { keymap } from '@codemirror/view'
+import { formatDoc } from '../utils/fileHelpers'
+import { basicSetup } from './basicSetup'
+
+/**
+ * JavaScript 格式化处理函数
+ */
+async function formatJavaScript(view: EditorView) {
+  const content = view.state.doc.toString()
+  const formatted = await formatDoc(content, `javascript`)
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: formatted },
+  })
+}
+
+/**
+ * JavaScript 编辑器的基础扩展集合
+ *
+ * 包含：
+ * - basicSetup（行号、代码折叠、自动补全、括号匹配等完整功能）
+ * - JavaScript 语言支持
+ * - 格式化功能（Shift-Alt-f）
+ *
+ * basicSetup 包含的功能详见 ./basicSetup.ts
+ *
+ * 主题请使用统一的 theme() 函数，从 './themes' 导入
+ */
+export function javascriptSetup() {
+  return [
+    basicSetup,
+    javascript(),
+    // 格式化快捷键
+    keymap.of([
+      { key: `Shift-Alt-f`, run: (view: EditorView) => { formatJavaScript(view); return true } },
+    ]),
+  ]
+}

--- a/apps/web/vendor/doocs-md/shared/editor/markdown.ts
+++ b/apps/web/vendor/doocs-md/shared/editor/markdown.ts
@@ -1,0 +1,137 @@
+import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete'
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
+import { foldGutter, foldKeymap } from '@codemirror/language'
+import { languages } from '@codemirror/language-data'
+import { highlightSelectionMatches } from '@codemirror/search'
+import { EditorSelection, EditorState, Prec } from '@codemirror/state'
+import { EditorView, keymap, placeholder } from '@codemirror/view'
+import { indentationMarkers } from '@replit/codemirror-indentation-markers'
+import { formatDoc } from '../utils/fileHelpers'
+import { applyHeading, formatBold, formatCode, formatItalic, formatLink, formatOrderedList, formatStrikethrough, formatUnorderedList, redoAction, undoAction } from './format'
+
+/**
+ * Markdown 格式化处理函数
+ */
+async function formatMarkdown(view: EditorView) {
+  const content = view.state.doc.toString()
+  const formatted = await formatDoc(content, `markdown`)
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: formatted },
+  })
+}
+
+/**
+ * 在光标位置插入缩进（空格）
+ */
+function insertTabAtCursor(view: EditorView): boolean {
+  const spaces = `  ` // 2 个空格作为缩进
+  const changes = view.state.changeByRange(range => ({
+    changes: { from: range.from, to: range.to, insert: spaces },
+    range: EditorSelection.range(range.from + spaces.length, range.from + spaces.length),
+  }))
+  view.dispatch(changes)
+  return true
+}
+
+interface MarkdownKeymapOptions {
+  onSearch?: (view: EditorView) => void
+  onReplace?: (view: EditorView) => void
+}
+
+/**
+ * Markdown 编辑器的快捷键映射
+ *
+ * @param options - 配置选项
+ * @param options.onSearch - 搜索回调（可选）
+ */
+export function markdownKeymap(options?: MarkdownKeymapOptions) {
+  const { onSearch, onReplace } = options || {}
+
+  return keymap.of([
+    // Tab 键在光标位置插入缩进
+    { key: `Tab`, run: insertTabAtCursor },
+
+    // 撤销/重做
+    { key: `Mod-z`, run: undoAction },
+    { key: `Mod-y`, run: redoAction },
+
+    // 文本格式
+    { key: `Mod-b`, run: (view) => { formatBold(view); return true } },
+    { key: `Mod-i`, run: (view) => { formatItalic(view); return true } },
+    { key: `Mod-d`, run: (view) => { formatStrikethrough(view); return true } },
+    { key: `Mod-k`, run: (view) => { formatLink(view); return true } },
+    { key: `Mod-e`, run: (view) => { formatCode(view); return true } },
+
+    // 标题（使用 Mod-1 到 Mod-6）
+    { key: `Mod-1`, run: (view) => { applyHeading(view, 1); return true } },
+    { key: `Mod-2`, run: (view) => { applyHeading(view, 2); return true } },
+    { key: `Mod-3`, run: (view) => { applyHeading(view, 3); return true } },
+    { key: `Mod-4`, run: (view) => { applyHeading(view, 4); return true } },
+    { key: `Mod-5`, run: (view) => { applyHeading(view, 5); return true } },
+    { key: `Mod-6`, run: (view) => { applyHeading(view, 6); return true } },
+
+    // 列表
+    { key: `Mod-u`, run: (view) => { formatUnorderedList(view); return true } },
+    { key: `Mod-o`, run: (view) => { formatOrderedList(view); return true } },
+
+    // 搜索和替换（可选）
+    ...(onSearch ? [{ key: `Mod-f`, run: (view: EditorView) => { onSearch(view); return true } }] : []),
+    ...(onReplace ? [{ key: `Mod-h`, run: (view: EditorView) => { onReplace(view); return true } }] : []),
+
+    // 格式化
+    { key: `Shift-Alt-f`, run: (view: EditorView) => { formatMarkdown(view); return true } },
+
+    // 阻止 Mod-g（避免触发 CodeMirror 内置搜索）
+    { key: `Mod-g`, run: () => true },
+  ])
+}
+
+/**
+ * Markdown 编辑器的基础扩展集合
+ * 包含语言支持、历史记录、括号匹配等基础功能
+ *
+ * 主题请使用统一的 theme() 函数，从 './themes' 导入
+ *
+ * @param options - 配置选项（可选）
+ * @param options.onSearch - 搜索回调，触发快捷键 Mod-f
+ *
+ */
+export function markdownSetup(options?: MarkdownKeymapOptions) {
+  return [
+    // 基础功能
+    history(),
+    highlightSelectionMatches(),
+    closeBrackets(),
+
+    // 缩进标记
+    indentationMarkers(),
+
+    // 语言支持
+    markdown({
+      base: markdownLanguage,
+      codeLanguages: languages,
+      addKeymap: true,
+    }),
+
+    // Markdown 快捷键（高优先级，优先于默认快捷键）
+    Prec.high(markdownKeymap(options)),
+
+    // 折叠功能
+    foldGutter(),
+
+    // 默认快捷键
+    keymap.of([
+      ...defaultKeymap,
+      ...historyKeymap,
+      ...closeBracketsKeymap,
+      ...foldKeymap,
+    ]),
+
+    // 编辑器配置
+    EditorView.lineWrapping,
+    EditorState.allowMultipleSelections.of(true),
+
+    placeholder(`输入 "/" 快速添加内容`),
+  ]
+}

--- a/apps/web/vendor/doocs-md/shared/editor/themes.ts
+++ b/apps/web/vendor/doocs-md/shared/editor/themes.ts
@@ -1,0 +1,50 @@
+import { EditorView } from '@codemirror/view'
+import { vsCodeDark } from '@fsegurai/codemirror-theme-vscode-dark'
+import { vsCodeLight } from '@fsegurai/codemirror-theme-vscode-light'
+
+const customStyles = EditorView.theme({
+  // 装订线：垂直居中、无背景无边框无内边距
+  '.cm-gutterElement': {
+    display: `flex`,
+    justifyContent: `right`,
+    alignItems: `center`,
+  },
+  '&.cm-editor .cm-gutters': {
+    backgroundColor: `transparent !important`,
+    borderRight: `none !important`,
+    padding: `0 !important`,
+  },
+
+  // 折叠装订线：固定宽度，无内边距
+  '.cm-foldGutter': {
+    width: `10px !important`,
+    overflow: `hidden`,
+  },
+  '.cm-foldGutter .cm-gutterElement': {
+    padding: `0 !important`,
+    width: `10px !important`,
+    minWidth: `unset !important`,
+  },
+
+  // 折叠图标：默认隐藏，hover 装订线时显示
+  '.cm-foldGutter .cm-gutterElement span': {
+    opacity: `0`,
+    transition: `opacity 0.15s ease`,
+  },
+  '&.cm-editor .cm-gutters:hover .cm-foldGutter .cm-gutterElement span': {
+    opacity: `1`,
+  },
+})
+
+export function lightTheme() {
+  return [vsCodeLight, customStyles]
+}
+
+export function darkTheme() {
+  return [vsCodeDark, customStyles]
+}
+
+// 根据主题模式获取主题扩展
+export function theme(isDark: boolean) {
+  return isDark ? darkTheme() : lightTheme()
+}

--- a/apps/web/vendor/doocs-md/shared/utils/clipboard.ts
+++ b/apps/web/vendor/doocs-md/shared/utils/clipboard.ts
@@ -1,0 +1,54 @@
+/**
+ * Clipboard utilities — vendored from doocs/md upstream.
+ * Provides copyPlain (text-only) and copyHtml (rich HTML + plain text fallback).
+ */
+
+function legacyCopy(text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', 'true');
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+
+      textarea.select();
+      const ok = document.execCommand('copy');
+      document.body.removeChild(textarea);
+
+      ok ? resolve() : reject(new Error('execCommand failed'));
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+export async function copyPlain(text: string): Promise<void> {
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // fall through to legacy
+    }
+  }
+  await legacyCopy(text);
+}
+
+export async function copyHtml(html: string, fallback?: string): Promise<void> {
+  const plain = fallback ?? html.replace(/<[^>]+>/g, '');
+  if (window.isSecureContext && navigator.clipboard?.write) {
+    try {
+      const item = new ClipboardItem({
+        'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([plain], { type: 'text/plain' }),
+      });
+      await navigator.clipboard.write([item]);
+      return;
+    } catch {
+      // fall through to plain
+    }
+  }
+  await copyPlain(plain);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,30 @@ importers:
 
   apps/web:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.3
+        version: 6.20.3
+      '@codemirror/commands':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.0
+        version: 6.5.0
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
+      '@codemirror/language-data':
+        specifier: ^6.5.2
+        version: 6.5.2
+      '@codemirror/search':
+        specifier: ^6.7.0
+        version: 6.7.0
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.43.0
+        version: 6.43.0
       '@molio/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -213,6 +237,96 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-angular@0.1.4':
+    resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
+
+  '@codemirror/lang-cpp@6.0.3':
+    resolution: {integrity: sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-go@6.0.1':
+    resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-java@6.0.2':
+    resolution: {integrity: sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-jinja@6.0.1':
+    resolution: {integrity: sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-less@6.0.2':
+    resolution: {integrity: sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==}
+
+  '@codemirror/lang-liquid@6.3.2':
+    resolution: {integrity: sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-php@6.0.2':
+    resolution: {integrity: sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-rust@6.0.2':
+    resolution: {integrity: sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==}
+
+  '@codemirror/lang-sass@6.0.2':
+    resolution: {integrity: sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/lang-vue@0.1.3':
+    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
+
+  '@codemirror/lang-wast@6.0.2':
+    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
+
+  '@codemirror/language-data@6.5.2':
+    resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/legacy-modes@6.5.3':
+    resolution: {integrity: sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==}
+
+  '@codemirror/lint@6.9.6':
+    resolution: {integrity: sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==}
+
+  '@codemirror/search@6.7.0':
+    resolution: {integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -639,6 +753,57 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/cpp@1.1.6':
+    resolution: {integrity: sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/java@1.1.3':
+    resolution: {integrity: sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.4':
+    resolution: {integrity: sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==}
+
+  '@lezer/php@1.0.5':
+    resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
+
+  '@lezer/python@1.1.19':
+    resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
+
+  '@lezer/rust@1.0.2':
+    resolution: {integrity: sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==}
+
+  '@lezer/sass@1.1.0':
+    resolution: {integrity: sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
+
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
@@ -646,6 +811,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@npmcli/fs@1.0.0':
     resolution: {integrity: sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==}
@@ -1208,6 +1376,9 @@ packages:
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2347,6 +2518,9 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -2519,6 +2693,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -2754,6 +2931,257 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-angular@0.1.4':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-cpp@6.0.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/cpp': 1.1.6
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-go@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/go': 1.0.1
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-java@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/java': 1.1.3
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-jinja@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-less@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-liquid@6.3.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.4
+
+  '@codemirror/lang-php@6.0.2':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/php': 1.0.5
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.19
+
+  '@codemirror/lang-rust@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/rust': 1.0.2
+
+  '@codemirror/lang-sass@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/sass': 1.1.0
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-vue@0.1.3':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-wast@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/xml': 1.0.6
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
+
+  '@codemirror/language-data@6.5.2':
+    dependencies:
+      '@codemirror/lang-angular': 0.1.4
+      '@codemirror/lang-cpp': 6.0.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-go': 6.0.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-java': 6.0.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-jinja': 6.0.1
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-less': 6.0.2
+      '@codemirror/lang-liquid': 6.3.2
+      '@codemirror/lang-markdown': 6.5.0
+      '@codemirror/lang-php': 6.0.2
+      '@codemirror/lang-python': 6.2.1
+      '@codemirror/lang-rust': 6.0.2
+      '@codemirror/lang-sass': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/lang-vue': 0.1.3
+      '@codemirror/lang-wast': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/legacy-modes': 6.5.3
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+
+  '@codemirror/lint@6.9.6':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
+  '@codemirror/search@6.7.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.43.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -3057,6 +3485,99 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/cpp@1.1.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/go@1.0.1':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/java@1.1.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/php@1.0.5':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/rust@1.0.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/sass@1.1.0':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
       cross-spawn: 7.0.6
@@ -3069,6 +3590,8 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@npmcli/fs@1.0.0':
     dependencies:
@@ -3681,6 +4204,8 @@ snapshots:
     dependencies:
       buffer: 5.7.1
     optional: true
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4972,6 +5497,8 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  style-mod@4.1.3: {}
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -5125,6 +5652,8 @@ snapshots:
       '@types/node': 22.19.19
       fsevents: 2.3.3
       tsx: 4.22.4
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## 改动概要

核查了 doocs/md 上游能力的利用情况，消除造轮子，补齐缺失功能。

### P0: 清理 markdown.ts 死代码 (204行→93行)
- 删除 5 个无调用方的函数（parseFrontmatter, renderKnowledgeMarkdown 等）
- 保留 renderMarkdown 正则渲染器用于聊天消息（轻量快速，适合 streaming）

### P1: 富 HTML 剪贴板
- vendor 上游 clipboard.ts（copyPlain + copyHtml）
- 排版模式复制按钮写入 `text/html` + `text/plain` 双格式
- 支持粘贴到微信公众号编辑器保留样式

### P2: 完善 doocs/md 更新脚本
- update-doocs-md.sh 新增 shared/configs/ 和 shared/editor/ 目录复制
- 同步上游最新 configs 和 editor 配置到 vendor

### P3: 排版编辑器升级为 CodeMirror 6
- 安装 @codemirror/view, @codemirror/lang-markdown 等 8 个依赖
- MdTypesetEditor: textarea 替换为 CodeMirror 编辑器
- Markdown 语法高亮，快捷键（Cmd+B/I/K/E/1-3）
- 编辑器主题匹配 Claude 设计 token
- 保持编辑器↔预览同步滚动

🤖 Generated with [Claude Code](https://claude.com/claude-code)