### PR TITLE
feat(kb): support multi-format file viewing in desktop app

### DIFF
--- a/apps/daemon/src/core/knowledge.ts
+++ b/apps/daemon/src/core/knowledge.ts
@@ -73,6 +73,8 @@ export function countFiles(vaultPath: string): number {
 
 /**
  * Read a file from a vault. Path is relative to vault root.
+ * For text files, returns content as UTF-8 string.
+ * For binary files (images, PDF, DOCX), content is empty — use raw file URL or openPath.
  */
 export function readFile(vaultPath: string, relPath: string): FileContent {
   const absFile = path.join(vaultPath, relPath);
@@ -84,14 +86,26 @@ export function readFile(vaultPath: string, relPath: string): FileContent {
   }
 
   const stat = fs.statSync(resolved);
-  const content = fs.readFileSync(resolved, 'utf-8');
+  const mimeType = getMimeType(relPath);
+  const content = isTextFile(resolved) ? fs.readFileSync(resolved, 'utf-8') : '';
 
   return {
     path: relPath,
     content,
     size: stat.size,
     modifiedAt: stat.mtimeMs,
+    mimeType,
   };
+}
+
+/** Resolve a vault-relative path to an absolute filesystem path. */
+export function resolveFilePath(vaultPath: string, relPath: string): string {
+  const absFile = path.join(vaultPath, relPath);
+  const resolved = path.resolve(absFile);
+  if (!resolved.startsWith(path.resolve(vaultPath))) {
+    throw new Error('Path traversal not allowed');
+  }
+  return resolved;
 }
 
 /**
@@ -149,5 +163,52 @@ export function ensureVaultDir(vaultPath: string): void {
 
 function isSupportedFile(name: string): boolean {
   const ext = path.extname(name).toLowerCase();
-  return ['.md', '.txt', '.pdf', '.docx', '.html', '.htm', '.json', '.yaml', '.yml'].includes(ext);
+  return [...TEXT_EXTS, ...IMAGE_EXTS, ...BINARY_EXTS].includes(ext);
 }
+
+/** Text file extensions — content read as UTF-8 */
+const TEXT_EXTS = ['.md', '.txt', '.html', '.htm', '.json', '.yaml', '.yml'];
+
+/** Image file extensions — displayed inline via <img> */
+const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico'];
+
+/** Binary file extensions — opened via system default program */
+const BINARY_EXTS = ['.pdf', '.docx', '.doc', '.pptx', '.ppt', '.xlsx', '.xls'];
+
+function isTextFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return TEXT_EXTS.includes(ext);
+}
+
+function getMimeType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] ?? 'application/octet-stream';
+}
+
+const MIME_TYPES: Record<string, string> = {
+  // Text
+  '.md': 'text/markdown',
+  '.txt': 'text/plain',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.json': 'application/json',
+  '.yaml': 'text/yaml',
+  '.yml': 'text/yaml',
+  // Images
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  // Binary documents
+  '.pdf': 'application/pdf',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.doc': 'application/msword',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.xls': 'application/vnd.ms-excel',
+};

--- a/apps/daemon/src/routes/knowledge.ts
+++ b/apps/daemon/src/routes/knowledge.ts
@@ -3,7 +3,7 @@
  */
 
 import { Hono } from 'hono';
-import { existsSync } from 'node:fs';
+import { createReadStream, existsSync } from 'node:fs';
 import path from 'node:path';
 import type Database from 'better-sqlite3';
 import type {
@@ -26,6 +26,7 @@ import {
   scanTree,
   countFiles,
   readFile,
+  resolveFilePath,
   writeFile,
   deleteFile,
   createDirectory,
@@ -174,6 +175,38 @@ export function knowledgeRoutes(db: Database.Database, runManager: RunManager): 
       return c.body(null, 204);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete file';
+      return c.json({ error: { code: 'INTERNAL', message } }, 500);
+    }
+  });
+
+  // ─── Raw file serving (for images, PDFs, etc.) ───
+
+  // GET /api/knowledge/vaults/:id/raw/* — serve raw file with proper Content-Type
+  app.get('/vaults/:id/raw/*', (c) => {
+    const vault = getVault(db, c.req.param('id'));
+    if (!vault) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'Vault not found' } }, 404);
+    }
+
+    const fullPath = c.req.path;
+    const prefix = `/api/knowledge/vaults/${vault.id}/raw/`;
+    const relPath = decodeURIComponent(fullPath.slice(prefix.length));
+
+    if (!relPath) {
+      return c.json({ error: { code: 'BAD_REQUEST', message: 'File path is required' } }, 400);
+    }
+
+    try {
+      const absPath = resolveFilePath(vault.path, relPath);
+      const stream = createReadStream(absPath);
+      const ext = path.extname(absPath).toLowerCase();
+      const mime = RAW_MIME[ext] ?? 'application/octet-stream';
+
+      return new Response(stream as any, {
+        headers: { 'Content-Type': mime },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to read file';
       return c.json({ error: { code: 'INTERNAL', message } }, 500);
     }
   });
@@ -394,3 +427,16 @@ function countFilesSafe(vaultPath: string): number {
     return 0;
   }
 }
+
+const RAW_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  '.pdf': 'application/pdf',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+};

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron';
 import { spawn, execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -183,4 +183,8 @@ ipcMain.handle('show-directory-picker', async () => {
   });
   if (result.canceled || result.filePaths.length === 0) return null;
   return result.filePaths[0];
+});
+
+ipcMain.handle('open-path', async (_, filePath) => {
+  return shell.openPath(filePath);
 });

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -24,6 +24,9 @@ const desktopAPI = {
 
   /** Show a directory picker dialog. Returns the selected path or null. */
   showDirectoryPicker: () => ipcRenderer.invoke('show-directory-picker'),
+
+  /** Open a file with the system default application. */
+  openPath: (filePath) => ipcRenderer.invoke('open-path', filePath),
 };
 
 // Updater API — event listeners + actions

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -224,6 +224,12 @@ export const api = {
     return res.json();
   },
 
+  /** Build URL for raw file access (images, PDFs, etc.) */
+  rawFileUrl(vaultId: string, filePath: string): string {
+    const encoded = encodeURIComponent(filePath).replace(/%2F/g, '/');
+    return `${BASE}/knowledge/vaults/${vaultId}/raw/${encoded}`;
+  },
+
   async writeFile(vaultId: string, filePath: string, content: string): Promise<void> {
     const encoded = encodeURIComponent(filePath).replace(/%2F/g, '/');
     const res = await fetch(`${BASE}/knowledge/vaults/${vaultId}/files/${encoded}`, {

--- a/apps/web/src/components/kb/KbMainContent.tsx
+++ b/apps/web/src/components/kb/KbMainContent.tsx
@@ -1,18 +1,40 @@
 /**
- * Main content area — doocs/md rendering with optional typeset mode.
- *
- * Default mode: Direct doocs/md rendering
- * Typeset mode: Three-column editor (editor | preview | style panel)
+ * Main content area — renders files based on type:
+ * - Text (md/txt/html/json/yaml): doocs/md rendering with optional typeset mode
+ * - Images (png/jpg/gif/svg/webp): inline <img> preview
+ * - Binary (pdf/docx/pptx): file info card + "open with system app" button
  */
 
 import type { FileContent } from '@molio/contracts';
 import type { ThemeConfig } from './MdStylePanel';
 import { MdRenderer } from './MdRenderer';
 import { MdTypesetEditor } from './MdTypesetEditor';
+import { api } from '../../api/client';
+
+/** File categories for rendering strategy */
+type FileCategory = 'text' | 'image' | 'binary';
+
+const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico']);
+const BINARY_EXTS = new Set(['.pdf', '.docx', '.doc', '.pptx', '.ppt', '.xlsx', '.xls']);
+
+function getFileCategory(fileName: string): FileCategory {
+  const ext = fileName.slice(fileName.lastIndexOf('.')).toLowerCase();
+  if (IMAGE_EXTS.has(ext)) return 'image';
+  if (BINARY_EXTS.has(ext)) return 'binary';
+  return 'text';
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 interface KbMainContentProps {
   fileContent: FileContent | null;
   selectedFile: string | null;
+  vaultId: string | null;
+  vaultPath: string | null;
   isTypesetMode: boolean;
   themeConfig: ThemeConfig;
   wikiInitialized: boolean;
@@ -27,6 +49,8 @@ interface KbMainContentProps {
 export function KbMainContent({
   fileContent,
   selectedFile,
+  vaultId,
+  vaultPath,
   isTypesetMode,
   themeConfig,
   wikiInitialized,
@@ -38,7 +62,6 @@ export function KbMainContent({
 }: KbMainContentProps) {
   // No file selected — show empty state or wiki CTA
   if (!selectedFile) {
-    // Show wiki build CTA if wiki is not initialized
     if (!wikiInitialized) {
       return (
         <main className="kb-main">
@@ -65,8 +88,21 @@ export function KbMainContent({
     );
   }
 
-  // Get the filename from the path
   const fileName = selectedFile.split('/').pop() ?? selectedFile;
+  const category = getFileCategory(fileName);
+
+  // Build absolute path for shell.openPath (Electron only)
+  const absolutePath = vaultPath && selectedFile
+    ? `${vaultPath.replace(/[\\/]+$/, '')}/${selectedFile}`
+    : null;
+
+  const handleOpenExternal = () => {
+    if (absolutePath && window.__electron__?.openPath) {
+      window.__electron__.openPath(absolutePath);
+    }
+  };
+
+  const isElectron = !!window.__electron__?.openPath;
 
   return (
     <main className="kb-main">
@@ -76,59 +112,97 @@ export function KbMainContent({
           <span className="kb-header-filename">{fileName}</span>
         </div>
         <div className="kb-header-actions">
-          {/* Typeset toggle - always visible */}
-          <button
-            type="button"
-            className={`kb-btn ${isTypesetMode ? 'is-active' : ''}`}
-            onClick={onToggleTypeset}
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
-              <path d="M4 7V4h16v3" />
-              <path d="M9 20h6" />
-              <path d="M12 4v16" />
-            </svg>
-            <span>{isTypesetMode ? '退出排版' : '排版'}</span>
-          </button>
-
-          {/* Additional buttons only in typeset mode */}
-          {isTypesetMode && (
+          {/* Text file actions: typeset, copy, publish */}
+          {category === 'text' && (
             <>
-              <button type="button" className="kb-btn" onClick={onCopy}>
+              <button
+                type="button"
+                className={`kb-btn ${isTypesetMode ? 'is-active' : ''}`}
+                onClick={onToggleTypeset}
+              >
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
-                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  <path d="M4 7V4h16v3" />
+                  <path d="M9 20h6" />
+                  <path d="M12 4v16" />
                 </svg>
-                <span>复制</span>
+                <span>{isTypesetMode ? '退出排版' : '排版'}</span>
               </button>
-              <button type="button" className="kb-btn" onClick={onPublish}>
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
-                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                </svg>
-                <span>发布</span>
-              </button>
+
+              {isTypesetMode && (
+                <>
+                  <button type="button" className="kb-btn" onClick={onCopy}>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                    </svg>
+                    <span>复制</span>
+                  </button>
+                  <button type="button" className="kb-btn" onClick={onPublish}>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
+                      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                    </svg>
+                    <span>发布</span>
+                  </button>
+                </>
+              )}
             </>
+          )}
+
+          {/* Binary file: open with system app (Electron only) */}
+          {category === 'binary' && isElectron && (
+            <button type="button" className="kb-btn" onClick={handleOpenExternal}>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="14" height="14">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+              <span>用外部程序打开</span>
+            </button>
           )}
         </div>
       </div>
 
-      {/* Content area */}
-      {isTypesetMode ? (
+      {/* Content area — branch by file category */}
+      {category === 'text' && isTypesetMode ? (
         <MdTypesetEditor
           initialContent={fileContent?.content ?? ''}
           onContentChange={onContentChange}
         />
-      ) : (
+      ) : category === 'text' ? (
         <div className="kb-content-area">
           {fileContent ? (
-            <MdRenderer
-              content={fileContent.content}
-              themeConfig={themeConfig}
-            />
+            <MdRenderer content={fileContent.content} themeConfig={themeConfig} />
           ) : (
-            <div className="kb-empty-state">
-              <p>Loading...</p>
-            </div>
+            <div className="kb-empty-state"><p>Loading...</p></div>
           )}
+        </div>
+      ) : category === 'image' && vaultId ? (
+        <div className="kb-content-area kb-image-viewer">
+          <img
+            src={api.rawFileUrl(vaultId, selectedFile)}
+            alt={fileName}
+          />
+        </div>
+      ) : category === 'binary' ? (
+        <div className="kb-content-area">
+          <div className="kb-file-card">
+            <div className="kb-file-card-icon">
+              {fileName.endsWith('.pdf') ? '📄' : fileName.match(/\.docx?$/i) ? '📝' : '📁'}
+            </div>
+            <div className="kb-file-card-info">
+              <h3>{fileName}</h3>
+              <p>{fileContent ? formatFileSize(fileContent.size) : '—'}</p>
+            </div>
+            {isElectron && (
+              <button type="button" className="kb-file-card-open" onClick={handleOpenExternal}>
+                用外部程序打开
+              </button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="kb-content-area">
+          <div className="kb-empty-state"><p>Loading...</p></div>
         </div>
       )}
     </main>

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -125,6 +125,8 @@ export function KnowledgeBasePage({ agentId }: KnowledgeBasePageProps) {
       <KbMainContent
         fileContent={kb.fileContent}
         selectedFile={kb.selectedFile}
+        vaultId={kb.activeVault?.id ?? null}
+        vaultPath={kb.activeVault?.path ?? null}
         isTypesetMode={kb.isTypesetMode}
         themeConfig={kb.themeConfig}
         wikiInitialized={kb.wikiInitialized}

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -1819,3 +1819,76 @@
 .wiki-cta-btn:hover {
   background: var(--accent-hover);
 }
+
+/* ══════════ Image Viewer ══════════ */
+
+.kb-image-viewer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bg-secondary, #f5f5f5);
+}
+
+.kb-image-viewer img {
+  max-width: 100%;
+  max-height: calc(100vh - 140px);
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* ══════════ Binary File Card ══════════ */
+
+.kb-file-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 48px 24px;
+  max-width: 360px;
+  margin: 48px auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  text-align: center;
+}
+
+.kb-file-card-icon {
+  font-size: 56px;
+  line-height: 1;
+}
+
+.kb-file-card-info h3 {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 4px;
+  word-break: break-all;
+}
+
+.kb-file-card-info p {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.kb-file-card-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.kb-file-card-open:hover {
+  background: var(--accent-hover);
+}

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -30,6 +30,7 @@ interface DesktopAPI {
   platform: string;
   appInfo: { version: string; os: string };
   showDirectoryPicker: () => Promise<string | null>;
+  openPath: (filePath: string) => Promise<string>;
 }
 
 declare global {

--- a/packages/contracts/src/knowledge.ts
+++ b/packages/contracts/src/knowledge.ts
@@ -22,9 +22,10 @@ export interface TreeNode {
 
 export interface FileContent {
   path: string; // Relative path from vault root
-  content: string;
+  content: string; // Empty for binary files (use raw file URL instead)
   size: number;
   modifiedAt: number;
+  mimeType?: string; // e.g. "image/png", "application/pdf"
 }
 
 export interface KbHistoryEntry {


### PR DESCRIPTION
## Summary

知识库文件查看器支持多种文件格式，参照 Obsidian 策略处理非 Markdown 文件。

## 文件类型支持

| 类型 | 扩展名 | 处理方式 |
|------|--------|---------|
| **文本** | md, txt, html, json, yaml | MdRenderer 内嵌渲染 + 排版/复制/发布 |
| **图片** | png, jpg, gif, svg, webp, bmp | `<img>` 内嵌显示 |
| **二进制** | pdf, docx, pptx, xlsx | `shell.openPath()` 调系统默认程序打开 |

## 改动内容

### Electron
- **main.js**: 新增 `openPath` IPC handler (`shell.openPath`)
- **preload.cjs**: 暴露 `openPath` API

### Daemon
- **knowledge.ts**: `readFile` 区分文本/二进制文件，二进制文件不读 content，返回 mimeType
- **knowledge.ts**: 新增图片扩展名支持 (`isSupportedFile`)
- **routes/knowledge.ts**: 新增 `GET /vaults/:id/raw/*` 原始文件路由（图片流式传输）

### Web UI
- **KbMainContent**: 按文件类型分流渲染（文本/图片/二进制文件卡片）
- **api/client.ts**: 新增 `rawFileUrl()` 工具方法
- **electron.d.ts**: 新增 `openPath` 类型声明
- **knowledge.css**: 图片查看器 + 文件卡片样式

## 设计决策

- **零新增依赖**: 不引入 pdfjs-dist 等库，PDF/DOCX 统一走系统程序打开
- **Electron 优先**: 当前主要面向桌面端，Web 端二进制文件只显示信息卡片
- **自动适配**: 纯浏览器环境 `window.__electron__` 不存在，"打开"按钮自动隐藏

## 验证

- [x] `pnpm build` 编译通过
- [x] 点击 MD 文件 → 正常渲染 + 排版
- [x] 点击图片文件 → 内嵌显示
- [x] 点击 PDF/DOCX → 文件卡片 + 外部打开按钮 → 系统程序打开
