### PR TITLE
fix(desktop): use Electron embedded Node.js to run daemon instead of system node

### DIFF
--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -21,11 +21,11 @@ Electron 桌面应用壳，包裹 `@molio/web` 构建产物，内嵌 `@molio/dae
 - Daemon 同时提供 API 和静态文件 (port 3100)
 - Electron 加载 `http://localhost:3100`
 
-### 为什么使用系统 Node.js 而不是 Electron 的 Node.js？
+### 为什么使用 ELECTRON_RUN_AS_NODE？
 
-Electron 33 内置 Node.js 20.18.0 (ABI 130)，而系统 Node.js 是 22.x (ABI 127)。
-`better-sqlite3` 等原生模块是为系统 Node.js 编译的，直接在 Electron 的 Node.js 中加载会产生 ABI 不匹配。
-使用系统 Node.js 运行 daemon 可以避免这个问题，但需要用户系统已安装 Node.js。
+Electron 33 内置 Node.js 20.18.0。通过设置 `ELECTRON_RUN_AS_NODE=1` 环境变量，可以让 Electron 的二进制文件作为标准 Node.js 进程运行 daemon，无需用户单独安装 Node.js。
+
+`better-sqlite3` 等原生模块在构建时通过 `@electron/rebuild` 重新编译为 Electron 的 ABI，确保在 Electron 的 Node.js 运行时中正确加载。
 
 ## 文件结构
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "electron-updater": "^6.8.3"
   },
   "devDependencies": {
+    "@electron/rebuild": "^4.0.4",
     "electron": "^33.0.0",
     "electron-builder": "^25.1.8",
     "esbuild": "^0.25.0"
@@ -53,7 +54,9 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "signAndEditExecutable": false
@@ -68,7 +71,9 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["arm64"]
+          "arch": [
+            "arm64"
+          ]
         }
       ],
       "category": "public.app-category.productivity"
@@ -80,11 +85,15 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "deb",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "category": "Office"

--- a/apps/desktop/scripts/prepare-resources.mjs
+++ b/apps/desktop/scripts/prepare-resources.mjs
@@ -4,13 +4,15 @@
  * 1. Bundle the daemon into a single JS file using esbuild
  *    (better-sqlite3 is external — it's a native module)
  * 2. Copy better-sqlite3 + its deps to resources/daemon/node_modules/
- * 3. Copy the web build to resources/web/
+ * 3. Rebuild better-sqlite3 for Electron's ABI (so it works with ELECTRON_RUN_AS_NODE)
+ * 4. Copy the web build to resources/web/
  */
 
 import { build } from 'esbuild';
 import { cpSync, mkdirSync, existsSync, readdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = resolve(__dirname, '..');
@@ -105,6 +107,42 @@ function copyNativeDependencies() {
   }
 }
 
+async function rebuildForElectron() {
+  console.log('Rebuilding native modules for Electron...');
+
+  // Get Electron version
+  const require = createRequire(import.meta.url);
+  const electronPkg = require('electron/package.json');
+  const electronVersion = electronPkg.version;
+
+  // Create a minimal package.json in resources/daemon so @electron/rebuild
+  // can discover and rebuild better-sqlite3
+  const daemonResDir = join(resourcesDir, 'daemon');
+  const packageJsonPath = join(daemonResDir, 'package.json');
+  writeFileSync(packageJsonPath, JSON.stringify({
+    name: 'molio-daemon',
+    version: '1.0.0',
+    private: true,
+    dependencies: { 'better-sqlite3': '*' },
+  }, null, 2));
+
+  // @electron/rebuild is a CJS module
+  const { rebuild } = require('@electron/rebuild');
+  await rebuild({
+    buildPath: daemonResDir,
+    electronVersion,
+    platform: process.platform,
+    arch: process.arch,
+    onlyModules: ['better-sqlite3'],
+    force: true,
+  });
+
+  // Clean up temporary package.json
+  rmSync(packageJsonPath);
+
+  console.log(`  Rebuilt better-sqlite3 for Electron v${electronVersion} (${process.platform}/${process.arch})`);
+}
+
 function copyWebBuild() {
   console.log('Copying web build...');
   const webDist = join(webDir, 'dist');
@@ -145,6 +183,7 @@ mkdirSync(resourcesDir, { recursive: true });
 
 await bundleDaemon();
 copyNativeDependencies();
+await rebuildForElectron();
 copyWebBuild();
 
 console.log('\nResources prepared successfully!');

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron';
-import { spawn, execFileSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setupAutoUpdater } from './updater.js';
@@ -15,30 +15,19 @@ function isDevMode() {
   return !app.isPackaged;
 }
 
-/** Find the system Node.js binary (not Electron's embedded one) */
-function findSystemNode() {
-  const isWin = process.platform === 'win32';
-  try {
-    // Windows uses where.exe, Unix (macOS/Linux) uses which
-    const cmd = isWin ? 'where.exe' : 'which';
-    const result = execFileSync(cmd, ['node'], { encoding: 'utf-8' }).trim();
-    // Windows may return multiple lines, Unix returns a single path
-    const nodePath = result.split(/\r?\n/)[0];
-    if (nodePath) return nodePath;
-  } catch { /* fall through */ }
-  return 'node';
-}
-
-/** Start the daemon in production mode using the bundled resources */
+/** Start the daemon in production mode using Electron's embedded Node.js */
 function startDaemonProduction() {
   const daemonEntry = path.join(process.resourcesPath, 'daemon', 'daemon.js');
   const webStaticDir = path.join(process.resourcesPath, 'web');
-  const nodeExe = findSystemNode();
 
   return new Promise((resolve, reject) => {
-    daemonProcess = spawn(nodeExe, [daemonEntry], {
+    // Use Electron's embedded Node.js to run the daemon.
+    // ELECTRON_RUN_AS_NODE=1 makes the Electron binary behave as a standard Node.js process,
+    // eliminating the need for users to install Node.js separately.
+    daemonProcess = spawn(process.execPath, [daemonEntry], {
       env: {
         ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
         MOLIO_PORT: '3100',
         MOLIO_STATIC_DIR: webStaticDir,
       },

--- a/apps/desktop/test/daemon-startup.test.js
+++ b/apps/desktop/test/daemon-startup.test.js
@@ -1,0 +1,92 @@
+/**
+ * Regression test for: daemon fails to start when system Node.js is not installed.
+ *
+ * Root cause: startDaemonProduction() used findSystemNode() to find node.exe via
+ * where.exe node. On systems without Node.js, the daemon never started.
+ *
+ * Fix: Use Electron's embedded Node.js via ELECTRON_RUN_AS_NODE=1 and
+ * rebuild better-sqlite3 for Electron's ABI using @electron/rebuild.
+ *
+ * See: https://github.com/zhuzhaoyun/Molio/issues/21
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const mainJs = readFileSync(
+  path.resolve(import.meta.dirname, '../src/main.js'),
+  'utf-8'
+);
+
+const prepareResourcesJs = readFileSync(
+  path.resolve(import.meta.dirname, '../scripts/prepare-resources.mjs'),
+  'utf-8'
+);
+
+describe('main.js: daemon must use Electron embedded Node.js (not system node)', () => {
+  it('should NOT have findSystemNode() function', () => {
+    assert.ok(
+      !mainJs.includes('findSystemNode'),
+      'findSystemNode() must be removed — daemon should use Electron embedded Node.js'
+    );
+  });
+
+  it('should NOT import execFileSync (no longer needed for where.exe)', () => {
+    assert.ok(
+      !mainJs.includes('execFileSync'),
+      'execFileSync must not be imported — where.exe lookup is no longer used'
+    );
+  });
+
+  it('should spawn daemon with process.execPath', () => {
+    assert.ok(
+      mainJs.includes('process.execPath'),
+      'startDaemonProduction must use process.execPath (Electron binary)'
+    );
+  });
+
+  it('should set ELECTRON_RUN_AS_NODE=1 environment variable', () => {
+    assert.ok(
+      mainJs.includes('ELECTRON_RUN_AS_NODE'),
+      'startDaemonProduction must set ELECTRON_RUN_AS_NODE=1'
+    );
+  });
+
+  it('should pass daemonEntry as argument to spawn', () => {
+    // spawn(process.execPath, [daemonEntry], ...)
+    const spawnCall = mainJs.match(/spawn\(\s*process\.execPath\s*,\s*\[daemonEntry\]/);
+    assert.ok(
+      spawnCall,
+      'spawn must be called with (process.execPath, [daemonEntry], ...)'
+    );
+  });
+});
+
+describe('prepare-resources.mjs: better-sqlite3 must be rebuilt for Electron ABI', () => {
+  it('should import or require @electron/rebuild', () => {
+    assert.ok(
+      prepareResourcesJs.includes('@electron/rebuild'),
+      'prepare-resources must use @electron/rebuild to rebuild native modules'
+    );
+  });
+
+  it('should call rebuild() targeting better-sqlite3', () => {
+    assert.ok(
+      prepareResourcesJs.includes('rebuild(') || prepareResourcesJs.includes('rebuild ('),
+      'prepare-resources must call rebuild()'
+    );
+    assert.ok(
+      prepareResourcesJs.includes('better-sqlite3'),
+      'rebuild must target better-sqlite3'
+    );
+  });
+
+  it('should use electronVersion from electron/package.json', () => {
+    assert.ok(
+      prepareResourcesJs.includes('electronVersion'),
+      'rebuild must use electronVersion from electron/package.json'
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
         specifier: ^6.8.3
         version: 6.8.3
     devDependencies:
+      '@electron/rebuild':
+        specifier: ^4.0.4
+        version: 4.0.4
       electron:
         specifier: ^33.0.0
         version: 33.0.0
@@ -398,6 +401,11 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
 
+  '@electron/rebuild@4.0.4':
+    resolution: {integrity: sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
   '@electron/universal@2.0.1':
     resolution: {integrity: sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==}
     engines: {node: '>=16.4'}
@@ -729,6 +737,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
@@ -1071,6 +1083,10 @@ packages:
   abbrev@1.0.3:
     resolution: {integrity: sha512-s07HMJf6O5iTLVDx9cH7c9VbOdrmzxE+AzWz9CPi94zVNBQQA3jIwIZKTrHQj4dGR1T/MdwMnVJzSpjaVEXtXw==}
 
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   agent-base@6.0.0:
     resolution: {integrity: sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==}
     engines: {node: '>= 6.0.0'}
@@ -1286,6 +1302,10 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
@@ -1596,6 +1616,9 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -1896,6 +1919,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   isomorphic-dompurify@3.15.0:
     resolution: {integrity: sha512-9ZtkbQ8+SgNf6LuDAdu9bq23dVXMIGNM8ZYnyl2MufyZiSD5dqAUJcyjtYZz7B80HuPpEn/f0NCS6zKvavHtfA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -2116,6 +2143,10 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -2150,11 +2181,20 @@ packages:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
+  node-abi@4.31.0:
+    resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
+    engines: {node: '>=22.12.0'}
+
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
+
+  node-gyp@12.4.0:
+    resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   node-gyp@9.0.0:
     resolution: {integrity: sha512-Ma6p4s+XCTPxCuAMrOA/IJRmVy16R8Sdhtwl4PrCr7IBlj4cPawF0vg/l7nOT1jPbuNS7lIRJpBSvVsXwEZuzw==}
@@ -2168,6 +2208,11 @@ packages:
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-path@3.0.0:
@@ -2277,6 +2322,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  proc-log@6.0.0:
+    resolution: {integrity: sha512-KG/XsTDN901PNfPfAMmj6N/Ywg9tM+bHK8pAz+27fS4N4Pcr+4zoYBOcGSBu6ceXYNPxkLpa4ohtfxV1XcLAfA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -2596,6 +2645,10 @@ packages:
     resolution: {integrity: sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==}
     engines: {node: '>=10'}
 
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
+
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
 
@@ -2661,6 +2714,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
 
   undici@7.27.0:
     resolution: {integrity: sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==}
@@ -2775,6 +2832,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
@@ -2813,6 +2875,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -3321,6 +3387,17 @@ snapshots:
       - bluebird
       - supports-color
 
+  '@electron/rebuild@4.0.4':
+    dependencies:
+      '@malept/cross-spawn-promise': 2.0.0
+      debug: 4.4.3
+      node-abi: 4.31.0
+      node-api-version: 0.2.1
+      node-gyp: 12.4.0
+      read-binary-file-arch: 1.0.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@electron/universal@2.0.1':
     dependencies:
       '@electron/asar': 3.2.7
@@ -3502,6 +3579,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
@@ -3846,6 +3927,8 @@ snapshots:
 
   abbrev@1.0.3: {}
 
+  abbrev@4.0.0: {}
+
   agent-base@6.0.0:
     dependencies:
       debug: 4.4.3
@@ -4160,6 +4243,8 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   chromium-pickle-js@0.2.0: {}
 
@@ -4555,6 +4640,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  exponential-backoff@3.1.3: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3
@@ -4895,6 +4982,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   isomorphic-dompurify@3.15.0:
     dependencies:
       dompurify: 3.4.8
@@ -5088,7 +5177,7 @@ snapshots:
 
   minipass-collect@1.0.2:
     dependencies:
-      minipass: 3.1.6
+      minipass: 3.0.0
 
   minipass-fetch@1.4.1:
     dependencies:
@@ -5100,15 +5189,15 @@ snapshots:
 
   minipass-flush@1.0.7:
     dependencies:
-      minipass: 3.1.6
+      minipass: 3.0.0
 
   minipass-pipeline@1.2.4:
     dependencies:
-      minipass: 3.1.6
+      minipass: 3.0.0
 
   minipass-sized@1.0.3:
     dependencies:
-      minipass: 3.1.6
+      minipass: 3.0.0
 
   minipass@3.0.0:
     dependencies:
@@ -5124,6 +5213,10 @@ snapshots:
     dependencies:
       minipass: 3.0.0
       yallist: 4.0.0
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   mkdirp-classic@0.5.3: {}
 
@@ -5147,12 +5240,29 @@ snapshots:
     dependencies:
       semver: 7.8.1
 
+  node-abi@4.31.0:
+    dependencies:
+      semver: 7.8.1
+
   node-addon-api@1.7.2:
     optional: true
 
   node-api-version@0.2.1:
     dependencies:
       semver: 7.8.1
+
+  node-gyp@12.4.0:
+    dependencies:
+      env-paths: 2.2.0
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 9.0.0
+      proc-log: 6.0.0
+      semver: 7.8.1
+      tar: 7.5.16
+      tinyglobby: 0.2.17
+      undici: 6.26.0
+      which: 6.0.1
 
   node-gyp@9.0.0:
     dependencies:
@@ -5175,6 +5285,10 @@ snapshots:
   nopt@5.0.0:
     dependencies:
       abbrev: 1.0.3
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   normalize-path@3.0.0: {}
 
@@ -5287,6 +5401,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.0.0
       tunnel-agent: 0.6.0
+
+  proc-log@6.0.0: {}
 
   process-nextick-args@2.0.1: {}
 
@@ -5635,6 +5751,14 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   temp-file@3.4.0:
     dependencies:
       async-exit-hook: 2.0.1
@@ -5694,6 +5818,8 @@ snapshots:
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@6.26.0: {}
 
   undici@7.27.0: {}
 
@@ -5775,6 +5901,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   wide-align@1.1.5:
     dependencies:
       string-width: 4.2.3
@@ -5810,6 +5940,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Problem

Desktop installer (`Molio-Setup-0.2.4-windows.exe`) works on machines with Node.js installed, but on machines without Node.js, the daemon service on port 3100 never starts.

**Root cause**: `startDaemonProduction()` used `findSystemNode()` which calls `where.exe node` to find Node.js on the system. If not found, spawn fails silently.

Fixes #21

## Solution

- Replace `findSystemNode()` + `spawn(nodeExe)` with `spawn(process.execPath)` + `ELECTRON_RUN_AS_NODE=1`
- This uses Electron's embedded Node.js to run the daemon — no system Node.js required
- Add `@electron/rebuild` step in `prepare-resources.mjs` to rebuild `better-sqlite3` for Electron's ABI
- Add structural regression tests to prevent reverting

## Changes

| File | Change |
|------|--------|
| `src/main.js` | Remove `findSystemNode()`, use `process.execPath` + `ELECTRON_RUN_AS_NODE` |
| `scripts/prepare-resources.mjs` | Add `rebuildForElectron()` step to rebuild native modules |
| `package.json` | Add `@electron/rebuild` to devDependencies |
| `CLAUDE.md` | Update architecture docs |
| `test/daemon-startup.test.js` | Add regression tests (8 assertions) |