### PR TITLE
fix(desktop): 发布按钮在系统浏览器中打开而非 Electron 内嵌窗口

### DIFF
--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -91,6 +91,15 @@ function createWindow() {
     mainWindow?.show();
   });
 
+  // Intercept window.open() — open in system browser instead of Electron
+  // This is critical for the COSE publish flow: the bridge page must run
+  // in the user's real Chrome (where the COSE extension is installed),
+  // not in Electron's embedded Chromium.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
   // Open DevTools in development
   if (isDevMode()) {
     mainWindow.webContents.openDevTools();

--- a/apps/desktop/test/window-open-handler.test.js
+++ b/apps/desktop/test/window-open-handler.test.js
@@ -1,0 +1,52 @@
+/**
+ * Regression test for Issue #18 — publish opens in Electron instead of system browser.
+ *
+ * Verifies that main.js registers a setWindowOpenHandler that calls
+ * shell.openExternal() and denies the window action. This prevents
+ * window.open() from creating Electron child windows — instead the URL
+ * is opened in the user's system browser where the COSE extension lives.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSource = readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf-8');
+
+describe('main.js window.open handler (regression #18)', () => {
+  it('should register setWindowOpenHandler on webContents', () => {
+    assert.ok(
+      mainSource.includes('setWindowOpenHandler'),
+      'main.js must register setWindowOpenHandler to intercept window.open() calls',
+    );
+  });
+
+  it('should call shell.openExternal for intercepted URLs', () => {
+    // The handler must forward the URL to the system browser
+    assert.ok(
+      mainSource.includes('shell.openExternal'),
+      'setWindowOpenHandler must call shell.openExternal(url) to open in system browser',
+    );
+  });
+
+  it('should deny the window action to prevent Electron child windows', () => {
+    // The handler must return { action: 'deny' } so Electron doesn't open a new window
+    assert.match(
+      mainSource,
+      /action:\s*['"]deny['"]/,
+      'setWindowOpenHandler must return { action: "deny" } to block Electron child windows',
+    );
+  });
+
+  it('should extract url from handler params', () => {
+    // Verify the handler destructures { url } from the params
+    assert.match(
+      mainSource,
+      /setWindowOpenHandler\s*\(\s*\(\s*\{\s*url\s*\}/,
+      'setWindowOpenHandler should destructure { url } from the handler params',
+    );
+  });
+});

--- a/apps/web/e2e/publish-flow.spec.ts
+++ b/apps/web/e2e/publish-flow.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -72,25 +73,37 @@ test.describe('Publish button regression (#11)', () => {
     await expect(publishBtn).toBeVisible();
 
     // THE REGRESSION TEST: click publish and verify something happens
-    // Before fix: clicking did nothing (no-op handler)
-    // After fix: either COSE install prompt appears OR bridge page opens
+    // Before fix (#11): clicking did nothing (no-op handler)
+    // After fix (#11): either COSE install prompt appears OR bridge page opens in new tab
+    // After fix (#18): in Electron, setWindowOpenHandler opens bridge in system browser
+
+    // Listen for new page/tab (bridge page opened via window.open)
+    const newPagePromise = page.context().waitForEvent('page', { timeout: 5_000 }).catch(() => null);
+
     await publishBtn.click();
 
-    // Verify a response within 3 seconds:
-    // - COSE install prompt modal (extension not installed)
-    // - Or a new browser tab/window (bridge page opened)
+    // Check for COSE install prompt modal first (extension not installed)
     const coseModal = page.locator('.kb-modal').filter({ hasText: /COSE|扩展|安装/ });
-    const anyModal = page.locator('.kb-overlay.show .kb-modal');
-
-    // Either the COSE modal appears, or we get a popup (bridge page)
     const modalVisible = await coseModal.isVisible({ timeout: 3_000 }).catch(() => false);
-    if (!modalVisible) {
-      // Check if any modal appeared
-      const anyModalVisible = await anyModal.isVisible({ timeout: 1_000 }).catch(() => false);
-      // If no modal, at least verify the page didn't freeze (button is still interactive)
-      if (!anyModalVisible) {
+
+    if (modalVisible) {
+      // COSE not installed — modal shown, this is correct behavior
+      await expect(coseModal).toBeVisible();
+    } else {
+      // COSE is installed (or check passed) — bridge page should open in new tab
+      const newPage = await newPagePromise;
+      if (newPage) {
+        // Verify the bridge page loaded (it should contain "Molio 发布" or the article title)
+        await newPage.waitForLoadState('domcontentloaded');
+        const bridgeContent = await newPage.content();
+        assert.ok(
+          bridgeContent.includes('Molio') || bridgeContent.includes('发布') || bridgeContent.includes('Test'),
+          'Bridge page should contain publish UI content',
+        );
+        await newPage.close();
+      } else {
+        // No modal and no new page — this is the #11 regression
         await expect(publishBtn).toBeEnabled();
-        // Fail: publish button click produced no visible response
         test.fail(false, 'Publish button click produced no response — regression of #11');
       }
     }


### PR DESCRIPTION
## 问题

Issue #18：在 Electron 桌面应用中点击知识库「发布」按钮后，bridge page 在 Electron 内嵌 Chromium 中打开，而非用户的系统浏览器。COSE 扩展安装在真实 Chrome 中，Electron 内嵌 Chromium 没有该扩展，导致发布流程无法执行。

## 根因

`useKnowledge.ts` 中的 `publishToChrome()` 使用 `window.open(bridgeUrl, '_blank')`。在 Electron 环境中，该调用在 Electron 内部打开新窗口，而非系统浏览器。

## 修复

在 `apps/desktop/src/main.js` 的 `createWindow()` 中添加 `webContents.setWindowOpenHandler`：

```javascript
mainWindow.webContents.setWindowOpenHandler(({ url }) => {
  shell.openExternal(url);
  return { action: 'deny' };
});
```

这样所有 `window.open()` 调用都会被拦截，URL 通过 `shell.openExternal()` 转发到系统默认浏览器。

## 变更文件

| 文件 | 变更 |
|------|------|
| `apps/desktop/src/main.js` | 添加 setWindowOpenHandler 拦截 |
| `apps/desktop/test/window-open-handler.test.js` | 4 条回归测试（#18） |
| `apps/web/e2e/publish-flow.spec.ts` | 更新 E2E 测试检测新标签页弹出 |

## 测试

- ✅ Desktop tests: 51/51 pass（含 4 条新增回归测试）
- ✅ Daemon tests: 142/142 pass

Closes #18