### PR TITLE
fix(desktop): add missing workspace dependencies to package.json

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,9 @@
     "test": "node --test \"test/**/*.test.js\""
   },
   "dependencies": {
+    "@molio/contracts": "workspace:*",
+    "@molio/daemon": "workspace:*",
+    "@molio/web": "workspace:*",
     "electron-updater": "^6.8.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,15 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@molio/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
+      '@molio/daemon':
+        specifier: workspace:*
+        version: link:../daemon
+      '@molio/web':
+        specifier: workspace:*
+        version: link:../web
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3


### PR DESCRIPTION
## Problem

`pnpm build` fails with:

```
apps/desktop build$ pnpm --filter @molio/desktop^... build && node scripts/prepare-resources.mjs
[ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT] None of the selected packages has a "build" script
```

## Root Cause

`@molio/desktop`'s build script uses `pnpm --filter @molio/desktop^... build` to build workspace dependencies first, but `@molio/contracts`, `@molio/daemon`, and `@molio/web` were never declared in `package.json`.

The `prepare-resources.mjs` script accessed sibling packages' build artifacts via relative paths (`../daemon/dist/`, `../web/dist/`), bypassing pnpm's dependency resolution entirely.

## Fix

Add the missing workspace dependency declarations:

```json
"dependencies": {
    "@molio/contracts": "workspace:*",
    "@molio/daemon": "workspace:*",
    "@molio/web": "workspace:*",
    "electron-updater": "^6.8.3"
}
```

This lets pnpm resolve the `^...` filter and build packages in the correct topological order: contracts → daemon + web (parallel) → desktop.

## Verification

`pnpm build` now completes successfully for all 4 packages.