### PR TITLE
feat(desktop): 加固自动更新系统 — 错误隔离、文件日志、静默安装、CI 验证

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,7 +28,10 @@ jobs:
         run: pnpm build
 
       - name: Run daemon tests
-        run: pnpm test
+        run: pnpm --filter @molio/daemon test
+
+      - name: Run desktop tests (updater regression)
+        run: pnpm --filter @molio/desktop test
 
       - name: Typecheck
         run: pnpm typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,55 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: npx electron-builder --${{ matrix.platform }} ${{ matrix.arch-flag }} --publish always "--config.extraMetadata.version=${{ steps.version.outputs.version }}"
+
+      - name: Verify update manifest exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
+
+          # Wait briefly for release asset upload to complete
+          sleep 5
+
+          echo "Checking release assets for ${TAG}..."
+          ASSETS=$(gh release view "${TAG}" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' 2>/dev/null || echo "")
+
+          if [ -z "$ASSETS" ]; then
+            echo "::error::No assets found in release ${TAG}"
+            exit 1
+          fi
+
+          echo "Release assets:"
+          echo "$ASSETS"
+
+          # Verify platform-specific update manifest exists
+          if [ "${{ matrix.platform }}" = "win" ]; then
+            MANIFEST="latest.yml"
+          elif [ "${{ matrix.platform }}" = "mac" ]; then
+            MANIFEST="latest-mac.yml"
+          else
+            MANIFEST="latest-linux.yml"
+          fi
+
+          if echo "$ASSETS" | grep -q "^${MANIFEST}$"; then
+            echo "✓ Update manifest '${MANIFEST}' found — auto-update will detect v${VERSION}"
+          else
+            echo "::error::Update manifest '${MANIFEST}' NOT found in release ${TAG}. Auto-update will NOT detect this version!"
+            exit 1
+          fi
+
+          # Validate manifest content: version must match
+          if [ "${{ matrix.platform }}" = "win" ]; then
+            MANIFEST_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/latest.yml"
+            echo "Fetching manifest from ${MANIFEST_URL}..."
+            MANIFEST_CONTENT=$(curl -sL "$MANIFEST_URL" || echo "")
+            if echo "$MANIFEST_CONTENT" | grep -q "version: ${VERSION}"; then
+              echo "✓ Manifest version matches ${VERSION}"
+            else
+              echo "::error::Manifest version does not match ${VERSION}. Content:"
+              echo "$MANIFEST_CONTENT"
+              exit 1
+            fi
+          fi

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,7 +16,8 @@
     "package:linux": "electron-builder --linux",
     "package:dir": "electron-builder --win --dir",
     "run:unpacked": "electron-builder --win --dir && echo 'Run: ./dist/win-unpacked/墨流 Molio.exe'",
-    "typecheck": "echo 'desktop: no TS to check'"
+    "typecheck": "echo 'desktop: no TS to check'",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "electron-updater": "^6.8.3"

--- a/apps/desktop/src/logger.js
+++ b/apps/desktop/src/logger.js
@@ -1,0 +1,68 @@
+/**
+ * Simple file logger for the desktop app.
+ *
+ * Writes to {userData}/logs/updater.log with automatic rotation.
+ * Uses only Node.js built-in `fs` — no external dependencies.
+ */
+
+import { app } from 'electron';
+import { appendFileSync, renameSync, statSync, mkdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const MAX_LOG_SIZE = 1024 * 1024; // 1 MB
+let logDir = null;
+let logFile = null;
+
+/** Initialize log directory and file path. Safe to call multiple times. */
+function ensureLogPath() {
+  if (logFile) return;
+  logDir = path.join(app.getPath('userData'), 'logs');
+  if (!existsSync(logDir)) {
+    mkdirSync(logDir, { recursive: true });
+  }
+  logFile = path.join(logDir, 'updater.log');
+
+  // Rotate if existing log is too large
+  try {
+    if (existsSync(logFile) && statSync(logFile).size > MAX_LOG_SIZE) {
+      const rotated = logFile + '.old';
+      if (existsSync(rotated)) {
+        // Silently discard old rotated file
+      }
+      renameSync(logFile, rotated);
+    }
+  } catch {
+    // Ignore rotation errors — just keep appending
+  }
+}
+
+/**
+ * Write a log line. Always appends.
+ * @param {'info'|'warn'|'error'} level
+ * @param {string} tag  — e.g. "updater", "main", "daemon"
+ * @param {string} message
+ */
+export function log(level, tag, message) {
+  const ts = new Date().toISOString();
+  const line = `[${ts}] [${level.toUpperCase()}] [${tag}] ${message}\n`;
+
+  // Always mirror to console for dev experience
+  const consoleFn = level === 'error' ? console.error : console.log;
+  consoleFn(line.trimEnd());
+
+  try {
+    ensureLogPath();
+    appendFileSync(logFile, line, 'utf-8');
+  } catch {
+    // File logging failure must never crash the app
+  }
+}
+
+/**
+ * Return the log file path (for diagnostics / IPC).
+ * @returns {string | null}
+ */
+export function getLogPath() {
+  ensureLogPath();
+  return logFile;
+}

--- a/apps/desktop/src/logger.js
+++ b/apps/desktop/src/logger.js
@@ -1,22 +1,47 @@
 /**
  * Simple file logger for the desktop app.
  *
- * Writes to {userData}/logs/updater.log with automatic rotation.
+ * Writes to {logDir}/updater.log with automatic rotation.
  * Uses only Node.js built-in `fs` — no external dependencies.
+ *
+ * By default the log directory is `{userData}/logs/` (from Electron).
+ * Call `setLogDir(dir)` before first use to override (e.g. for testing).
  */
 
-import { app } from 'electron';
 import { appendFileSync, renameSync, statSync, mkdirSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
 const MAX_LOG_SIZE = 1024 * 1024; // 1 MB
+let customLogDir = null;
 let logDir = null;
 let logFile = null;
+
+/**
+ * Override the log directory (for testing or custom deployments).
+ * Must be called before the first `log()` or `getLogPath()` call.
+ *
+ * @param {string} dir — absolute path to log directory
+ */
+export function setLogDir(dir) {
+  customLogDir = dir;
+  logDir = null;
+  logFile = null;
+}
 
 /** Initialize log directory and file path. Safe to call multiple times. */
 function ensureLogPath() {
   if (logFile) return;
-  logDir = path.join(app.getPath('userData'), 'logs');
+
+  if (customLogDir) {
+    logDir = customLogDir;
+  } else {
+    // Lazy import electron only when needed (avoids error in plain Node.js tests)
+    const require = createRequire(import.meta.url);
+    const { app } = require('electron');
+    logDir = path.join(app.getPath('userData'), 'logs');
+  }
+
   if (!existsSync(logDir)) {
     mkdirSync(logDir, { recursive: true });
   }
@@ -26,9 +51,6 @@ function ensureLogPath() {
   try {
     if (existsSync(logFile) && statSync(logFile).size > MAX_LOG_SIZE) {
       const rotated = logFile + '.old';
-      if (existsSync(rotated)) {
-        // Silently discard old rotated file
-      }
       renameSync(logFile, rotated);
     }
   } catch {
@@ -65,4 +87,11 @@ export function log(level, tag, message) {
 export function getLogPath() {
   ensureLogPath();
   return logFile;
+}
+
+/** @internal Reset state for testing */
+export function _reset() {
+  customLogDir = null;
+  logDir = null;
+  logFile = null;
 }

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -3,6 +3,7 @@ import { spawn, execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setupAutoUpdater } from './updater.js';
+import { log } from './logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -113,16 +114,44 @@ ipcMain.on('app:get-info', (event) => {
   };
 });
 
+// ─── Global crash protection ───
+// These handlers prevent unhandled exceptions in non-critical subsystems
+// (daemon, UI) from killing the main process and taking the auto-updater with it.
+// The updater is the lifeline for pushing fixes, so it must survive all other failures.
+
+process.on('uncaughtException', (err) => {
+  log('error', 'main', `uncaughtException: ${err?.message ?? err}`);
+  if (err?.stack) log('error', 'main', err.stack);
+  // Do NOT exit — keep the updater running
+});
+
+process.on('unhandledRejection', (reason) => {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  log('error', 'main', `unhandledRejection: ${msg}`);
+  // Do NOT exit — keep the updater running
+});
+
 // ─── App lifecycle ───
 
 app.whenReady().then(async () => {
-  if (!isDevMode()) {
-    await startDaemonProduction();
-  }
+  // ① Create window first (updater IPC needs getMainWindow reference)
   createWindow();
 
-  // Set up auto-updater IPC handlers (dev mode returns "not available")
+  // ② Set up auto-updater IMMEDIATELY — before daemon.
+  // Even if daemon fails to start, the updater must be operational
+  // so we can push fixes to users.
   setupAutoUpdater(() => mainWindow);
+
+  // ③ Start daemon last — failure here must not affect updater
+  if (!isDevMode()) {
+    try {
+      await startDaemonProduction();
+    } catch (err) {
+      log('error', 'main', `daemon startup failed: ${err?.message ?? err}`);
+      // Daemon failure is not fatal for the updater.
+      // The UI will show connection errors, but updates still work.
+    }
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -43,8 +43,14 @@ const updaterAPI = {
     ipcRenderer.on('updater:update-downloaded', handler);
     return () => ipcRenderer.removeListener('updater:update-downloaded', handler);
   },
+  onUpdateError: (callback) => {
+    const handler = (_, info) => callback(info);
+    ipcRenderer.on('updater:error', handler);
+    return () => ipcRenderer.removeListener('updater:error', handler);
+  },
   installUpdate: () => ipcRenderer.invoke('updater:install'),
   checkForUpdates: () => ipcRenderer.invoke('updater:check'),
+  getLogPath: () => ipcRenderer.invoke('updater:log-path'),
 };
 
 contextBridge.exposeInMainWorld('__electron__', desktopAPI);

--- a/apps/desktop/src/retry.js
+++ b/apps/desktop/src/retry.js
@@ -1,0 +1,50 @@
+/**
+ * Retry/backoff logic for the auto-updater.
+ *
+ * Extracted as a pure module (no Electron dependencies) so it can be
+ * unit-tested in plain Node.js without any mocking.
+ */
+
+/** Backoff delays in ms: 30s → 1m → 2m → 5m → 15m */
+export const RETRY_DELAYS = [30_000, 60_000, 120_000, 300_000, 900_000];
+
+/**
+ * Get the next retry delay for a given attempt index.
+ * After exhausting all delays, stays at the last value.
+ *
+ * @param {number} attempt — 0-based attempt index
+ * @returns {number} delay in milliseconds
+ */
+export function getRetryDelay(attempt) {
+  if (attempt < 0) return RETRY_DELAYS[0];
+  const idx = Math.min(attempt, RETRY_DELAYS.length - 1);
+  return RETRY_DELAYS[idx];
+}
+
+/**
+ * Create a new retry state tracker.
+ * Each call to `.next()` returns the delay and advances the counter.
+ * `.reset()` resets the counter (e.g. after a successful check).
+ */
+export function createRetryState() {
+  let index = 0;
+
+  return {
+    /** Get the current attempt (0-based) */
+    get attempt() {
+      return index;
+    },
+
+    /** Get next delay and advance the counter */
+    next() {
+      const delay = getRetryDelay(index);
+      index++;
+      return delay;
+    },
+
+    /** Reset counter after a successful check */
+    reset() {
+      index = 0;
+    },
+  };
+}

--- a/apps/desktop/src/updater.js
+++ b/apps/desktop/src/updater.js
@@ -16,6 +16,7 @@
 import pkg from 'electron-updater';
 import { app, ipcMain } from 'electron';
 import { log } from './logger.js';
+import { createRetryState } from './retry.js';
 
 const { autoUpdater } = pkg;
 
@@ -26,12 +27,9 @@ autoUpdater.autoInstallOnAppQuit = true;
 const STARTUP_DELAY = 5_000;         // check 5s after launch
 const POLL_INTERVAL = 60 * 60 * 1000; // check every hour
 
-// Retry backoff delays on failure (ms): 30s → 1m → 2m → 5m → 15m
-const RETRY_DELAYS = [30_000, 60_000, 120_000, 300_000, 900_000];
-
 // Deduplicate concurrent check requests
 let inFlightCheck = null;
-let retryIndex = 0;
+const retry = createRetryState();
 let retryTimer = null;
 let pollTimer = null;
 
@@ -54,7 +52,7 @@ function checkForUpdatesOnce() {
         log('info', 'updater', 'no update available');
       }
       // Reset retry counter on success
-      retryIndex = 0;
+      retry.reset();
 
       void result?.downloadPromise?.catch((err) => {
         const msg = err instanceof Error ? err.message : String(err);
@@ -91,10 +89,10 @@ function notifyError(message) {
 function scheduleRetry() {
   if (retryTimer) return; // already scheduled
 
-  const delay = RETRY_DELAYS[Math.min(retryIndex, RETRY_DELAYS.length - 1)];
-  retryIndex++;
+  const delay = retry.next();
+  const attempt = retry.attempt;
 
-  log('info', 'updater', `retry scheduled in ${delay / 1000}s (attempt ${retryIndex})`);
+  log('info', 'updater', `retry scheduled in ${delay / 1000}s (attempt ${attempt})`);
 
   retryTimer = setTimeout(() => {
     retryTimer = null;

--- a/apps/desktop/src/updater.js
+++ b/apps/desktop/src/updater.js
@@ -4,12 +4,18 @@
  * Uses electron-updater to check for updates from GitHub Releases,
  * download them in the background, and notify the renderer when ready.
  *
+ * Key design:
+ * - Errors are logged to file AND surfaced to the renderer UI
+ * - Failed checks retry with exponential backoff (not waiting a full hour)
+ * - All activity is logged to {userData}/logs/updater.log for diagnosis
+ *
  * In dev mode (not packaged), IPC handlers are registered but return
  * "not available" — autoUpdater requires a packaged app to function.
  */
 
 import pkg from 'electron-updater';
 import { app, ipcMain } from 'electron';
+import { log } from './logger.js';
 
 const { autoUpdater } = pkg;
 
@@ -20,25 +26,96 @@ autoUpdater.autoInstallOnAppQuit = true;
 const STARTUP_DELAY = 5_000;         // check 5s after launch
 const POLL_INTERVAL = 60 * 60 * 1000; // check every hour
 
+// Retry backoff delays on failure (ms): 30s → 1m → 2m → 5m → 15m
+const RETRY_DELAYS = [30_000, 60_000, 120_000, 300_000, 900_000];
+
 // Deduplicate concurrent check requests
 let inFlightCheck = null;
+let retryIndex = 0;
+let retryTimer = null;
+let pollTimer = null;
 
+/**
+ * Attempt a single update check.
+ * On success: reset retry counter, schedule next poll.
+ * On failure: log, notify renderer, schedule retry with backoff.
+ */
 function checkForUpdatesOnce() {
   if (inFlightCheck) return inFlightCheck;
+
+  log('info', 'updater', 'checking for updates...');
+
   const p = autoUpdater
     .checkForUpdates()
     .then((result) => {
+      if (result?.isUpdateAvailable) {
+        log('info', 'updater', `update available: v${result.updateInfo?.version}`);
+      } else {
+        log('info', 'updater', 'no update available');
+      }
+      // Reset retry counter on success
+      retryIndex = 0;
+
       void result?.downloadPromise?.catch((err) => {
-        console.error('[updater] download failed:', err);
+        const msg = err instanceof Error ? err.message : String(err);
+        log('error', 'updater', `download failed: ${msg}`);
+        notifyError(msg);
+        scheduleRetry();
       });
       return result;
+    })
+    .catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      log('error', 'updater', `check failed: ${msg}`);
+      notifyError(msg);
+      scheduleRetry();
+      return null;
     })
     .finally(() => {
       if (inFlightCheck === p) inFlightCheck = null;
     });
+
   inFlightCheck = p;
   return p;
 }
+
+/** Send error event to renderer so UI can show it. */
+function notifyError(message) {
+  const win = getMainWindowRef?.();
+  if (win?.webContents) {
+    win.webContents.send('updater:error', { message });
+  }
+}
+
+/** Schedule a retry with exponential backoff after a failed check. */
+function scheduleRetry() {
+  if (retryTimer) return; // already scheduled
+
+  const delay = RETRY_DELAYS[Math.min(retryIndex, RETRY_DELAYS.length - 1)];
+  retryIndex++;
+
+  log('info', 'updater', `retry scheduled in ${delay / 1000}s (attempt ${retryIndex})`);
+
+  retryTimer = setTimeout(() => {
+    retryTimer = null;
+    checkForUpdatesOnce().catch((err) => {
+      log('error', 'updater', `retry failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }, delay);
+}
+
+/** Start the periodic polling loop. */
+function startPolling() {
+  if (pollTimer) clearInterval(pollTimer);
+  pollTimer = setInterval(() => {
+    checkForUpdatesOnce().catch((err) => {
+      log('error', 'updater', `poll failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }, POLL_INTERVAL);
+}
+
+// Reference to getMainWindow — set by setupAutoUpdater
+let getMainWindowRef = null;
 
 /**
  * Set up auto-updater events and IPC handlers.
@@ -48,6 +125,7 @@ function checkForUpdatesOnce() {
  * @param {() => import('electron').BrowserWindow | null} getMainWindow
  */
 export function setupAutoUpdater(getMainWindow) {
+  getMainWindowRef = getMainWindow;
   const isPackaged = app.isPackaged;
 
   // IPC: manual check from renderer (Settings page "Check for updates" button)
@@ -75,21 +153,32 @@ export function setupAutoUpdater(getMainWindow) {
     }
   });
 
-  // IPC: install and restart
+  // IPC: install and restart — silent install, no user interaction needed
   ipcMain.handle('updater:install', () => {
     if (!isPackaged) return;
-    autoUpdater.quitAndInstall(false, true);
+    log('info', 'updater', 'installing update (silent) and restarting...');
+    autoUpdater.quitAndInstall(true, true);
+  });
+
+  // IPC: return log file path for diagnostics
+  ipcMain.handle('updater:log-path', async () => {
+    try {
+      const { getLogPath } = await import('./logger.js');
+      return getLogPath();
+    } catch {
+      return null;
+    }
   });
 
   // Only set up autoUpdater events and background polling in packaged builds
   if (!isPackaged) {
-    console.log('[updater] dev mode — auto-update disabled, IPC handlers registered');
+    log('info', 'updater', 'dev mode — auto-update disabled, IPC handlers registered');
     return;
   }
 
   // Notify renderer when a new version is available
   autoUpdater.on('update-available', (info) => {
-    console.log(`[updater] v${info.version} available`);
+    log('info', 'updater', `v${info.version} available`);
     getMainWindow()?.webContents.send('updater:update-available', {
       version: info.version,
     });
@@ -104,23 +193,29 @@ export function setupAutoUpdater(getMainWindow) {
 
   // Notify renderer when update is downloaded and ready to install
   autoUpdater.on('update-downloaded', (info) => {
-    console.log(`[updater] v${info.version} downloaded`);
+    log('info', 'updater', `v${info.version} downloaded and ready`);
     getMainWindow()?.webContents.send('updater:update-downloaded', {
       version: info.version,
     });
   });
 
+  // Catch autoUpdater errors — log to file AND notify renderer
   autoUpdater.on('error', (err) => {
-    console.error('[updater] error:', err);
+    const msg = err instanceof Error ? err.message : String(err);
+    log('error', 'updater', `autoUpdater error: ${msg}`);
+    notifyError(msg);
+    scheduleRetry();
   });
 
-  // Background check after startup delay
+  // Initial check after startup delay
   setTimeout(() => {
-    checkForUpdatesOnce().catch(console.error);
+    checkForUpdatesOnce().catch((err) => {
+      log('error', 'updater', `initial check failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
   }, STARTUP_DELAY);
 
   // Periodic polling
-  setInterval(() => {
-    checkForUpdatesOnce().catch(console.error);
-  }, POLL_INTERVAL);
+  startPolling();
+
+  log('info', 'updater', `initialized (v${app.getVersion()}, startup delay ${STARTUP_DELAY / 1000}s, poll every ${POLL_INTERVAL / 60_000}min)`);
 }

--- a/apps/desktop/test/logger.test.js
+++ b/apps/desktop/test/logger.test.js
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for logger.js — file-based logging used by the auto-updater.
+ *
+ * Uses setLogDir(tmpdir) to avoid needing Electron's app.getPath().
+ * If any PR breaks the logger, these tests will catch it.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { log, getLogPath, setLogDir, _reset } from '../src/logger.js';
+
+let tmpDir;
+
+beforeEach(() => {
+  _reset();
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'molio-logger-test-'));
+  setLogDir(tmpDir);
+});
+
+afterEach(() => {
+  _reset();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('log()', () => {
+  it('should create log file on first write', () => {
+    log('info', 'test', 'hello');
+    const logPath = getLogPath();
+    assert.ok(existsSync(logPath), 'log file should exist');
+  });
+
+  it('should write timestamped lines in correct format', () => {
+    log('info', 'updater', 'test message');
+    const content = readFileSync(getLogPath(), 'utf-8');
+    // Format: [ISO timestamp] [LEVEL] [tag] message
+    assert.match(content, /\[\d{4}-\d{2}-\d{2}T.*\] \[INFO\] \[updater\] test message\n/);
+  });
+
+  it('should handle all log levels', () => {
+    log('info', 't', 'msg1');
+    log('warn', 't', 'msg2');
+    log('error', 't', 'msg3');
+    const content = readFileSync(getLogPath(), 'utf-8');
+    assert.match(content, /\[INFO\]/);
+    assert.match(content, /\[WARN\]/);
+    assert.match(content, /\[ERROR\]/);
+  });
+
+  it('should append, not overwrite', () => {
+    log('info', 't', 'line1');
+    log('info', 't', 'line2');
+    log('info', 't', 'line3');
+    const content = readFileSync(getLogPath(), 'utf-8');
+    const lines = content.trim().split('\n');
+    assert.equal(lines.length, 3);
+  });
+
+  it('should not crash on special characters', () => {
+    assert.doesNotThrow(() => {
+      log('error', 'updater', 'Error: ETIMEDOUT (connection refused)');
+      log('error', 'updater', 'message with "quotes" and {braces}');
+      log('error', 'updater', 'multiline\nmessage');
+    });
+    const content = readFileSync(getLogPath(), 'utf-8');
+    assert.ok(content.includes('ETIMEDOUT'));
+  });
+});
+
+describe('getLogPath()', () => {
+  it('should return a path inside the configured log directory', () => {
+    const logPath = getLogPath();
+    assert.ok(logPath.startsWith(tmpDir), `log path ${logPath} should be inside ${tmpDir}`);
+    assert.ok(logPath.endsWith('updater.log'));
+  });
+});
+
+describe('log rotation', () => {
+  it('should rotate log file when it exceeds 1MB', () => {
+    // Write a large file to simulate an oversized log
+    const logPath = path.join(tmpDir, 'updater.log');
+    const bigContent = 'x'.repeat(1024 * 1024 + 100); // > 1MB
+    writeFileSync(logPath, bigContent);
+
+    // Reset to trigger ensureLogPath again
+    _reset();
+    setLogDir(tmpDir);
+
+    // Writing a new log entry should trigger rotation
+    log('info', 'test', 'after rotation');
+
+    // Old file should be rotated to .old
+    assert.ok(existsSync(logPath + '.old'), 'rotated .old file should exist');
+
+    // New file should only have the new entry
+    const newContent = readFileSync(logPath, 'utf-8');
+    assert.ok(newContent.includes('after rotation'));
+    assert.ok(!newContent.includes('xxxxx'), 'new file should not contain old content');
+  });
+});
+
+describe('setLogDir()', () => {
+  it('should allow overriding the log directory', () => {
+    const customDir = mkdtempSync(path.join(os.tmpdir(), 'molio-custom-log-'));
+    _reset();
+    setLogDir(customDir);
+
+    log('info', 'test', 'custom dir');
+    const logPath = getLogPath();
+    assert.ok(logPath.startsWith(customDir));
+
+    _reset();
+    rmSync(customDir, { recursive: true, force: true });
+  });
+});

--- a/apps/desktop/test/retry.test.js
+++ b/apps/desktop/test/retry.test.js
@@ -1,0 +1,111 @@
+/**
+ * Regression tests for retry.js — the backoff logic used by the auto-updater.
+ *
+ * This module has ZERO Electron dependencies, so it runs in plain Node.js.
+ * If any PR breaks the retry logic, these tests will catch it.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getRetryDelay, createRetryState, RETRY_DELAYS } from '../src/retry.js';
+
+describe('RETRY_DELAYS', () => {
+  it('should have exactly 5 delay levels', () => {
+    assert.equal(RETRY_DELAYS.length, 5);
+  });
+
+  it('should start at 30 seconds', () => {
+    assert.equal(RETRY_DELAYS[0], 30_000);
+  });
+
+  it('should end at 15 minutes', () => {
+    assert.equal(RETRY_DELAYS[4], 900_000);
+  });
+
+  it('should be strictly increasing', () => {
+    for (let i = 1; i < RETRY_DELAYS.length; i++) {
+      assert.ok(RETRY_DELAYS[i] > RETRY_DELAYS[i - 1],
+        `RETRY_DELAYS[${i}] (${RETRY_DELAYS[i]}) should be > RETRY_DELAYS[${i - 1}] (${RETRY_DELAYS[i - 1]})`);
+    }
+  });
+
+  it('all delays should be under 1 hour (less than poll interval)', () => {
+    const ONE_HOUR = 60 * 60 * 1000;
+    for (const d of RETRY_DELAYS) {
+      assert.ok(d < ONE_HOUR, `${d}ms should be < 1 hour`);
+    }
+  });
+});
+
+describe('getRetryDelay', () => {
+  it('should return first delay for attempt 0', () => {
+    assert.equal(getRetryDelay(0), 30_000);
+  });
+
+  it('should return correct delays for each attempt', () => {
+    assert.equal(getRetryDelay(0), 30_000);
+    assert.equal(getRetryDelay(1), 60_000);
+    assert.equal(getRetryDelay(2), 120_000);
+    assert.equal(getRetryDelay(3), 300_000);
+    assert.equal(getRetryDelay(4), 900_000);
+  });
+
+  it('should cap at last delay for attempts beyond array length', () => {
+    assert.equal(getRetryDelay(5), 900_000);
+    assert.equal(getRetryDelay(10), 900_000);
+    assert.equal(getRetryDelay(100), 900_000);
+  });
+
+  it('should handle negative attempt by returning first delay', () => {
+    assert.equal(getRetryDelay(-1), 30_000);
+  });
+});
+
+describe('createRetryState', () => {
+  it('should start at attempt 0', () => {
+    const state = createRetryState();
+    assert.equal(state.attempt, 0);
+  });
+
+  it('should return increasing delays on each .next() call', () => {
+    const state = createRetryState();
+    assert.equal(state.next(), 30_000);
+    assert.equal(state.next(), 60_000);
+    assert.equal(state.next(), 120_000);
+    assert.equal(state.next(), 300_000);
+    assert.equal(state.next(), 900_000);
+    // Should cap at last delay
+    assert.equal(state.next(), 900_000);
+  });
+
+  it('should increment attempt after each .next()', () => {
+    const state = createRetryState();
+    assert.equal(state.attempt, 0);
+    state.next();
+    assert.equal(state.attempt, 1);
+    state.next();
+    assert.equal(state.attempt, 2);
+  });
+
+  it('should reset attempt to 0', () => {
+    const state = createRetryState();
+    state.next();
+    state.next();
+    state.next();
+    assert.equal(state.attempt, 3);
+    state.reset();
+    assert.equal(state.attempt, 0);
+    assert.equal(state.next(), 30_000);
+  });
+
+  it('multiple instances should be independent', () => {
+    const a = createRetryState();
+    const b = createRetryState();
+    a.next();
+    a.next();
+    assert.equal(a.attempt, 2);
+    assert.equal(b.attempt, 0);
+    b.reset();
+    assert.equal(a.attempt, 2); // unaffected
+  });
+});

--- a/apps/desktop/test/updater-structure.test.js
+++ b/apps/desktop/test/updater-structure.test.js
@@ -1,0 +1,183 @@
+/**
+ * Regression tests for updater resilience invariants in main.js.
+ *
+ * These are STRUCTURAL tests — they read main.js as text and verify that
+ * critical code patterns exist. This catches the most common AI-generated
+ * regression: reordering initialization so updater starts after daemon,
+ * or removing global crash handlers.
+ *
+ * If any PR changes main.js and breaks these invariants, these tests fail.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const mainJs = readFileSync(
+  path.resolve(import.meta.dirname, '../src/main.js'),
+  'utf-8'
+);
+
+describe('main.js: updater must initialize before daemon', () => {
+  it('setupAutoUpdater should be called before startDaemonProduction', () => {
+    const updaterPos = mainJs.indexOf('setupAutoUpdater');
+    const daemonPos = mainJs.indexOf('startDaemonProduction');
+
+    assert.ok(updaterPos !== -1, 'setupAutoUpdater must be called in main.js');
+    assert.ok(daemonPos !== -1, 'startDaemonProduction must exist in main.js');
+
+    // In app.whenReady(), setupAutoUpdater must appear BEFORE startDaemonProduction
+    // Find the whenReady block
+    const whenReadyPos = mainJs.indexOf('app.whenReady()');
+    assert.ok(whenReadyPos !== -1, 'app.whenReady() must exist');
+
+    const whenReadyBlock = mainJs.slice(whenReadyPos);
+    const updaterInBlock = whenReadyBlock.indexOf('setupAutoUpdater');
+    const daemonInBlock = whenReadyBlock.indexOf('startDaemonProduction');
+
+    assert.ok(updaterInBlock !== -1, 'setupAutoUpdater must be in whenReady block');
+    assert.ok(daemonInBlock !== -1, 'startDaemonProduction must be in whenReady block');
+    assert.ok(
+      updaterInBlock < daemonInBlock,
+      `setupAutoUpdater (pos ${updaterInBlock}) must be called BEFORE startDaemonProduction (pos ${daemonInBlock}) in app.whenReady()`
+    );
+  });
+
+  it('daemon startup failure should be caught (not crash the app)', () => {
+    // startDaemonProduction must be wrapped in try/catch
+    const whenReadyPos = mainJs.indexOf('app.whenReady()');
+    const whenReadyBlock = mainJs.slice(whenReadyPos);
+
+    // Find the try/catch around startDaemonProduction
+    const daemonPos = whenReadyBlock.indexOf('startDaemonProduction');
+    const beforeDaemon = whenReadyBlock.slice(0, daemonPos);
+
+    // There should be a 'try {' before startDaemonProduction in the whenReady block
+    const lastTry = beforeDaemon.lastIndexOf('try');
+    assert.ok(lastTry !== -1, 'startDaemonProduction must be wrapped in try/catch');
+
+    // The try should be close to startDaemonProduction (within ~200 chars)
+    assert.ok(
+      daemonPos - lastTry < 200,
+      `try block (pos ${lastTry}) should be near startDaemonProduction (pos ${daemonPos})`
+    );
+  });
+});
+
+describe('main.js: global crash protection must exist', () => {
+  it('should have uncaughtException handler', () => {
+    assert.ok(
+      mainJs.includes("process.on('uncaughtException'") ||
+      mainJs.includes('process.on("uncaughtException"'),
+      'main.js must have process.on("uncaughtException") handler'
+    );
+  });
+
+  it('should have unhandledRejection handler', () => {
+    assert.ok(
+      mainJs.includes("process.on('unhandledRejection'") ||
+      mainJs.includes('process.on("unhandledRejection"'),
+      'main.js must have process.on("unhandledRejection") handler'
+    );
+  });
+
+  it('crash handlers should NOT call process.exit', () => {
+    // Extract the crash handler blocks
+    const handlers = mainJs.match(/process\.on\(['"](uncaughtException|unhandledRejection)['"][\s\S]*?\}\);/g) || [];
+    for (const handler of handlers) {
+      assert.ok(
+        !handler.includes('process.exit'),
+        'Crash handlers must NOT call process.exit — the updater must survive crashes'
+      );
+    }
+  });
+});
+
+describe('updater.js: quitAndInstall must use silent mode', () => {
+  const updaterJs = readFileSync(
+    path.resolve(import.meta.dirname, '../src/updater.js'),
+    'utf-8'
+  );
+
+  it('quitAndInstall should be called with (true, true) for silent install', () => {
+    // Find all quitAndInstall calls
+    const calls = updaterJs.match(/quitAndInstall\([^)]*\)/g) || [];
+    assert.ok(calls.length > 0, 'quitAndInstall must be called somewhere');
+
+    for (const call of calls) {
+      assert.ok(
+        call.includes('quitAndInstall(true, true)'),
+        `quitAndInstall must use (true, true) for silent install, got: ${call}`
+      );
+    }
+  });
+});
+
+describe('updater.js: error event must notify renderer', () => {
+  const updaterJs = readFileSync(
+    path.resolve(import.meta.dirname, '../src/updater.js'),
+    'utf-8'
+  );
+
+  it("autoUpdater 'error' event should send to renderer via updater:error", () => {
+    // The error handler must contain both: log AND send to renderer
+    assert.ok(
+      updaterJs.includes("'error'") || updaterJs.includes('"error"'),
+      "autoUpdater.on('error') handler must exist"
+    );
+    assert.ok(
+      updaterJs.includes("'updater:error'") || updaterJs.includes('"updater:error"'),
+      "error handler must send 'updater:error' IPC event to renderer"
+    );
+  });
+});
+
+describe('updater.js: must use retry module (not inline delays)', () => {
+  const updaterJs = readFileSync(
+    path.resolve(import.meta.dirname, '../src/updater.js'),
+    'utf-8'
+  );
+
+  it('should import createRetryState from retry.js', () => {
+    assert.ok(
+      updaterJs.includes("from './retry.js'") || updaterJs.includes('from "./retry.js"'),
+      "updater.js must import from './retry.js'"
+    );
+    assert.ok(
+      updaterJs.includes('createRetryState'),
+      'updater.js must use createRetryState'
+    );
+  });
+
+  it('should NOT have inline RETRY_DELAYS array', () => {
+    // The old pattern was: const RETRY_DELAYS = [30_000, ...]
+    // This should now be in retry.js
+    const hasInlineDelays = /const\s+RETRY_DELAYS\s*=\s*\[/.test(updaterJs);
+    assert.ok(
+      !hasInlineDelays,
+      'updater.js should NOT define RETRY_DELAYS inline — it should use retry.js'
+    );
+  });
+});
+
+describe('preload.cjs: must expose onUpdateError', () => {
+  const preloadCjs = readFileSync(
+    path.resolve(import.meta.dirname, '../src/preload.cjs'),
+    'utf-8'
+  );
+
+  it('should expose onUpdateError method', () => {
+    assert.ok(
+      preloadCjs.includes('onUpdateError'),
+      'preload.cjs must expose onUpdateError method'
+    );
+  });
+
+  it("should listen for 'updater:error' IPC event", () => {
+    assert.ok(
+      preloadCjs.includes("'updater:error'") || preloadCjs.includes('"updater:error"'),
+      "preload.cjs must listen for 'updater:error' IPC event"
+    );
+  });
+});

--- a/apps/web/src/components/UpdateNotification.tsx
+++ b/apps/web/src/components/UpdateNotification.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from 'react';
 
 type UpdateState =
   | { status: 'idle' }
-  | { status: 'ready'; version: string };
+  | { status: 'ready'; version: string }
+  | { status: 'error'; message: string };
 
 /**
  * Fixed-position toast that appears when an update has been downloaded
- * and is ready to install. Only renders in Electron (packaged) mode.
+ * and is ready to install, or when an update error occurs.
+ * Only renders in Electron (packaged) mode.
  */
 export function UpdateNotification() {
   const [state, setState] = useState<UpdateState>({ status: 'idle' });
@@ -14,15 +16,63 @@ export function UpdateNotification() {
 
   useEffect(() => {
     if (!window.updater) return;
-    const cleanup = window.updater.onUpdateDownloaded((info) => {
-      setState({ status: 'ready', version: info.version });
-      setDismissed(false);
-    });
-    return cleanup;
+
+    const cleanups: (() => void)[] = [];
+
+    cleanups.push(
+      window.updater.onUpdateDownloaded((info) => {
+        setState({ status: 'ready', version: info.version });
+        setDismissed(false);
+      })
+    );
+
+    cleanups.push(
+      window.updater.onUpdateError((info) => {
+        setState({ status: 'error', message: info.message });
+        setDismissed(false);
+      })
+    );
+
+    return () => cleanups.forEach((fn) => fn());
   }, []);
 
   if (!window.updater) return null;
   if (state.status === 'idle' || dismissed) return null;
+
+  if (state.status === 'error') {
+    return (
+      <div className="update-toast update-toast--error">
+        <button
+          className="update-toast__close"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+        >
+          ✕
+        </button>
+        <p className="update-toast__title">更新检测失败</p>
+        <p className="update-toast__subtitle update-toast__subtitle--error">
+          {state.message}
+        </p>
+        <div className="update-toast__actions">
+          <button
+            className="rt-btn rt-btn--sm"
+            onClick={() => setDismissed(true)}
+          >
+            关闭
+          </button>
+          <button
+            className="rt-btn rt-btn--sm update-toast__primary"
+            onClick={() => {
+              window.updater?.checkForUpdates();
+              setDismissed(true);
+            }}
+          >
+            重试
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="update-toast">

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -62,6 +62,13 @@ export function SettingsPage() {
       })
     );
 
+    // Surface background updater errors (network failures, etc.)
+    cleanups.push(
+      window.updater.onUpdateError((info) => {
+        setResult({ status: 'error', message: info.message });
+      })
+    );
+
     return () => cleanups.forEach((fn) => fn());
   }, []);
 

--- a/apps/web/src/styles/settings.css
+++ b/apps/web/src/styles/settings.css
@@ -266,6 +266,21 @@
   border-color: var(--accent-hover);
 }
 
+/* Error variant */
+.update-toast--error {
+  border-color: #e74c3c;
+}
+
+.update-toast--error .update-toast__title {
+  color: #e74c3c;
+}
+
+.update-toast__subtitle--error {
+  word-break: break-word;
+  max-height: 48px;
+  overflow: hidden;
+}
+
 /* ── Responsive ── */
 @media (max-width: 640px) {
   .settings-header {

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -10,11 +10,13 @@ interface UpdaterAPI {
   onUpdateAvailable: (callback: (info: { version: string }) => void) => () => void;
   onDownloadProgress: (callback: (progress: { percent: number }) => void) => () => void;
   onUpdateDownloaded: (callback: (info: { version: string }) => void) => () => void;
+  onUpdateError: (callback: (info: { message: string }) => void) => () => void;
   installUpdate: () => Promise<void>;
   checkForUpdates: () => Promise<
     | { ok: true; currentVersion: string; latestVersion: string; available: boolean }
     | { ok: false; error: string }
   >;
+  getLogPath: () => Promise<string | null>;
 }
 
 interface DesktopAPI {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "package": "pnpm build && pnpm --filter @molio/desktop package",
     "package:dir": "pnpm build && pnpm --filter @molio/desktop package:dir",
     "desktop:run": "pnpm build && pnpm --filter @molio/desktop run:unpacked",
-    "test": "pnpm --filter @molio/daemon test",
+    "test": "pnpm --filter @molio/daemon test && pnpm --filter @molio/desktop test",
     "test:e2e": "pnpm --filter @molio/web test:e2e",
     "typecheck": "pnpm -r typecheck"
   },


### PR DESCRIPTION
## 背景

用户安装 v0.2.0-beta.2 后，GitHub 上已发布 v0.2.1（latest release），但桌面端从未弹出更新提示。

自动更新是推送修复的生命线，必须做到**即使其他功能报错，自动更新也不能受影响**。

## 变更内容

### 1. 初始化顺序修复（核心）
- `setupAutoUpdater()` 从 daemon 启动**之后**改为**之前**
- 即使 daemon 启动失败，updater 仍然正常工作
- 新增全局 `uncaughtException`/`unhandledRejection` 处理，保护 updater 不被其他模块崩溃连带杀死

### 2. 文件日志（诊断）
- 新建 `src/logger.js`，写入 `{userData}/logs/updater.log`
- 自动轮转（>1MB 时重命名为 .old）
- 所有 updater 活动（检查、下载、错误）均记录到文件

### 3. 错误通知到 UI（可见性）
- `autoUpdater.on("error")` 现在通过 `updater:error` IPC 事件发送到 renderer
- `UpdateNotification.tsx` 新增错误状态 toast（红色边框 + 重试按钮）
- `SettingsPage.tsx` 监听 `onUpdateError` 实时显示错误信息

### 4. 失败退避重试（可靠性）
- 检查失败后不再等待 1 小时才重试
- 改为退避间隔：30s → 1m → 2m → 5m → 15m
- 成功后重置计数器，恢复正常轮询

### 5. 静默安装（体验优化）
- `quitAndInstall(false, true)` → `quitAndInstall(true, true)`
- 点击"立即重启"后一键完成安装，无需手动选择安装位置

### 6. CI 验证（防护网）
- Release workflow 新增 `Verify update manifest exists` 步骤
- 验证 `latest.yml` 存在于 release assets 中
- 验证 manifest 中的版本号与实际版本匹配
- 缺失时 CI 失败，阻止发布无法被自动检测到的版本

Closes #10