### PR TITLE
fix(desktop): move workspace deps to devDependencies

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,12 +20,12 @@
     "test": "node --test \"test/**/*.test.js\""
   },
   "dependencies": {
-    "@molio/contracts": "workspace:*",
-    "@molio/daemon": "workspace:*",
-    "@molio/web": "workspace:*",
     "electron-updater": "^6.8.3"
   },
   "devDependencies": {
+    "@molio/contracts": "workspace:*",
+    "@molio/daemon": "workspace:*",
+    "@molio/web": "workspace:*",
     "electron": "^40.0.0",
     "electron-builder": "^25.1.8",
     "esbuild": "^0.25.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,10 @@ importers:
 
   apps/desktop:
     dependencies:
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
+    devDependencies:
       '@molio/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -51,10 +55,6 @@ importers:
       '@molio/web':
         specifier: workspace:*
         version: link:../web
-      electron-updater:
-        specifier: ^6.8.3
-        version: 6.8.3
-    devDependencies:
       electron:
         specifier: ^40.0.0
         version: 40.10.2


### PR DESCRIPTION
## Problem

Release builds fail on both Windows and macOS:

```
packages/contracts/dist/agent.js must be under apps/desktop/
```

## Root Cause

The previous PR (#27) added workspace dependencies as production `dependencies`, which caused electron-builder to follow pnpm symlinks in `node_modules` and try to pack files from sibling workspace packages (`packages/contracts`, `apps/daemon`, `apps/web`) into the asar — but those files live outside `apps/desktop/`.

## Fix

Move workspace deps to `devDependencies`:

```json
devDependencies: {
    @molio/contracts: workspace:*,
    @molio/daemon: workspace:*,
    @molio/web: workspace:*,
    ...
}
```

This satisfies both requirements:
- **pnpm filter** (`--filter @molio/desktop^...`) still resolves workspace deps for correct build ordering
- **electron-builder** excludes devDependencies from the asar by default, so it won't follow the symlinks

Verified locally with `electron-builder --win --dir` — packaging succeeds.