### PR TITLE
refactor(web): unify chat hooks + rename assistant to Molio

### DIFF
--- a/apps/web/src/components/kb/WikiChatPanel.tsx
+++ b/apps/web/src/components/kb/WikiChatPanel.tsx
@@ -1,15 +1,16 @@
 /**
  * Wiki Chat Panel — right-side sliding panel for wiki build/ingest/lint/query conversations.
  *
- * Reuses existing message components (UserMessage, AssistantMessage, ToolCard).
- * Pure presentation — the agent drives all interaction through its own tools.
+ * Reuses existing message components (UserMessage, AssistantMessage)
+ * and ChatComposer for the input area.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useMemo, useCallback } from 'react';
 import type { WikiOperationType } from '@molio/contracts';
 import type { ChatMessage } from '../../hooks/useChat';
 import { UserMessage } from '../UserMessage';
 import { AssistantMessage } from '../AssistantMessage';
+import { ChatComposer } from '../ChatComposer';
 
 const OPERATION_LABELS: Record<WikiOperationType, string> = {
   build: '构建 Wiki',
@@ -48,48 +49,28 @@ export function WikiChatPanel({
 }: WikiChatPanelProps) {
   const logRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
-  const [text, setText] = useState('');
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages.length, messages[messages.length - 1]?.content]);
 
-  // Auto-resize textarea
-  useEffect(() => {
-    const el = textareaRef.current;
-    if (el) {
-      el.style.height = 'auto';
-      el.style.height = Math.min(el.scrollHeight, 120) + 'px';
+  // Find the last assistant message ID so only that card stays interactive
+  const lastAssistantId = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg && msg.role === 'assistant') return msg.id;
     }
-  }, [text]);
+    return null;
+  }, [messages]);
 
-  // Focus textarea when not running
-  useEffect(() => {
-    if (!isRunning) textareaRef.current?.focus();
-  }, [isRunning]);
-
-  const handleSend = () => {
-    const trimmed = text.trim();
-    if (trimmed && !isRunning) {
-      onSend(trimmed);
-      setText('');
-      if (textareaRef.current) textareaRef.current.style.height = 'auto';
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-  };
-
-  const handleAnswerToolUse = async (toolUseId: string, content: string): Promise<boolean> => {
-    onSubmitToolResult(toolUseId, content);
-    return true;
-  };
+  const onAnswerToolUse = useCallback(
+    async (toolUseId: string, content: string) => {
+      onSubmitToolResult(toolUseId, content);
+      return true;
+    },
+    [onSubmitToolResult],
+  );
 
   const label = operationType ? OPERATION_LABELS[operationType] : 'Wiki';
   const color = operationType ? OPERATION_COLORS[operationType] : 'var(--text-muted)';
@@ -120,7 +101,7 @@ export function WikiChatPanel({
           </div>
         ) : (
           <>
-            {messages.map((msg, idx) => {
+            {messages.map((msg) => {
               if (msg.role === 'user') {
                 return <UserMessage key={msg.id} content={msg.content} timestamp={msg.timestamp} />;
               }
@@ -129,8 +110,8 @@ export function WikiChatPanel({
                   <AssistantMessage
                     key={msg.id}
                     message={msg}
-                    isLast={idx === messages.length - 1}
-                    onAnswerToolUse={handleAnswerToolUse}
+                    isLast={msg.id === lastAssistantId}
+                    onAnswerToolUse={onAnswerToolUse}
                     onSubmitForm={onSend}
                   />
                 );
@@ -149,41 +130,13 @@ export function WikiChatPanel({
         )}
       </div>
 
-      {/* Input */}
+      {/* Input — reuse shared ChatComposer */}
       <div className="wiki-chat-input">
-        <div className="wiki-chat-input-shell">
-          <textarea
-            ref={textareaRef}
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={isRunning ? '等待回复…' : '输入消息…'}
-            disabled={isRunning}
-            rows={1}
-          />
-          <div className="wiki-chat-input-actions">
-            {isRunning ? (
-              <button type="button" className="wiki-btn-stop" onClick={onCancel}>
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                  <rect x="4" y="4" width="16" height="16" rx="2" />
-                </svg>
-                停止
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="wiki-btn-send"
-                disabled={!text.trim()}
-                onClick={handleSend}
-              >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="22" y1="2" x2="11" y2="13" />
-                  <polygon points="22 2 15 22 11 13 2 9 22 2" />
-                </svg>
-              </button>
-            )}
-          </div>
-        </div>
+        <ChatComposer
+          isRunning={isRunning}
+          onSend={onSend}
+          onCancel={onCancel}
+        />
       </div>
     </aside>
   );

--- a/apps/web/src/hooks/useChat.ts
+++ b/apps/web/src/hooks/useChat.ts
@@ -1,37 +1,20 @@
-import { useState, useCallback, useRef } from 'react';
-import type { AgentEvent, ChatMessage as ContractsChatMessage } from '@molio/contracts';
+/**
+ * useChat — home page chat hook.
+ *
+ * Wraps useChatCore with:
+ *  - DB persistence (saveMessage)
+ *  - Conversation ID management
+ *  - History loading (loadConversation)
+ *  - api.createRun() as the run creator
+ */
+
+import { useCallback } from 'react';
+import type { ChatMessage as ContractsChatMessage } from '@molio/contracts';
 import { api } from '../api/client';
-import { subscribeToRun } from '../api/sse';
+import { useChatCore } from './useChatCore';
+import type { ChatMessage } from './useChatCore';
 
-export interface ToolEvent {
-  id: string;
-  name: string;
-  input: unknown;
-  result?: string;
-  isError?: boolean;
-  status: 'running' | 'done' | 'error';
-}
-
-export interface ChatMessage {
-  id: string;
-  role: 'user' | 'assistant' | 'error';
-  content: string;
-  timestamp: number;
-  runId?: string;
-  agentId?: string;
-  // Assistant-only fields
-  thinking?: string;
-  tools?: ToolEvent[];
-  streaming?: boolean;
-  usage?: { input?: number; output?: number; cost?: number };
-}
-
-interface ChatState {
-  messages: ChatMessage[];
-  runId: string | null;
-  isRunning: boolean;
-  conversationId: string | null;
-}
+export type { ChatMessage, ToolEvent } from './useChatCore';
 
 interface UseChatOptions {
   agentId: string | null;
@@ -41,9 +24,6 @@ interface UseChatOptions {
   cwd?: string | null;
 }
 
-let msgCounter = 0;
-function nextMsgId() { return `msg-${++msgCounter}-${Date.now()}`; }
-
 export function useChat(options: UseChatOptions | string | null) {
   // Support both old API (useChat(agentId)) and new API (useChat({ agentId, ... }))
   const agentId = typeof options === 'string' || options === null ? options : options.agentId;
@@ -51,204 +31,57 @@ export function useChat(options: UseChatOptions | string | null) {
   const initialConversationId = typeof options === 'object' && options !== null ? options.conversationId : null;
   const cwd = typeof options === 'object' && options !== null ? options.cwd : null;
 
-  const [state, setState] = useState<ChatState>({
-    messages: typeof options === 'object' && options !== null && options.initialMessages
-      ? options.initialMessages
-      : [],
-    runId: null,
-    isRunning: false,
-    conversationId: initialConversationId ?? null,
-  });
-  const esRef = useRef<EventSource | null>(null);
-  const assistantIdRef = useRef<string | null>(null);
+  const core = useChatCore({
+    initialMessages: typeof options === 'object' && options !== null ? options.initialMessages : undefined,
+    initialConversationId: initialConversationId ?? null,
+    createRun: async ({ message, history, conversationId }) => {
+      // Map to contracts ChatMessage type (strips 'error' role)
+      const contractHistory = history
+        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .map((m) => ({
+          id: m.id,
+          role: m.role as 'user' | 'assistant',
+          content: m.content,
+          timestamp: m.timestamp,
+          agentId: m.agentId,
+          runId: m.runId,
+          tools: m.tools,
+          usage: m.usage,
+        }));
 
-  const closeEventSource = useCallback(() => {
-    esRef.current?.close();
-    esRef.current = null;
-  }, []);
-
-  /**
-   * Build history array from current messages for transcript building.
-   */
-  const buildHistory = useCallback((): ContractsChatMessage[] => {
-    return state.messages
-      .filter((m) => m.role === 'user' || m.role === 'assistant')
-      .map((m) => ({
-        id: m.id,
-        role: m.role as 'user' | 'assistant',
-        content: m.content,
-        timestamp: m.timestamp,
-        agentId: m.agentId,
-        runId: m.runId,
-        tools: m.tools,
-        usage: m.usage,
-      }));
-  }, [state.messages]);
-
-  const send = useCallback(async (text: string) => {
-    if (!agentId || !text.trim()) return;
-
-    const userMsg: ChatMessage = {
-      id: nextMsgId(),
-      role: 'user',
-      content: text.trim(),
-      timestamp: Date.now(),
-    };
-
-    const newAssistantId = nextMsgId();
-    assistantIdRef.current = newAssistantId;
-
-    const assistantMsg: ChatMessage = {
-      id: newAssistantId,
-      role: 'assistant',
-      content: '',
-      timestamp: Date.now(),
-      streaming: true,
-      tools: [],
-    };
-
-    setState((prev) => ({
-      ...prev,
-      messages: [...prev.messages, userMsg, assistantMsg],
-      isRunning: true,
-    }));
-
-    // Persist user message to DB if we have project/conversation
-    if (projectId && state.conversationId) {
-      try {
-        await api.saveMessage(projectId, state.conversationId, {
-          ...userMsg,
-          role: 'user',
-        } as ContractsChatMessage);
-      } catch {
-        // Persistence failure is non-fatal
-      }
-    }
-
-    // Check if we can send to an existing run (multi-turn via stdin).
-    // For multi-turn agents (e.g. Claude Code), the process stays alive
-    // between turns, so follow-up messages go to the same stdin.
-    const existingRunId = state.runId;
-
-    if (existingRunId) {
-      try {
-        await api.sendMessage(existingRunId, text.trim());
-        return; // SSE is still active, events route via assistantIdRef
-      } catch {
-        // Multi-turn failed (run ended or stdin closed), fall through to new run
-      }
-    }
-
-    // Build history for transcript (all messages before this turn)
-    const history = buildHistory();
-
-    // Create a new run with conversation history for transcript building
-    closeEventSource();
-
-    try {
       const result = await api.createRun({
-        agentId,
-        message: text.trim(),
-        conversationId: state.conversationId ?? undefined,
-        history: history.length > 0 ? history : undefined,
+        agentId: agentId!,
+        message,
+        conversationId: conversationId ?? undefined,
+        history: contractHistory.length > 0 ? contractHistory : undefined,
         cwd: cwd ?? undefined,
       });
 
-      const runId = result.runId;
-      const convId = result.conversationId ?? state.conversationId;
-
-      setState((prev) => ({ ...prev, runId, conversationId: convId }));
-
-      // Persist assistant placeholder
-      if (projectId && convId) {
+      // Persist user message (best-effort)
+      if (projectId && result.conversationId) {
         try {
-          await api.saveMessage(projectId, convId, {
-            ...assistantMsg,
-            role: 'assistant',
-            runId,
-            agentId,
+          await api.saveMessage(projectId, result.conversationId, {
+            id: `msg-persist-${Date.now()}`,
+            role: 'user',
+            content: message,
+            timestamp: Date.now(),
           } as ContractsChatMessage);
         } catch {
           // Persistence failure is non-fatal
         }
       }
 
-      const es = subscribeToRun(
-        runId,
-        (event: AgentEvent) => {
-          // Read ref at event time, not closure time. This is critical
-          // for multi-turn: when send() is called again, it updates
-          // assistantIdRef before sendMessage(), so subsequent SSE events
-          // route to the new assistant message.
-          const currentId = assistantIdRef.current;
-          if (!currentId) return;
-          setState((prev) => updateWithEvent(prev, currentId, event));
-        },
-        () => { /* SSE error — EventSource auto-retries */ },
-      );
+      return result;
+    },
+  });
 
-      esRef.current = es;
-    } catch (err) {
-      // If run creation fails, mark the assistant message as error
-      const errId = newAssistantId;
-      setState((prev) => {
-        const messages = prev.messages.map((msg) =>
-          msg.id === errId
-            ? { ...msg, content: `Error: ${(err as Error).message}`, streaming: false }
-            : msg
-        );
-        return { ...prev, messages, isRunning: false };
-      });
-    }
-  }, [agentId, state.runId, state.conversationId, projectId, cwd, closeEventSource, buildHistory]);
-
-  const submitToolResult = useCallback(async (toolUseId: string, content: string) => {
-    if (!state.runId) return;
-    await api.submitToolResult(state.runId, { toolUseId, content });
-
-    // Update the tool card status in whichever assistant message owns it
-    setState((prev) => {
-      const messages = prev.messages.map((msg) => {
-        if (msg.tools) {
-          const tools = msg.tools.map((t) =>
-            t.id === toolUseId ? { ...t, result: content, status: 'done' as const } : t
-          );
-          return { ...msg, tools };
-        }
-        return msg;
-      });
-      return { ...prev, messages };
-    });
-  }, [state.runId]);
-
-  const cancel = useCallback(async () => {
-    if (state.runId) {
-      await api.cancelRun(state.runId);
-    }
-    closeEventSource();
-    assistantIdRef.current = null;
-
-    setState((prev) => {
-      const messages = prev.messages.map((msg) =>
-        msg.streaming ? { ...msg, streaming: false } : msg
-      );
-      return { ...prev, messages, isRunning: false, runId: null };
-    });
-  }, [state.runId, closeEventSource]);
-
-  const reset = useCallback(() => {
-    closeEventSource();
-    assistantIdRef.current = null;
-    setState({ messages: [], runId: null, isRunning: false, conversationId: null });
-  }, [closeEventSource]);
-
+  /**
+   * Load a conversation from DB and populate the chat state.
+   */
   const loadConversation = useCallback(async (
     projId: string,
     convId: string,
   ) => {
-    closeEventSource();
-    assistantIdRef.current = null;
-
     try {
       const messages = await api.listMessages(projId, convId);
       const chatMessages: ChatMessage[] = messages.map((m) => ({
@@ -258,134 +91,26 @@ export function useChat(options: UseChatOptions | string | null) {
         timestamp: m.timestamp,
         agentId: m.agentId,
         runId: m.runId,
-        tools: m.tools as ToolEvent[] | undefined,
+        tools: m.tools as ChatMessage['tools'],
         usage: m.usage,
       }));
 
-      setState({
-        messages: chatMessages,
-        runId: null,
-        isRunning: false,
-        conversationId: convId,
-      });
+      core.setMessages(chatMessages, convId);
     } catch (err) {
       console.error('Failed to load conversation:', err);
-      setState({ messages: [], runId: null, isRunning: false, conversationId: convId });
+      core.setMessages([], convId);
     }
-  }, [closeEventSource]);
+  }, [core.setMessages]);
 
   return {
-    ...state,
-    send,
-    submitToolResult,
-    cancel,
-    reset,
+    messages: core.messages,
+    runId: core.runId,
+    isRunning: core.isRunning,
+    conversationId: core.conversationId,
+    send: core.send,
+    submitToolResult: core.submitToolResult,
+    cancel: core.cancel,
+    reset: core.reset,
     loadConversation,
   };
-}
-
-/**
- * Apply an SSE event to the chat state.
- *
- * Key behaviors for multi-turn agents (Claude Code with stream-json stdin):
- *  - The child process stays alive between turns (stdin stays open).
- *  - `turn_end` with stopReason !== 'tool_use' means the agent finished
- *    answering this turn → re-enable input, mark message as done.
- *  - `turn_end` with stopReason === 'tool_use' means the agent paused for
- *    tool execution → keep streaming, keep input locked.
- *  - `usage` always arrives after a turn completes → also re-enables input
- *    (serves as a fallback signal).
- *  - `status: completed/failed` means the child process exited → clear runId.
- *    For multi-turn agents this only happens on cancel.
- */
-function updateWithEvent(
-  prev: ChatState,
-  assistantId: string,
-  event: AgentEvent,
-): ChatState {
-  // Update the target assistant message's content/tools/status.
-  // Guard: if the message already has streaming: false (turn completed),
-  // ignore content-type events to prevent idle chatter from being appended.
-  const messages = prev.messages.map((msg) => {
-    if (msg.id !== assistantId) return msg;
-
-    switch (event.type) {
-      case 'text_delta':
-        // Skip if this message already finished (prevents idle chatter)
-        if (!msg.streaming) return msg;
-        return { ...msg, content: msg.content + event.delta };
-
-      case 'thinking_delta':
-        if (!msg.streaming) return msg;
-        return { ...msg, thinking: (msg.thinking ?? '') + event.delta };
-
-      case 'tool_use':
-        if (!msg.streaming) return msg;
-        return {
-          ...msg,
-          tools: [
-            ...(msg.tools ?? []),
-            { id: event.id, name: event.name, input: event.input, status: 'running' as const },
-          ],
-        };
-
-      case 'tool_result': {
-        const tools = (msg.tools ?? []).map((t) =>
-          t.id === event.toolUseId
-            ? { ...t, result: event.content, isError: event.isError, status: (event.isError ? 'error' : 'done') as ToolEvent['status'] }
-            : t
-        );
-        return { ...msg, tools };
-      }
-
-      case 'usage':
-        return {
-          ...msg,
-          usage: {
-            input: event.usage?.input_tokens,
-            output: event.usage?.output_tokens,
-            cost: event.costUsd,
-          },
-        };
-
-      case 'turn_end':
-        // Only mark as done when the agent actually finished answering.
-        // 'tool_use' means it paused for tool execution, not done yet.
-        if (event.stopReason === 'tool_use') return msg;
-        return { ...msg, streaming: false };
-
-      case 'error':
-        return { ...msg, content: msg.content + `\n\nError: ${event.message}`, streaming: false };
-
-      default:
-        return msg;
-    }
-  });
-
-  // Determine isRunning and runId based on the event.
-  let isRunning = prev.isRunning;
-  let runId = prev.runId;
-
-  // Signal 1: turn_end with non-tool_use stopReason → agent finished this turn
-  if (event.type === 'turn_end' && event.stopReason !== 'tool_use') {
-    isRunning = false;
-  }
-
-  // Signal 2: usage → always emitted after a turn completes (fallback)
-  if (event.type === 'usage') {
-    isRunning = false;
-  }
-
-  // Signal 3: process exited → run is truly over, clear runId.
-  // For multi-turn agents this only fires on cancelRun() or process crash.
-  if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed')) {
-    isRunning = false;
-    runId = null;
-    const finalized = messages.map((msg) =>
-      msg.id === assistantId ? { ...msg, streaming: false } : msg
-    );
-    return { ...prev, messages: finalized, isRunning, runId };
-  }
-
-  return { ...prev, messages, isRunning, runId };
 }

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -1,0 +1,358 @@
+/**
+ * useChatCore — shared chat logic for all chat-based UIs.
+ *
+ * Handles SSE subscription, event processing, message state, multi-turn,
+ * cancel, tool result submission, and reset.
+ *
+ * Callers provide a `createRun` function to decide which API endpoint to call.
+ */
+
+import { useState, useCallback, useRef } from 'react';
+import type { AgentEvent } from '@molio/contracts';
+import { api } from '../api/client';
+import { subscribeToRun } from '../api/sse';
+
+export interface ToolEvent {
+  id: string;
+  name: string;
+  input: unknown;
+  result?: string;
+  isError?: boolean;
+  status: 'running' | 'done' | 'error';
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'error';
+  content: string;
+  timestamp: number;
+  runId?: string;
+  agentId?: string;
+  // Assistant-only fields
+  thinking?: string;
+  tools?: ToolEvent[];
+  streaming?: boolean;
+  usage?: { input?: number; output?: number; cost?: number };
+}
+
+interface ChatState {
+  messages: ChatMessage[];
+  runId: string | null;
+  isRunning: boolean;
+  conversationId: string | null;
+}
+
+export interface RunResult {
+  runId: string;
+  conversationId?: string;
+}
+
+export interface CreateRunContext {
+  message: string;
+  history: ChatMessage[];
+  conversationId: string | null;
+  /** Operation type for wiki operations (build/ingest/lint/query/save). */
+  operationType?: string;
+  /** Extra params (e.g. filePath for ingest). */
+  extra?: Record<string, unknown>;
+}
+
+export interface UseChatCoreOptions {
+  /** Called to create a new run. Implementations decide which API to call. */
+  createRun: (ctx: CreateRunContext) => Promise<RunResult>;
+  /** Initial messages to pre-populate (e.g. from DB). */
+  initialMessages?: ChatMessage[];
+  /** Initial conversation ID. */
+  initialConversationId?: string | null;
+  /** Called when a run completes successfully. */
+  onComplete?: () => void;
+}
+
+let msgCounter = 0;
+function nextMsgId() { return `msg-${++msgCounter}-${Date.now()}`; }
+
+export function useChatCore(options: UseChatCoreOptions) {
+  const { createRun, initialMessages = [], initialConversationId = null, onComplete } = options;
+
+  const [state, setState] = useState<ChatState>({
+    messages: initialMessages,
+    runId: null,
+    isRunning: false,
+    conversationId: initialConversationId,
+  });
+
+  const esRef = useRef<EventSource | null>(null);
+  const assistantIdRef = useRef<string | null>(null);
+
+  const closeEventSource = useCallback(() => {
+    esRef.current?.close();
+    esRef.current = null;
+  }, []);
+
+  /**
+   * Send a message — tries multi-turn on existing run first, falls back to createRun.
+   */
+  const send = useCallback(async (text: string, extra?: { operationType?: string; extra?: Record<string, unknown> }) => {
+    if (!text.trim()) return;
+
+    const userMsg: ChatMessage = {
+      id: nextMsgId(),
+      role: 'user',
+      content: text.trim(),
+      timestamp: Date.now(),
+    };
+
+    const newAssistantId = nextMsgId();
+    assistantIdRef.current = newAssistantId;
+
+    const assistantMsg: ChatMessage = {
+      id: newAssistantId,
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      streaming: true,
+      tools: [],
+    };
+
+    setState((prev) => ({
+      ...prev,
+      messages: [...prev.messages, userMsg, assistantMsg],
+      isRunning: true,
+    }));
+
+    // Try multi-turn on existing run
+    const existingRunId = state.runId;
+    if (existingRunId) {
+      try {
+        await api.sendMessage(existingRunId, text.trim());
+        return; // SSE is still active, events route via assistantIdRef
+      } catch {
+        // Multi-turn failed — fall through to new run
+      }
+    }
+
+    // Build history for transcript
+    const history = state.messages
+      .filter((m) => m.role === 'user' || m.role === 'assistant')
+      .map((m) => ({
+        id: m.id,
+        role: m.role as 'user' | 'assistant',
+        content: m.content,
+        timestamp: m.timestamp,
+        agentId: m.agentId,
+        runId: m.runId,
+        tools: m.tools,
+        usage: m.usage,
+      }));
+
+    closeEventSource();
+
+    try {
+      const result = await createRun({
+        message: text.trim(),
+        history,
+        conversationId: state.conversationId,
+        operationType: extra?.operationType,
+        extra: extra?.extra,
+      });
+
+      const runId = result.runId;
+      const convId = result.conversationId ?? state.conversationId;
+
+      setState((prev) => ({ ...prev, runId, conversationId: convId }));
+
+      const es = subscribeToRun(
+        runId,
+        (event: AgentEvent) => {
+          const currentId = assistantIdRef.current;
+          if (!currentId) return;
+          setState((prev) => updateWithEvent(prev, currentId, event));
+        },
+        () => { /* SSE error — EventSource auto-retries */ },
+      );
+
+      esRef.current = es;
+
+      // Listen for completion to trigger onComplete callback
+      if (onComplete) {
+        const origOnEvent = es.onmessage;
+        es.onmessage = (msg) => {
+          origOnEvent?.call(es, msg);
+          try {
+            const envelope = JSON.parse(msg.data);
+            const ev = envelope.event;
+            if (ev.type === 'status' && ev.label === 'completed') {
+              onComplete();
+            }
+          } catch { /* ignore parse errors */ }
+        };
+      }
+    } catch (err) {
+      const errId = newAssistantId;
+      setState((prev) => {
+        const messages = prev.messages.map((msg) =>
+          msg.id === errId
+            ? { ...msg, content: `Error: ${(err as Error).message}`, streaming: false }
+            : msg
+        );
+        return { ...prev, messages, isRunning: false };
+      });
+    }
+  }, [state.runId, state.conversationId, state.messages, closeEventSource, createRun, onComplete]);
+
+  const submitToolResult = useCallback(async (toolUseId: string, content: string) => {
+    if (!state.runId) return;
+    await api.submitToolResult(state.runId, { toolUseId, content });
+
+    setState((prev) => {
+      const messages = prev.messages.map((msg) => {
+        if (msg.tools) {
+          const tools = msg.tools.map((t) =>
+            t.id === toolUseId ? { ...t, result: content, status: 'done' as const } : t
+          );
+          return { ...msg, tools };
+        }
+        return msg;
+      });
+      return { ...prev, messages };
+    });
+  }, [state.runId]);
+
+  const cancel = useCallback(async () => {
+    if (state.runId) {
+      await api.cancelRun(state.runId);
+    }
+    closeEventSource();
+    assistantIdRef.current = null;
+
+    setState((prev) => {
+      const messages = prev.messages.map((msg) =>
+        msg.streaming ? { ...msg, streaming: false } : msg
+      );
+      return { ...prev, messages, isRunning: false, runId: null };
+    });
+  }, [state.runId, closeEventSource]);
+
+  const reset = useCallback(() => {
+    closeEventSource();
+    assistantIdRef.current = null;
+    setState({ messages: [], runId: null, isRunning: false, conversationId: null });
+  }, [closeEventSource]);
+
+  /**
+   * Replace messages and conversationId (used by loadConversation in useChat).
+   */
+  const setMessages = useCallback((messages: ChatMessage[], conversationId?: string | null) => {
+    closeEventSource();
+    assistantIdRef.current = null;
+    setState({
+      messages,
+      runId: null,
+      isRunning: false,
+      conversationId: conversationId ?? null,
+    });
+  }, [closeEventSource]);
+
+  return {
+    ...state,
+    send,
+    submitToolResult,
+    cancel,
+    reset,
+    setMessages,
+  };
+}
+
+/**
+ * Apply an SSE event to the chat state.
+ *
+ * Key behaviors for multi-turn agents (Claude Code with stream-json stdin):
+ *  - The child process stays alive between turns (stdin stays open).
+ *  - `turn_end` with stopReason !== 'tool_use' means the agent finished
+ *    answering this turn → re-enable input, mark message as done.
+ *  - `turn_end` with stopReason === 'tool_use' means the agent paused for
+ *    tool execution → keep streaming, keep input locked.
+ *  - `usage` always arrives after a turn completes → also re-enables input
+ *    (serves as a fallback signal).
+ *  - `status: completed/failed` means the child process exited → clear runId.
+ */
+function updateWithEvent(
+  prev: ChatState,
+  assistantId: string,
+  event: AgentEvent,
+): ChatState {
+  const messages = prev.messages.map((msg) => {
+    if (msg.id !== assistantId) return msg;
+
+    switch (event.type) {
+      case 'text_delta':
+        if (!msg.streaming) return msg;
+        return { ...msg, content: msg.content + event.delta };
+
+      case 'thinking_delta':
+        if (!msg.streaming) return msg;
+        return { ...msg, thinking: (msg.thinking ?? '') + event.delta };
+
+      case 'tool_use':
+        if (!msg.streaming) return msg;
+        return {
+          ...msg,
+          tools: [
+            ...(msg.tools ?? []),
+            { id: event.id, name: event.name, input: event.input, status: 'running' as const },
+          ],
+        };
+
+      case 'tool_result': {
+        const tools = (msg.tools ?? []).map((t) =>
+          t.id === event.toolUseId
+            ? { ...t, result: event.content, isError: event.isError, status: (event.isError ? 'error' : 'done') as ToolEvent['status'] }
+            : t
+        );
+        return { ...msg, tools };
+      }
+
+      case 'usage':
+        return {
+          ...msg,
+          usage: {
+            input: event.usage?.input_tokens,
+            output: event.usage?.output_tokens,
+            cost: event.costUsd,
+          },
+        };
+
+      case 'turn_end':
+        if (event.stopReason === 'tool_use') return msg;
+        return { ...msg, streaming: false };
+
+      case 'error':
+        return { ...msg, content: msg.content + `\n\nError: ${event.message}`, streaming: false };
+
+      default:
+        return msg;
+    }
+  });
+
+  let isRunning = prev.isRunning;
+  let runId = prev.runId;
+
+  if (event.type === 'turn_end' && event.stopReason !== 'tool_use') {
+    isRunning = false;
+  }
+
+  if (event.type === 'usage') {
+    isRunning = false;
+  }
+
+  if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed')) {
+    isRunning = false;
+    runId = null;
+    const finalized = messages.map((msg) =>
+      msg.id === assistantId ? { ...msg, streaming: false } : msg
+    );
+    return { ...prev, messages: finalized, isRunning, runId };
+  }
+
+  return { ...prev, messages, isRunning, runId };
+}

--- a/apps/web/src/hooks/useWikiChat.ts
+++ b/apps/web/src/hooks/useWikiChat.ts
@@ -1,22 +1,19 @@
 /**
- * Wiki chat hook — manages agent conversation for wiki operations.
+ * useWikiChat — wiki operation hook.
  *
- * Simplified version of useChat: no DB persistence, wiki-specific API calls.
- * Used by the KB page's WikiChatPanel for build/ingest/lint/query operations.
+ * Wraps useChatCore with:
+ *  - Wiki-specific API endpoints (build/ingest/lint/query/save)
+ *  - startOperation() for triggering wiki operations
+ *  - onComplete callback for refreshing the file tree
+ *  - send() defaults to queryWiki for follow-up messages
  */
 
-import { useState, useCallback, useRef } from 'react';
-import type { AgentEvent, WikiOperationType } from '@molio/contracts';
+import { useRef, useCallback } from 'react';
+import type { WikiOperationType } from '@molio/contracts';
 import { api } from '../api/client';
-import { subscribeToRun } from '../api/sse';
-import type { ChatMessage, ToolEvent } from './useChat';
+import { useChatCore } from './useChatCore';
 
-interface WikiChatState {
-  messages: ChatMessage[];
-  runId: string | null;
-  isRunning: boolean;
-  operationType: WikiOperationType | null;
-}
+export type { ChatMessage, ToolEvent } from './useChatCore';
 
 interface UseWikiChatOptions {
   vaultId: string | null;
@@ -25,26 +22,32 @@ interface UseWikiChatOptions {
   onComplete?: () => void;
 }
 
-let msgCounter = 0;
-function nextMsgId() { return `wiki-msg-${++msgCounter}-${Date.now()}`; }
-
 export function useWikiChat(options: UseWikiChatOptions) {
   const { vaultId, agentId, onComplete } = options;
+  const operationTypeRef = useRef<WikiOperationType | null>(null);
 
-  const [state, setState] = useState<WikiChatState>({
-    messages: [],
-    runId: null,
-    isRunning: false,
-    operationType: null,
+  const core = useChatCore({
+    onComplete,
+    createRun: async ({ message, operationType, extra }) => {
+      if (!vaultId || !agentId) throw new Error('No vault or agent selected');
+
+      switch (operationType as WikiOperationType) {
+        case 'build':
+          return api.buildWiki(vaultId, { agentId });
+        case 'ingest':
+          return api.ingestFile(vaultId, { agentId, filePath: (extra?.filePath as string) ?? message });
+        case 'lint':
+          return api.lintWiki(vaultId, { agentId });
+        case 'query':
+          return api.queryWiki(vaultId, { agentId, message });
+        case 'save':
+          return api.saveWiki(vaultId, { agentId, message });
+        default:
+          // Default to query for plain send() calls
+          return api.queryWiki(vaultId, { agentId, message });
+      }
+    },
   });
-
-  const esRef = useRef<EventSource | null>(null);
-  const assistantIdRef = useRef<string | null>(null);
-
-  const closeEventSource = useCallback(() => {
-    esRef.current?.close();
-    esRef.current = null;
-  }, []);
 
   /**
    * Start a wiki operation — creates a run with the appropriate API endpoint.
@@ -54,283 +57,27 @@ export function useWikiChat(options: UseWikiChatOptions) {
     message: string,
     extra?: { filePath?: string },
   ) => {
-    if (!vaultId || !agentId) return;
-
-    const userMsg: ChatMessage = {
-      id: nextMsgId(),
-      role: 'user',
-      content: message,
-      timestamp: Date.now(),
-    };
-
-    const assistantId = nextMsgId();
-    assistantIdRef.current = assistantId;
-
-    const assistantMsg: ChatMessage = {
-      id: assistantId,
-      role: 'assistant',
-      content: '',
-      timestamp: Date.now(),
-      streaming: true,
-      tools: [],
-    };
-
-    setState((prev) => ({
-      messages: [...prev.messages, userMsg, assistantMsg],
-      runId: null,
-      isRunning: true,
+    operationTypeRef.current = type;
+    await core.send(message, {
       operationType: type,
-    }));
-
-    closeEventSource();
-
-    try {
-      let result: { runId: string };
-
-      switch (type) {
-        case 'build':
-          result = await api.buildWiki(vaultId, { agentId });
-          break;
-        case 'ingest':
-          result = await api.ingestFile(vaultId, { agentId, filePath: extra?.filePath ?? message });
-          break;
-        case 'lint':
-          result = await api.lintWiki(vaultId, { agentId });
-          break;
-        case 'query':
-          result = await api.queryWiki(vaultId, { agentId, message });
-          break;
-        case 'save':
-          result = await api.saveWiki(vaultId, { agentId, message });
-          break;
-      }
-
-      const runId = result.runId;
-      setState((prev) => ({ ...prev, runId }));
-
-      const es = subscribeToRun(
-        runId,
-        (event: AgentEvent) => {
-          setState((prev) => updateWithEvent(prev, assistantId, event));
-        },
-        () => { /* SSE error — EventSource auto-retries */ },
-      );
-
-      esRef.current = es;
-
-      // Listen for run completion via events
-      const origOnEvent = es.onmessage;
-      es.onmessage = (msg) => {
-        origOnEvent?.call(es, msg);
-        try {
-          const envelope = JSON.parse(msg.data);
-          const ev = envelope.event;
-          if (ev.type === 'status' && (ev.label === 'completed' || ev.label === 'failed')) {
-            if (ev.label === 'completed') {
-              onComplete?.();
-            }
-          }
-        } catch { /* ignore parse errors */ }
-      };
-    } catch (err) {
-      setState((prev) => {
-        const messages = prev.messages.map((msg) =>
-          msg.id === assistantId
-            ? { ...msg, content: `Error: ${(err as Error).message}`, streaming: false }
-            : msg
-        );
-        return { ...prev, messages, isRunning: false };
-      });
-    }
-  }, [vaultId, agentId, closeEventSource, onComplete]);
-
-  /**
-   * Send a follow-up message to the active run (multi-turn).
-   */
-  const send = useCallback(async (text: string) => {
-    if (!text.trim()) return;
-
-    const userMsg: ChatMessage = {
-      id: nextMsgId(),
-      role: 'user',
-      content: text.trim(),
-      timestamp: Date.now(),
-    };
-
-    const assistantId = nextMsgId();
-    assistantIdRef.current = assistantId;
-
-    const assistantMsg: ChatMessage = {
-      id: assistantId,
-      role: 'assistant',
-      content: '',
-      timestamp: Date.now(),
-      streaming: true,
-      tools: [],
-    };
-
-    setState((prev) => ({
-      ...prev,
-      messages: [...prev.messages, userMsg, assistantMsg],
-      isRunning: true,
-    }));
-
-    // Try multi-turn on existing run
-    if (state.runId) {
-      try {
-        await api.sendMessage(state.runId, text.trim());
-        return;
-      } catch {
-        // Multi-turn failed — fall through to new query run
-      }
-    }
-
-    // Fallback: create a new query run
-    if (!vaultId || !agentId) return;
-
-    closeEventSource();
-
-    try {
-      const result = await api.queryWiki(vaultId, { agentId, message: text.trim() });
-      const runId = result.runId;
-      setState((prev) => ({ ...prev, runId }));
-
-      const es = subscribeToRun(
-        runId,
-        (event: AgentEvent) => {
-          setState((prev) => updateWithEvent(prev, assistantId, event));
-        },
-        () => {},
-      );
-      esRef.current = es;
-    } catch (err) {
-      setState((prev) => {
-        const messages = prev.messages.map((msg) =>
-          msg.id === assistantId
-            ? { ...msg, content: `Error: ${(err as Error).message}`, streaming: false }
-            : msg
-        );
-        return { ...prev, messages, isRunning: false };
-      });
-    }
-  }, [state.runId, vaultId, agentId, closeEventSource]);
-
-  const submitToolResult = useCallback(async (toolUseId: string, content: string) => {
-    if (!state.runId) return;
-    await api.submitToolResult(state.runId, { toolUseId, content });
-
-    setState((prev) => {
-      const messages = prev.messages.map((msg) => {
-        if (msg.tools) {
-          const tools = msg.tools.map((t) =>
-            t.id === toolUseId ? { ...t, result: content, status: 'done' as const } : t
-          );
-          return { ...msg, tools };
-        }
-        return msg;
-      });
-      return { ...prev, messages };
+      extra: extra as Record<string, unknown>,
     });
-  }, [state.runId]);
-
-  const cancel = useCallback(async () => {
-    if (state.runId) {
-      await api.cancelRun(state.runId);
-    }
-    closeEventSource();
-    assistantIdRef.current = null;
-
-    setState((prev) => {
-      const messages = prev.messages.map((msg) =>
-        msg.streaming ? { ...msg, streaming: false } : msg
-      );
-      return { ...prev, messages, isRunning: false, runId: null };
-    });
-  }, [state.runId, closeEventSource]);
+  }, [core.send]);
 
   const reset = useCallback(() => {
-    closeEventSource();
-    assistantIdRef.current = null;
-    setState({ messages: [], runId: null, isRunning: false, operationType: null });
-  }, [closeEventSource]);
+    operationTypeRef.current = null;
+    core.reset();
+  }, [core.reset]);
 
   return {
-    ...state,
+    messages: core.messages,
+    runId: core.runId,
+    isRunning: core.isRunning,
+    operationType: operationTypeRef.current,
     startOperation,
-    send,
-    submitToolResult,
-    cancel,
+    send: core.send,
+    submitToolResult: core.submitToolResult,
+    cancel: core.cancel,
     reset,
   };
-}
-
-/**
- * Update chat state based on SSE event — same logic as useChat's updateWithEvent.
- */
-function updateWithEvent(
-  prev: WikiChatState,
-  assistantId: string,
-  event: AgentEvent,
-): WikiChatState {
-  const messages = prev.messages.map((msg) => {
-    if (msg.id !== assistantId) return msg;
-
-    switch (event.type) {
-      case 'text_delta':
-        return { ...msg, content: msg.content + event.delta };
-
-      case 'thinking_delta':
-        return { ...msg, thinking: (msg.thinking ?? '') + event.delta };
-
-      case 'tool_use':
-        return {
-          ...msg,
-          tools: [
-            ...(msg.tools ?? []),
-            { id: event.id, name: event.name, input: event.input, status: 'running' as const },
-          ],
-        };
-
-      case 'tool_result': {
-        const tools = (msg.tools ?? []).map((t) =>
-          t.id === event.toolUseId
-            ? { ...t, result: event.content, isError: event.isError, status: (event.isError ? 'error' : 'done') as ToolEvent['status'] }
-            : t
-        );
-        return { ...msg, tools };
-      }
-
-      case 'usage':
-        return {
-          ...msg,
-          usage: {
-            input: event.usage?.input_tokens,
-            output: event.usage?.output_tokens,
-            cost: event.costUsd,
-          },
-        };
-
-      case 'turn_end':
-        return { ...msg, streaming: false };
-
-      case 'error':
-        return { ...msg, content: msg.content + `\n\nError: ${event.message}`, streaming: false };
-
-      default:
-        return msg;
-    }
-  });
-
-  let isRunning = prev.isRunning;
-  let runId = prev.runId;
-  if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed')) {
-    isRunning = false;
-    runId = null;
-    const finalized = messages.map((msg) =>
-      msg.id === assistantId ? { ...msg, streaming: false } : msg
-    );
-    return { ...prev, messages: finalized, isRunning, runId };
-  }
-
-  return { ...prev, messages, isRunning, runId };
 }

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -19,7 +19,7 @@ const en: Record<string, string> = {
   'composer.hint': 'Shift+Enter for new line',
 
   // ── AssistantMessage ──
-  'assistant.label': 'Assistant',
+  'assistant.label': 'Molio',
 
   // ── ThinkingBlock ──
   'thinking.title': 'Thinking',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -19,7 +19,7 @@ const zh: Record<string, string> = {
   'composer.hint': 'Shift+Enter 换行',
 
   // ── AssistantMessage ──
-  'assistant.label': 'Assistant',
+  'assistant.label': 'Molio',
 
   // ── ThinkingBlock ──
   'thinking.title': '思考',

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -1680,91 +1680,19 @@
   font-size: 13px;
 }
 
-/* Input area */
+/* Input area — reuses shared ChatComposer */
 .wiki-chat-input {
-  padding: 10px 12px;
   border-top: 1px solid var(--border);
   flex-shrink: 0;
 }
 
-.wiki-chat-input-shell {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  background: var(--bg-subtle, #f5f5f4);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 6px 10px;
-  transition: border-color 120ms ease;
+.wiki-chat-input .composer {
+  border-top: none;
+  padding: 8px 12px;
 }
 
-.wiki-chat-input-shell:focus-within {
-  border-color: var(--accent);
-}
-
-.wiki-chat-input-shell textarea {
-  flex: 1;
-  border: none;
-  background: transparent;
-  font: inherit;
-  font-size: 13px;
-  color: var(--text);
-  resize: none;
-  outline: none;
-  line-height: 1.5;
-  max-height: 120px;
-}
-
-.wiki-chat-input-shell textarea::placeholder {
-  color: var(--text-faint);
-}
-
-.wiki-chat-input-actions {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-}
-
-.wiki-btn-send {
-  width: 28px;
-  height: 28px;
-  border: none;
-  background: var(--accent);
-  color: #fff;
-  border-radius: 6px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 120ms ease;
-}
-
-.wiki-btn-send:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.wiki-btn-send:not(:disabled):hover {
-  background: var(--accent-hover);
-}
-
-.wiki-btn-stop {
-  height: 28px;
-  padding: 0 10px;
-  border: 1px solid var(--red, #dc2626);
-  background: transparent;
-  color: var(--red, #dc2626);
-  border-radius: 6px;
-  font-size: 12px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  transition: all 120ms ease;
-}
-
-.wiki-btn-stop:hover {
-  background: var(--red-bg, #fef2f2);
+.wiki-chat-input .composer-hint {
+  display: none;
 }
 
 /* ══════════ Wiki Tree "+" Button ══════════ */


### PR DESCRIPTION
## 概述

统一首页对话和知识库对话的 chat 逻辑，消除重复代码。

## 改动

### 1. Chat Hook 重构

- **新建 `useChatCore`**：抽取共享核心 — SSE 订阅、事件处理、消息状态管理、multi-turn、cancel、submitToolResult、reset
- **瘦身 `useChat`**（391→104 行）：委托给 core，仅保留 DB 持久化 + loadConversation
- **瘦身 `useWikiChat`**（336→79 行）：委托给 core，仅保留 wiki API 分发 + startOperation

### 2. WikiChatPanel 复用 ChatComposer

- 替换内联 textarea 为共享的 `ChatComposer` 组件
- 清理对应的 wiki 专用 CSS（wiki-btn-send/stop 等死代码）

### 3. 重命名 Assistant 标签

- 对话中 "Assistant" 显示名改为 "Molio"（中英文同步）

## 代码变化

| 文件 | 变化 |
|------|------|
| `hooks/useChatCore.ts` | **新建** — 共享核心 hook |
| `hooks/useChat.ts` | 瘦身，委托给 core |
| `hooks/useWikiChat.ts` | 瘦身，委托给 core |
| `kb/WikiChatPanel.tsx` | 复用 ChatComposer |
| `styles/knowledge.css` | 清理死代码 |
| `i18n/locales/{zh,en}.ts` | label 改名 |

**净减少约 290 行重复代码**（+498 -787）

## 验证

- ✅ `tsc --noEmit` — 零报错
- ✅ `pnpm test` — 61/61 通过
- ✅ Vite 编译成功