### PR TITLE
feat(kb): Vault Manager 弹窗样式与打开本地仓库

### DIFF
--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import { spawn, execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -122,4 +122,17 @@ app.on('before-quit', () => {
   if (daemonProcess) {
     daemonProcess.kill('SIGTERM');
   }
+});
+
+// ─── IPC handlers ───
+
+ipcMain.handle('show-directory-picker', async () => {
+  const focusedWindow = BrowserWindow.getFocusedWindow();
+  if (!focusedWindow) return null;
+  const result = await dialog.showOpenDialog(focusedWindow, {
+    properties: ['openDirectory'],
+    title: '选择本地仓库文件夹',
+  });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return result.filePaths[0];
 });

--- a/apps/desktop/src/preload.js
+++ b/apps/desktop/src/preload.js
@@ -4,10 +4,13 @@
  * Context isolation is enabled; this script runs in an isolated context.
  */
 
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 
-// Expose a minimal API to the renderer (currently none needed;
+// Expose a minimal API to the renderer (currently none needed,
 // the web app communicates with the daemon via HTTP/SSE.)
 contextBridge.exposeInMainWorld('__electron__', {
   platform: process.platform,
+
+  /** Show a directory picker dialog. Returns the selected path or null. */
+  showDirectoryPicker: () => ipcRenderer.invoke('show-directory-picker'),
 });

--- a/apps/web/src/components/kb/CreateVaultForm.tsx
+++ b/apps/web/src/components/kb/CreateVaultForm.tsx
@@ -1,0 +1,75 @@
+/**
+ * Create vault form — right panel of the vault manager.
+ */
+
+import { useState, useCallback } from 'react';
+
+interface CreateVaultFormProps {
+  onCreate: (name: string, path: string, description?: string) => Promise<void>;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+export function CreateVaultForm({ onCreate, onCancel, isLoading }: CreateVaultFormProps) {
+  const [name, setName] = useState('');
+  const [vaultPath, setVaultPath] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = useCallback(async () => {
+    if (!name.trim() || !vaultPath.trim()) return;
+    await onCreate(name.trim(), vaultPath.trim(), description.trim() || undefined);
+  }, [name, vaultPath, description, onCreate]);
+
+  const canSubmit = name.trim() && vaultPath.trim() && !isLoading;
+
+  return (
+    <div className="vm-create-form">
+      <button className="vm-back-btn" onClick={onCancel}>
+        ← 返回
+      </button>
+      <h2 className="vm-create-title">创建本地仓库</h2>
+
+      <div className="vm-form-group">
+        <label className="vm-form-label">仓库名称</label>
+        <input
+          className="vm-form-input"
+          type="text"
+          placeholder="给新仓库起一个名字"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+
+      <div className="vm-form-group">
+        <label className="vm-form-label">仓库位置</label>
+        <div className="vm-form-row">
+          <input
+            className="vm-form-input"
+            type="text"
+            placeholder="指定新仓库的存放位置"
+            value={vaultPath}
+            onChange={(e) => setVaultPath(e.target.value)}
+          />
+          <button className="vm-browse-btn">浏览</button>
+        </div>
+      </div>
+
+      <div className="vm-form-group">
+        <label className="vm-form-label">描述（可选）</label>
+        <input
+          className="vm-form-input"
+          type="text"
+          placeholder="简短描述这个仓库"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+
+      <div className="vm-form-actions">
+        <button className="vm-submit-btn" onClick={handleSubmit} disabled={!canSubmit}>
+          {isLoading ? '创建中...' : '创建'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -1,12 +1,16 @@
 /**
  * Knowledge Base page — assembles file panel, main content, and modals.
+ *
+ * When no vault is active (first-time user), shows the Obsidian-style
+ * vault manager (VaultManager) instead of the file panel + content.
  */
 
 import { useCallback, useRef } from 'react';
 import { useKnowledge } from '../../hooks/useKnowledge';
 import { KbFilePanel } from './KbFilePanel';
 import { KbMainContent } from './KbMainContent';
-import { VaultSwitcherModal, AddVaultModal, ImportModal } from './KbModals';
+import { VaultManager } from './VaultManager';
+import { ImportModal } from './KbModals';
 
 export function KnowledgeBasePage() {
   const kb = useKnowledge();
@@ -40,6 +44,29 @@ export function KnowledgeBasePage() {
     document.addEventListener('mouseup', onUp);
   }, [kb.panelWidth, kb.setPanelWidth]);
 
+  // ── No active vault → show vault manager ──
+  if (!kb.activeVault) {
+    return (
+      <div className="kb-shell" ref={panelRef}>
+        <VaultManager
+          vaults={kb.vaults}
+          activeVaultId={null}
+          onSelectVault={kb.selectVault}
+          onCreateVault={kb.createVault}
+          onDeleteVault={kb.deleteVault}
+        />
+
+        {/* Import modal (reused from existing flow) */}
+        <ImportModal
+          show={kb.showImport}
+          vaultName=""
+          onClose={() => kb.setShowImport(false)}
+        />
+      </div>
+    );
+  }
+
+  // ── Active vault → show file panel + content ──
   return (
     <div className="kb-shell" ref={panelRef}>
       {/* File Panel */}
@@ -54,7 +81,10 @@ export function KnowledgeBasePage() {
         onNewFile={() => {/* TODO: new file flow */}}
         onNewFolder={() => {/* TODO: new folder flow */}}
         onImport={() => kb.setShowImport(true)}
-        onVaultClick={() => kb.setShowVaultSwitcher(true)}
+        onVaultClick={() => {
+          // Deselect vault → show vault manager
+          kb.selectVault('');
+        }}
       >
         {/* Resize handle attached to panel */}
         <div className="kb-resize-handle" onMouseDown={handleResizeStart} />
@@ -70,31 +100,57 @@ export function KnowledgeBasePage() {
         onThemeConfigChange={kb.setThemeConfig}
         onContentChange={kb.setEditedContent}
         onCopy={kb.copyToClipboard}
-        onPublish={() => {/* TODO: publish flow */}}
+        onPublish={kb.publishToChrome}
       />
 
-      {/* Modals */}
-      <VaultSwitcherModal
-        show={kb.showVaultSwitcher}
-        vaults={kb.vaults}
-        activeVaultId={kb.activeVault?.id ?? null}
-        onClose={() => kb.setShowVaultSwitcher(false)}
-        onSelect={kb.selectVault}
-        onAddVault={() => kb.setShowAddVault(true)}
-        onImport={() => kb.setShowImport(true)}
-      />
-
-      <AddVaultModal
-        show={kb.showAddVault}
-        onClose={() => kb.setShowAddVault(false)}
-        onCreate={kb.createVault}
-      />
-
+      {/* Import modal */}
       <ImportModal
         show={kb.showImport}
         vaultName={kb.activeVault?.name ?? ''}
         onClose={() => kb.setShowImport(false)}
       />
+
+      {/* COSE install prompt */}
+      <CoseInstallModal
+        show={kb.showCoseInstallPrompt}
+        onClose={() => kb.setShowCoseInstallPrompt(false)}
+      />
+    </div>
+  );
+}
+
+// ─── COSE Install Modal ───
+
+const COSE_WEBSTORE_URL = 'https://chromewebstore.google.com/detail/ilhikcdphhpjofhlnbojifbihhfmmhfk';
+
+function CoseInstallModal({ show, onClose }: { show: boolean; onClose: () => void }) {
+  if (!show) return null;
+
+  const handleInstall = () => {
+    window.open(COSE_WEBSTORE_URL, '_blank');
+    onClose();
+  };
+
+  return (
+    <div className={`kb-overlay ${show ? 'show' : ''}`} onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="kb-modal" style={{ maxWidth: 420 }}>
+        <div className="kb-modal-header">
+          <h2>安装 COSE 扩展</h2>
+          <button className="kb-modal-close" onClick={onClose}>&times;</button>
+        </div>
+        <div className="kb-modal-body" style={{ fontSize: 13, lineHeight: 1.7 }}>
+          <p style={{ marginBottom: 12 }}>
+            发布功能需要安装 <strong>COSE 文章同步助手</strong> 浏览器扩展。
+          </p>
+          <p style={{ marginBottom: 12, color: 'var(--text-muted, #888)' }}>
+            COSE 支持将文章一键同步到微信公众号、知乎、掘金、CSDN 等 30+ 平台，完全本地运行，不收集用户信息。
+          </p>
+        </div>
+        <div className="kb-modal-footer" style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button className="kb-btn" onClick={onClose}>取消</button>
+          <button className="kb-btn kb-btn-primary" onClick={handleInstall}>安装扩展</button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -1,15 +1,12 @@
 /**
  * Knowledge Base page — assembles file panel, main content, and modals.
- *
- * When no vault is active (first-time user), shows the Obsidian-style
- * vault manager (VaultManager) instead of the file panel + content.
  */
 
 import { useCallback, useRef } from 'react';
 import { useKnowledge } from '../../hooks/useKnowledge';
 import { KbFilePanel } from './KbFilePanel';
 import { KbMainContent } from './KbMainContent';
-import { VaultManager } from './VaultManager';
+import { VaultManagerModal } from './VaultManager';
 import { ImportModal } from './KbModals';
 
 export function KnowledgeBasePage() {
@@ -44,29 +41,6 @@ export function KnowledgeBasePage() {
     document.addEventListener('mouseup', onUp);
   }, [kb.panelWidth, kb.setPanelWidth]);
 
-  // ── No active vault → show vault manager ──
-  if (!kb.activeVault) {
-    return (
-      <div className="kb-shell" ref={panelRef}>
-        <VaultManager
-          vaults={kb.vaults}
-          activeVaultId={null}
-          onSelectVault={kb.selectVault}
-          onCreateVault={kb.createVault}
-          onDeleteVault={kb.deleteVault}
-        />
-
-        {/* Import modal (reused from existing flow) */}
-        <ImportModal
-          show={kb.showImport}
-          vaultName=""
-          onClose={() => kb.setShowImport(false)}
-        />
-      </div>
-    );
-  }
-
-  // ── Active vault → show file panel + content ──
   return (
     <div className="kb-shell" ref={panelRef}>
       {/* File Panel */}
@@ -82,8 +56,8 @@ export function KnowledgeBasePage() {
         onNewFolder={() => {/* TODO: new folder flow */}}
         onImport={() => kb.setShowImport(true)}
         onVaultClick={() => {
-          // Deselect vault → show vault manager
-          kb.selectVault('');
+          console.log('Vault bar clicked, setting showVaultSwitcher to true');
+          kb.setShowVaultSwitcher(true);
         }}
       >
         {/* Resize handle attached to panel */}
@@ -100,7 +74,19 @@ export function KnowledgeBasePage() {
         onThemeConfigChange={kb.setThemeConfig}
         onContentChange={kb.setEditedContent}
         onCopy={kb.copyToClipboard}
-        onPublish={kb.publishToChrome}
+        onPublish={() => {/* TODO: publish flow */}}
+      />
+
+      {/* Vault Manager Modal (Obsidian-style) */}
+      <VaultManagerModal
+        show={kb.showVaultSwitcher}
+        vaults={kb.vaults}
+        activeVaultId={kb.activeVault?.id ?? null}
+        onClose={() => kb.setShowVaultSwitcher(false)}
+        onSelect={kb.selectVault}
+        onCreate={kb.createVault}
+        onOpen={kb.openVault}
+        onDelete={kb.deleteVault}
       />
 
       {/* Import modal */}
@@ -109,48 +95,6 @@ export function KnowledgeBasePage() {
         vaultName={kb.activeVault?.name ?? ''}
         onClose={() => kb.setShowImport(false)}
       />
-
-      {/* COSE install prompt */}
-      <CoseInstallModal
-        show={kb.showCoseInstallPrompt}
-        onClose={() => kb.setShowCoseInstallPrompt(false)}
-      />
-    </div>
-  );
-}
-
-// ─── COSE Install Modal ───
-
-const COSE_WEBSTORE_URL = 'https://chromewebstore.google.com/detail/ilhikcdphhpjofhlnbojifbihhfmmhfk';
-
-function CoseInstallModal({ show, onClose }: { show: boolean; onClose: () => void }) {
-  if (!show) return null;
-
-  const handleInstall = () => {
-    window.open(COSE_WEBSTORE_URL, '_blank');
-    onClose();
-  };
-
-  return (
-    <div className={`kb-overlay ${show ? 'show' : ''}`} onClick={(e) => e.target === e.currentTarget && onClose()}>
-      <div className="kb-modal" style={{ maxWidth: 420 }}>
-        <div className="kb-modal-header">
-          <h2>安装 COSE 扩展</h2>
-          <button className="kb-modal-close" onClick={onClose}>&times;</button>
-        </div>
-        <div className="kb-modal-body" style={{ fontSize: 13, lineHeight: 1.7 }}>
-          <p style={{ marginBottom: 12 }}>
-            发布功能需要安装 <strong>COSE 文章同步助手</strong> 浏览器扩展。
-          </p>
-          <p style={{ marginBottom: 12, color: 'var(--text-muted, #888)' }}>
-            COSE 支持将文章一键同步到微信公众号、知乎、掘金、CSDN 等 30+ 平台，完全本地运行，不收集用户信息。
-          </p>
-        </div>
-        <div className="kb-modal-footer" style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
-          <button className="kb-btn" onClick={onClose}>取消</button>
-          <button className="kb-btn kb-btn-primary" onClick={handleInstall}>安装扩展</button>
-        </div>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/components/kb/VaultActionPanel.tsx
+++ b/apps/web/src/components/kb/VaultActionPanel.tsx
@@ -1,0 +1,45 @@
+/**
+ * Right-side action panel for the vault manager.
+ * Branding + "Create vault" / "Open local vault" actions.
+ */
+
+interface VaultActionPanelProps {
+  onCreate: () => void;
+  onOpenLocal: () => void;
+}
+
+export function VaultActionPanel({ onCreate, onOpenLocal }: VaultActionPanelProps) {
+  return (
+    <div className="vm-action-panel">
+      {/* Branding */}
+      <div className="vm-brand">
+        <div className="vm-brand-logo">📚</div>
+        <div className="vm-brand-title">Molio 知识库</div>
+        <div className="vm-brand-version">版本 1.0</div>
+      </div>
+
+      {/* Actions */}
+      <div className="vm-actions">
+        <div className="vm-action-card">
+          <div className="vm-action-text">
+            <div className="vm-action-title">新建仓库</div>
+            <div className="vm-action-desc">在指定文件夹下创建一个新的仓库。</div>
+          </div>
+          <button className="vm-action-btn vm-action-btn-primary" onClick={onCreate}>
+            创建
+          </button>
+        </div>
+
+        <div className="vm-action-card">
+          <div className="vm-action-text">
+            <div className="vm-action-title">打开本地仓库</div>
+            <div className="vm-action-desc">将一个本地文件夹作为仓库在 Molio 中打开。</div>
+          </div>
+          <button className="vm-action-btn" onClick={onOpenLocal}>
+            打开
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/kb/VaultList.tsx
+++ b/apps/web/src/components/kb/VaultList.tsx
@@ -1,0 +1,52 @@
+/**
+ * Left-side vault list panel — Obsidian-style.
+ */
+
+import type { Vault } from '@molio/contracts';
+
+interface VaultListProps {
+  vaults: Vault[];
+  activeVaultId: string | null;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => Promise<void>;
+}
+
+export function VaultList({ vaults, activeVaultId, onSelect, onDelete }: VaultListProps) {
+  const handleDelete = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    if (window.confirm('Delete this vault? This only removes it from the app.')) {
+      await onDelete(id);
+    }
+  };
+
+  return (
+    <aside className="vm-list">
+      <div className="vm-list-header">知识库仓库</div>
+      <div className="vm-list-body">
+        {vaults.length === 0 && (
+          <div className="vm-list-empty">
+            <div>📂</div>
+            <p>还没有仓库</p>
+          </div>
+        )}
+        {vaults.map((vault) => (
+          <div
+            key={vault.id}
+            className={`vm-vault-item ${vault.id === activeVaultId ? 'is-active' : ''}`}
+            onClick={() => onSelect(vault.id)}
+          >
+            <div className="vm-vault-name">{vault.name}</div>
+            <div className="vm-vault-path">{vault.path}</div>
+            <button
+              className="vm-vault-delete"
+              onClick={(e) => handleDelete(e, vault.id)}
+              title="Remove from app"
+            >
+              ⋯
+            </button>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/kb/VaultManager.tsx
+++ b/apps/web/src/components/kb/VaultManager.tsx
@@ -1,6 +1,7 @@
 /**
- * Obsidian-style Vault Manager.
+ * Obsidian-style Vault Manager — modal overlay.
  *
+ * A full-screen modal that covers the entire page.
  * Left side: list of existing vaults.
  * Right side: branding + actions (Create / Open local vault).
  *
@@ -17,21 +18,27 @@ import { CreateVaultForm } from './CreateVaultForm';
 
 export type VaultManagerView = 'list' | 'create';
 
-interface VaultManagerProps {
+interface VaultManagerModalProps {
+  show: boolean;
   vaults: Vault[];
   activeVaultId: string | null;
-  onSelectVault: (id: string) => void;
-  onCreateVault: (name: string, path: string, description?: string) => Promise<void>;
-  onDeleteVault: (id: string) => Promise<void>;
+  onClose: () => void;
+  onSelect: (id: string) => void;
+  onCreate: (name: string, path: string, description?: string) => Promise<void>;
+  onOpen: (path: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
 }
 
-export function VaultManager({
+export function VaultManagerModal({
+  show,
   vaults,
   activeVaultId,
-  onSelectVault,
-  onCreateVault,
-  onDeleteVault,
-}: VaultManagerProps) {
+  onClose,
+  onSelect,
+  onCreate,
+  onOpen,
+  onDelete,
+}: VaultManagerModalProps) {
   const [view, setView] = useState<VaultManagerView>('list');
   const [creating, setCreating] = useState(false);
 
@@ -39,52 +46,85 @@ export function VaultManager({
     async (name: string, path: string, description?: string) => {
       setCreating(true);
       try {
-        await onCreateVault(name, path, description);
+        await onCreate(name, path, description);
         setView('list');
       } finally {
         setCreating(false);
       }
     },
-    [onCreateVault]
+    [onCreate]
   );
 
   const handleBackToList = useCallback(() => setView('list'), []);
 
-  // Wrap onSelectVault to reset view before selecting a vault
-  const handleSelectVault = useCallback(
+  const handleSelect = useCallback(
     (id: string) => {
       setView('list');
-      onSelectVault(id);
+      onSelect(id);
     },
-    [onSelectVault]
+    [onSelect]
   );
 
-  return (
-    <div className="vm-shell">
-      {/* Left: Vault List */}
-      <VaultList
-        vaults={vaults}
-        activeVaultId={activeVaultId}
-        onSelect={handleSelectVault}
-        onDelete={onDeleteVault}
-      />
+  console.log('VaultManagerModal render, show =', show);
 
-      {/* Right: Action Panel or Create Form */}
-      <div className="vm-panel">
-        {view === 'list' ? (
-          <VaultActionPanel
-            onCreate={() => setView('create')}
-            onOpenLocal={() => {
-              /* TODO: open local folder dialog */
-            }}
+  if (!show) return null;
+
+  return (
+    <div className="vm-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="vm-modal">
+        {/* Left: Vault List */}
+        <div className="vm-modal-left">
+          <VaultList
+            vaults={vaults}
+            activeVaultId={activeVaultId}
+            onSelect={handleSelect}
+            onDelete={onDelete}
           />
-        ) : (
-          <CreateVaultForm
-            onCreate={handleCreate}
-            onCancel={handleBackToList}
-            isLoading={creating}
-          />
-        )}
+        </div>
+
+        {/* Right: Action Panel or Create Form */}
+        <div className="vm-modal-right">
+          {view === 'list' ? (
+            <VaultActionPanel
+              onCreate={() => setView('create')}
+              onOpenLocal={async () => {
+                let pickedPath: string | null = null;
+
+                // 1. Try Electron's native directory picker (desktop app)
+                if (window.__electron__?.showDirectoryPicker) {
+                  try {
+                    pickedPath = await window.__electron__.showDirectoryPicker();
+                  } catch { /* user cancelled */ }
+                }
+
+                // 2. Try browser's File System Access API (web)
+                if (!pickedPath && 'showDirectoryPicker' in window) {
+                  try {
+                    // @ts-expect-error - File System Access API
+                    const dirHandle = await window.showDirectoryPicker();
+                    pickedPath = dirHandle.name;
+                  } catch { /* user cancelled or not supported */ }
+                }
+
+                // 3. Fall back to manual path input
+                if (!pickedPath) {
+                  pickedPath = window.prompt('请输入本地文件夹路径：');
+                }
+
+                if (pickedPath) {
+                  await onOpen(pickedPath);
+                  setView('list');
+                }
+              }}
+            />
+          ) : (
+            <CreateVaultForm
+              onCreate={handleCreate}
+              onCancel={handleBackToList}
+              isLoading={creating}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/kb/VaultManager.tsx
+++ b/apps/web/src/components/kb/VaultManager.tsx
@@ -1,0 +1,91 @@
+/**
+ * Obsidian-style Vault Manager.
+ *
+ * Left side: list of existing vaults.
+ * Right side: branding + actions (Create / Open local vault).
+ *
+ * State machine:
+ *   'list'    → show vault list + action panel
+ *   'create'  → show create vault form
+ */
+
+import { useState, useCallback } from 'react';
+import type { Vault } from '@molio/contracts';
+import { VaultList } from './VaultList';
+import { VaultActionPanel } from './VaultActionPanel';
+import { CreateVaultForm } from './CreateVaultForm';
+
+export type VaultManagerView = 'list' | 'create';
+
+interface VaultManagerProps {
+  vaults: Vault[];
+  activeVaultId: string | null;
+  onSelectVault: (id: string) => void;
+  onCreateVault: (name: string, path: string, description?: string) => Promise<void>;
+  onDeleteVault: (id: string) => Promise<void>;
+}
+
+export function VaultManager({
+  vaults,
+  activeVaultId,
+  onSelectVault,
+  onCreateVault,
+  onDeleteVault,
+}: VaultManagerProps) {
+  const [view, setView] = useState<VaultManagerView>('list');
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = useCallback(
+    async (name: string, path: string, description?: string) => {
+      setCreating(true);
+      try {
+        await onCreateVault(name, path, description);
+        setView('list');
+      } finally {
+        setCreating(false);
+      }
+    },
+    [onCreateVault]
+  );
+
+  const handleBackToList = useCallback(() => setView('list'), []);
+
+  // Wrap onSelectVault to reset view before selecting a vault
+  const handleSelectVault = useCallback(
+    (id: string) => {
+      setView('list');
+      onSelectVault(id);
+    },
+    [onSelectVault]
+  );
+
+  return (
+    <div className="vm-shell">
+      {/* Left: Vault List */}
+      <VaultList
+        vaults={vaults}
+        activeVaultId={activeVaultId}
+        onSelect={handleSelectVault}
+        onDelete={onDeleteVault}
+      />
+
+      {/* Right: Action Panel or Create Form */}
+      <div className="vm-panel">
+        {view === 'list' ? (
+          <VaultActionPanel
+            onCreate={() => setView('create')}
+            onOpenLocal={() => {
+              /* TODO: open local folder dialog */
+            }}
+          />
+        ) : (
+          <CreateVaultForm
+            onCreate={handleCreate}
+            onCancel={handleBackToList}
+            isLoading={creating}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useKnowledge.ts
+++ b/apps/web/src/hooks/useKnowledge.ts
@@ -40,6 +40,7 @@ interface UseKnowledgeReturn {
   // Actions
   selectVault: (id: string) => void;
   createVault: (name: string, path: string, description?: string) => Promise<void>;
+  openVault: (path: string) => Promise<void>;
   deleteVault: (id: string) => Promise<void>;
   selectFile: (path: string) => void;
   refreshTree: () => void;
@@ -166,6 +167,14 @@ export function useKnowledge(): UseKnowledgeReturn {
     setShowAddVault(false);
   }, []);
 
+  const openVault = useCallback(async (path: string) => {
+    // Derive a name from the last path segment
+    const name = path.split(/[\/]/).pop() || '未命名仓库';
+    const vault = await api.createVault({ name, path, description: `从本地文件夹打开: ${path}` });
+    setVaults((prev) => [vault, ...prev]);
+    setActiveVaultId(vault.id);
+  }, []);
+
   const deleteVault = useCallback(async (id: string) => {
     await api.deleteVault(id);
     setVaults((prev) => prev.filter((v) => v.id !== id));
@@ -243,6 +252,7 @@ export function useKnowledge(): UseKnowledgeReturn {
     setShowVaultSwitcher,
     setShowAddVault,
     setShowImport,
+    openVault,
     toggleTypesetMode,
     setThemeConfig,
     setEditedContent: handleEditedContentChange,

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -1171,25 +1171,50 @@
   left: 18px;
 }
 
-/* ══════════ Vault Manager (Obsidian-style) ══════════ */
+/* ══════════ Vault Manager (Obsidian-style Modal) ══════════ */
 
-.vm-shell {
+/* Modal overlay — centered */
+.vm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+}
+
+/* Modal container — two columns, centered card */
+.vm-modal {
   display: flex;
   width: 100%;
-  height: 100%;
+  max-width: 900px;
+  height: 580px;
+  max-height: 80vh;
   overflow: hidden;
+  background: var(--bg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg), 0 0 0 1px var(--border);
 }
 
 /* ── Left: Vault List ── */
-.vm-list {
-  width: 320px;
-  min-width: 260px;
-  max-width: 400px;
+.vm-modal-left {
+  width: 280px;
+  min-width: 240px;
+  max-width: 320px;
   flex-shrink: 0;
   background: var(--bg);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+}
+
+.vm-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   overflow: hidden;
 }
 
@@ -1298,14 +1323,14 @@
 }
 
 /* ── Right: Action Panel ── */
-.vm-panel {
+.vm-modal-right {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   overflow-y: auto;
-  padding: 48px 24px;
+  padding: 40px 32px;
   background: var(--bg);
 }
 

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -1171,6 +1171,375 @@
   left: 18px;
 }
 
+/* ══════════ Vault Manager (Obsidian-style) ══════════ */
+
+.vm-shell {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Left: Vault List ── */
+.vm-list {
+  width: 320px;
+  min-width: 260px;
+  max-width: 400px;
+  flex-shrink: 0;
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.vm-list-header {
+  padding: 16px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--border);
+}
+
+.vm-list-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.vm-list-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 20px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.vm-list-empty div {
+  font-size: 40px;
+  margin-bottom: 12px;
+  opacity: 0.4;
+}
+
+.vm-list-empty p {
+  font-size: 13px;
+}
+
+/* Vault item in list */
+.vm-vault-item {
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 120ms ease;
+  position: relative;
+  margin-bottom: 6px;
+  border: 1px solid transparent;
+}
+
+.vm-vault-item:hover {
+  background: var(--bg-subtle);
+}
+
+.vm-vault-item.is-active {
+  background: var(--accent-tint);
+  border-color: var(--accent);
+}
+
+.vm-vault-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-strong);
+  margin-bottom: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 24px;
+}
+
+.vm-vault-path {
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vm-vault-delete {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.vm-vault-item:hover .vm-vault-delete {
+  opacity: 1;
+}
+
+.vm-vault-delete:hover {
+  background: var(--bg-muted);
+  color: var(--text);
+}
+
+/* ── Right: Action Panel ── */
+.vm-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow-y: auto;
+  padding: 48px 24px;
+  background: var(--bg);
+}
+
+.vm-action-panel {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Branding */
+.vm-brand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 48px;
+}
+
+.vm-brand-logo {
+  font-size: 64px;
+  margin-bottom: 16px;
+  opacity: 0.8;
+}
+
+.vm-brand-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text-strong);
+  letter-spacing: -0.02em;
+  margin-bottom: 6px;
+}
+
+.vm-brand-version {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+/* Action cards */
+.vm-actions {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.vm-action-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: all 120ms ease;
+}
+
+.vm-action-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.vm-action-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.vm-action-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-strong);
+  margin-bottom: 4px;
+}
+
+.vm-action-desc {
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.vm-action-btn {
+  height: 34px;
+  padding: 0 20px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 120ms ease;
+  flex-shrink: 0;
+}
+
+.vm-action-btn:hover {
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
+}
+
+.vm-action-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.vm-action-btn-primary:hover {
+  background: var(--accent-hover);
+}
+
+/* ── Create Vault Form ── */
+.vm-create-form {
+  width: 100%;
+  max-width: 520px;
+}
+
+.vm-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  margin-bottom: 8px;
+  transition: color 120ms ease;
+}
+
+.vm-back-btn:hover {
+  color: var(--text);
+}
+
+.vm-create-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-strong);
+  margin-bottom: 24px;
+  letter-spacing: -0.01em;
+}
+
+.vm-form-group {
+  margin-bottom: 16px;
+}
+
+.vm-form-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-strong);
+  margin-bottom: 6px;
+}
+
+.vm-form-input {
+  width: 100%;
+  height: 38px;
+  padding: 0 12px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.vm-form-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--selected-soft);
+}
+
+.vm-form-input::placeholder {
+  color: var(--text-faint);
+}
+
+.vm-form-row {
+  display: flex;
+  gap: 8px;
+}
+
+.vm-form-row .vm-form-input {
+  flex: 1;
+}
+
+.vm-browse-btn {
+  height: 38px;
+  padding: 0 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-panel);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 120ms ease;
+}
+
+.vm-browse-btn:hover {
+  background: var(--bg-subtle);
+}
+
+.vm-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.vm-submit-btn {
+  height: 38px;
+  padding: 0 24px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.vm-submit-btn:hover {
+  background: var(--accent-hover);
+}
+
+.vm-submit-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ══════════ doocs/md Preview Styles ══════════
    注意：所有 Markdown 渲染样式由 doocs/md 主题系统（applyTheme）动态注入，
    这里不再定义任何 .md-preview 相关样式，避免与主题 CSS 冲突。

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Electron preload API type declarations.
+ */
+
+declare global {
+  interface Window {
+    __electron__?: {
+      platform: string;
+      showDirectoryPicker: () => Promise<string | null>;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## 改动内容

### 修复
- 将 Vault Manager 全屏布局改为居中模态弹窗（900×580px，圆角 + 阴影）
- 修复弹窗 z-index 和 overlay 居中问题

### 新增
- 实现「打开本地仓库」功能：通过 Electron dialog 选择本地文件夹作为仓库
- 支持三层降级：Electron IPC → 浏览器 showDirectoryPicker → prompt 输入路径
- 暴露 Electron preload API: showDirectoryPicker
- 添加 Electron preload API TypeScript 类型声明

## 测试
- 已在浏览器中验证弹窗居中显示正常
- 点击 Vault Bar → 弹出模态框 → 左侧仓库列表 + 右侧操作面板

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)