### PR TITLE
feat(desktop): cross-platform support for macOS and Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ inputs.version }}" ]; then
-            version="${{ inputs.version }}"
+            version=$(echo "${{ inputs.version }}" | xargs)
           else
             raw=$(git describe --tags --always --dirty)
             version=${raw#v}
@@ -53,4 +53,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: npx electron-builder --win --publish always --config.extraMetadata.version=${{ steps.version.outputs.version }}
+        run: npx electron-builder --win --publish always "--config.extraMetadata.version=${{ steps.version.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,12 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   desktop:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,7 +45,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             version=$(echo "${{ inputs.version }}" | xargs)
           else
-            raw=$(git describe --tags --always --dirty)
+            raw=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
             version=${raw#v}
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,88 @@ if (first) {
 
 **适用范围**：任何涉及用户偏好设置的功能（默认运行时、默认项目、主题选择等）。
 
+## 团队贡献规则
 
+**核心原则**：所有代码变更必须通过 Pull Request 流程，**禁止直接 push 到 main 分支**。
 
+### 工作流程
 
+```bash
+# 1. 创建功能分支（从 main 切出）
+git checkout main
+git pull origin main
+git checkout -b feat/功能名称
+# 或 fix/问题描述、chore/任务类型
 
+# 2. 开发并提交
+git add .
+git commit -m "feat(scope): 描述"
+
+# 3. 推送并创建 PR
+git push -u origin feat/功能名称
+gh pr create --title "feat: 功能描述" --base main
+```
+
+### 分支命名规范
+
+| 类型 | 格式 | 示例 |
+|------|------|------|
+| 新功能 | `feat/功能简述` | `feat/auto-update-check` |
+| Bug 修复 | `fix/问题描述` | `fix/daemon-port-conflict` |
+| 重构 | `refactor/模块名` | `refactor/knowledge-base-ui` |
+| 配置/工具 | `chore/任务` | `chore/upgrade-dependencies` |
+| 文档 | `docs/内容` | `docs/api-guide` |
+
+### Commit Message 规范
+
+遵循 [Conventional Commits](https://www.conventionalcommits.org/)：
+
+```
+<type>(<scope>): <description>
+
+[可选 body]
+
+[可选 footer]
+```
+
+**Type 类型**：
+- `feat`: 新功能
+- `fix`: Bug 修复
+- `docs`: 文档变更
+- `style`: 代码格式（不影响功能）
+- `refactor`: 重构（既不是新功能也不是修复）
+- `perf`: 性能优化
+- `test`: 测试相关
+- `chore`: 构建过程或辅助工具变更
+
+**Scope（可选）**：
+- `daemon`: daemon 服务相关
+- `web`: web 前端相关
+- `desktop`: Electron 桌面端相关
+- `kb`: 知识库功能相关
+- `ci`: CI/CD 相关
+
+**示例**：
+```bash
+feat(desktop): add auto-update check on startup
+fix(daemon): resolve port 3100 conflict when upgrading
+refactor(kb): extract vault manager into separate component
+chore(ci): add workflow_dispatch for manual builds
+```
+
+### PR 合并规则
+
+1. **必须创建 PR**：所有变更都要通过 PR 合并到 main，不能直接 push
+2. **等待 Review**：至少需要 1 个 approve 才能合并（除非紧急情况）
+3. **解决冲突**：如果 PR 与 main 有冲突，必须 rebase 解决
+4. **CI 通过**：确保所有 CI 检查通过后再合并
+5. **Squash 合并**：多个 commit 的 PR 建议 squash 成一个有意义的 commit
+
+### 管理员权限使用
+
+虽然 `enforce_admins: false` 允许管理员跳过审查直接合并，但**仅在以下紧急情况使用**：
+- 紧急 hotfix 需要立即上线
+- 修复 CI 配置问题
+- 其他协作者都不可用时的关键修复
+
+**正常开发仍然要求走 PR + Review 流程。**

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,7 +10,10 @@
     "dev": "electron .",
     "prepare": "node scripts/prepare-resources.mjs",
     "build": "pnpm --filter @molio/contracts build && pnpm --filter @molio/daemon build && pnpm --filter @molio/web build && node scripts/prepare-resources.mjs",
-    "package": "electron-builder --win",
+    "package": "node scripts/package.mjs",
+    "package:win": "electron-builder --win",
+    "package:mac": "electron-builder --mac",
+    "package:linux": "electron-builder --linux",
     "package:dir": "electron-builder --win --dir",
     "run:unpacked": "electron-builder --win --dir && echo 'Run: ./dist/win-unpacked/墨流 Molio.exe'",
     "typecheck": "echo 'desktop: no TS to check'"
@@ -49,9 +52,7 @@
       "target": [
         {
           "target": "nsis",
-          "arch": [
-            "x64"
-          ]
+          "arch": ["x64"]
         }
       ],
       "signAndEditExecutable": false
@@ -61,6 +62,39 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "deleteAppDataOnUninstall": false
+    },
+    "mac": {
+      "target": [
+        {
+          "target": "dmg",
+          "arch": ["x64", "arm64"]
+        }
+      ],
+      "category": "public.app-category.productivity",
+      "icon": "build/icon.icns"
+    },
+    "dmg": {
+      "artifactName": "${productName}-Setup-${version}-mac-${arch}.${ext}"
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        },
+        {
+          "target": "deb",
+          "arch": ["x64"]
+        }
+      ],
+      "category": "Office",
+      "icon": "build/icon.png"
+    },
+    "appImage": {
+      "artifactName": "${productName}-${version}-linux-${arch}.${ext}"
+    },
+    "deb": {
+      "artifactName": "${productName}_${version}_linux_${arch}.${ext}"
     },
     "publish": {
       "provider": "github",

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform packaging script.
+ * Detects the current OS and runs the appropriate electron-builder command.
+ *
+ * Usage: pnpm package
+ * Or specify a platform: pnpm package:win | pnpm package:mac | pnpm package:linux
+ */
+
+import { execSync } from 'node:child_process';
+
+const platform = process.platform;
+
+let target;
+switch (platform) {
+  case 'win32':
+    target = '--win';
+    console.log('🪟 Packaging for Windows...');
+    break;
+  case 'darwin':
+    target = '--mac';
+    console.log('🍎 Packaging for macOS...');
+    break;
+  case 'linux':
+    target = '--linux';
+    console.log('🐧 Packaging for Linux...');
+    break;
+  default:
+    console.error(`❌ Unsupported platform: ${platform}`);
+    process.exit(1);
+}
+
+try {
+  execSync(`electron-builder ${target}`, {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  });
+  console.log('✅ Packaging complete!');
+} catch (err) {
+  console.error('❌ Packaging failed:', err.message);
+  process.exit(1);
+}

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -16,8 +16,12 @@ function isDevMode() {
 
 /** Find the system Node.js binary (not Electron's embedded one) */
 function findSystemNode() {
+  const isWin = process.platform === 'win32';
   try {
-    const result = execFileSync('where.exe', ['node'], { encoding: 'utf-8' }).trim();
+    // Windows uses where.exe, Unix (macOS/Linux) uses which
+    const cmd = isWin ? 'where.exe' : 'which';
+    const result = execFileSync(cmd, ['node'], { encoding: 'utf-8' }).trim();
+    // Windows may return multiple lines, Unix returns a single path
     const nodePath = result.split(/\r?\n/)[0];
     if (nodePath) return nodePath;
   } catch { /* fall through */ }


### PR DESCRIPTION
## 变更内容

支持桌面端在 macOS、Windows、Linux 三个平台上构建和打包。

### 主要改动

- **`findSystemNode()`**：macOS/Linux 使用 `which` 替代 Windows 专有的 `where.exe`
- **electron-builder 配置**：新增 mac (DMG) 和 linux (AppImage/deb) 构建 target
- **`scripts/package.mjs`**：自动检测当前平台，调用对应的 builder

### 构建产物

| 平台 | 格式 | 架构 |
|------|------|------|
| Windows | NSIS 安装包 | x64 |
| macOS | DMG | x64 + arm64 |
| Linux | AppImage + deb | x64 |

### 打包命令

```bash
pnpm package          # 自动检测当前平台
pnpm package:win      # Windows
pnpm package:mac      # macOS
pnpm package:linux    # Linux
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)