### PR TITLE
fix(web): sync active vault selection between KB page and home chat

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,7 +11,7 @@ import { UpdateNotification } from './components/UpdateNotification';
 import { LanguageProvider } from './i18n/LanguageProvider';
 import type { Locale } from './i18n';
 import { api } from './api/client';
-import type { Vault } from '@molio/contracts';
+import { useActiveVault, vaultStore } from './stores/vaultStore';
 import './styles/rail.css';
 import './styles/home.css';
 import './styles/knowledge.css';
@@ -23,7 +23,7 @@ export default function App() {
   const { agents } = useAgents();
   const [defaultAgentId, setDefaultAgentId] = useState<string | null>(null);
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
-  const [activeVault, setActiveVault] = useState<Vault | null>(null);
+  const activeVault = useActiveVault();
   const [locale, setLocale] = useState<Locale>('zh');
   const [configLoaded, setConfigLoaded] = useState(false);
   const chat = useChat({ agentId: selectedAgent, cwd: activeVault?.path });
@@ -73,11 +73,12 @@ export default function App() {
     }
   }, [agents, defaultAgentId, selectedAgent]);
 
-  // Load first vault as default cwd for agent runs
+  // Load vaults into the shared store on mount (so chat cwd is set even
+  // when the KB page has never been visited).
   useEffect(() => {
-    api.listVaults().then((vaults) => {
-      if (vaults.length > 0) setActiveVault(vaults[0]!);
-    }).catch(() => {});
+    api.listVaults()
+      .then((list) => vaultStore.setVaults(list))
+      .catch(() => {});
   }, []);
 
   const handleNewChat = () => {

--- a/apps/web/src/hooks/useKnowledge.ts
+++ b/apps/web/src/hooks/useKnowledge.ts
@@ -9,6 +9,7 @@ import { api } from '../api/client';
 import type { ThemeConfig } from '../components/kb/MdStylePanel';
 import { defaultThemeConfig } from '../components/kb/MdStylePanel';
 import { copyHtml } from '@molio/doocs-md/shared/utils/clipboard';
+import { vaultStore, useActiveVaultId } from '../stores/vaultStore';
 
 export type KbTab = 'preview'; // Simplified - only preview tab now
 
@@ -67,7 +68,8 @@ interface UseKnowledgeReturn {
 
 export function useKnowledge(): UseKnowledgeReturn {
   const [vaults, setVaults] = useState<Vault[]>([]);
-  const [activeVaultId, setActiveVaultId] = useState<string | null>(null);
+  // Read active vault ID from the shared store so App.tsx stays in sync.
+  const activeVaultId = useActiveVaultId();
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [fileContent, setFileContent] = useState<FileContent | null>(null);
@@ -100,9 +102,7 @@ export function useKnowledge(): UseKnowledgeReturn {
         const list = await api.listVaults();
         if (cancelled) return;
         setVaults(list);
-        if (list.length > 0 && !activeVaultId && list[0]) {
-          setActiveVaultId(list[0].id);
-        }
+        vaultStore.setVaults(list); // shared store handles auto-selection
       } catch {
         // No vaults yet — fine
       }
@@ -209,14 +209,18 @@ export function useKnowledge(): UseKnowledgeReturn {
   const activeVault = vaults.find((v) => v.id === activeVaultId) ?? null;
 
   const selectVault = useCallback((id: string) => {
-    setActiveVaultId(id);
+    vaultStore.setActiveVaultId(id);
     setShowVaultSwitcher(false);
   }, []);
 
   const createVault = useCallback(async (name: string, path: string, description?: string) => {
     const vault = await api.createVault({ name, path, description });
-    setVaults((prev) => [vault, ...prev]);
-    setActiveVaultId(vault.id);
+    setVaults((prev) => {
+      const next = [vault, ...prev];
+      vaultStore.setVaults(next);
+      return next;
+    });
+    vaultStore.setActiveVaultId(vault.id);
     setShowAddVault(false);
   }, []);
 
@@ -224,15 +228,23 @@ export function useKnowledge(): UseKnowledgeReturn {
     // Derive a name from the last path segment
     const name = path.split(/[\/]/).pop() || '未命名仓库';
     const vault = await api.createVault({ name, path, description: `从本地文件夹打开: ${path}` });
-    setVaults((prev) => [vault, ...prev]);
-    setActiveVaultId(vault.id);
+    setVaults((prev) => {
+      const next = [vault, ...prev];
+      vaultStore.setVaults(next);
+      return next;
+    });
+    vaultStore.setActiveVaultId(vault.id);
   }, []);
 
   const deleteVault = useCallback(async (id: string) => {
     await api.deleteVault(id);
-    setVaults((prev) => prev.filter((v) => v.id !== id));
+    setVaults((prev) => {
+      const next = prev.filter((v) => v.id !== id);
+      vaultStore.setVaults(next);
+      return next;
+    });
     if (activeVaultId === id) {
-      setActiveVaultId(null);
+      vaultStore.setActiveVaultId(null);
       setTree([]);
       setSelectedFile(null);
       setFileContent(null);

--- a/apps/web/src/stores/vaultStore.ts
+++ b/apps/web/src/stores/vaultStore.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared vault store — single source of truth for active vault selection.
+ *
+ * Uses React 18's useSyncExternalStore for tear-safe external store access.
+ * Both App.tsx (chat cwd) and useKnowledge (KB page) read/write the same state.
+ */
+
+import { useSyncExternalStore } from 'react';
+import type { Vault } from '@molio/contracts';
+
+type Listener = () => void;
+
+let activeVaultId: string | null = null;
+let vaults: Vault[] = [];
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export const vaultStore = {
+  subscribe(cb: Listener) {
+    listeners.add(cb);
+    return () => { listeners.delete(cb); };
+  },
+
+  getActiveVaultId() { return activeVaultId; },
+
+  getVaults() { return vaults; },
+
+  getActiveVault(): Vault | null {
+    return vaults.find((v) => v.id === activeVaultId) ?? null;
+  },
+
+  setActiveVaultId(id: string | null) {
+    if (activeVaultId !== id) {
+      activeVaultId = id;
+      emit();
+    }
+  },
+
+  setVaults(list: Vault[]) {
+    vaults = list;
+    // Auto-select first vault if nothing is selected yet
+    if (!activeVaultId && list.length > 0 && list[0]) {
+      activeVaultId = list[0].id;
+    }
+    emit();
+  },
+};
+
+/** Subscribe to the active vault (re-renders when it changes). */
+export function useActiveVault(): Vault | null {
+  return useSyncExternalStore(
+    vaultStore.subscribe,
+    vaultStore.getActiveVault,
+    vaultStore.getActiveVault,
+  );
+}
+
+/** Subscribe to the active vault ID only. */
+export function useActiveVaultId(): string | null {
+  return useSyncExternalStore(
+    vaultStore.subscribe,
+    vaultStore.getActiveVaultId,
+    vaultStore.getActiveVaultId,
+  );
+}


### PR DESCRIPTION
## Summary

- 修复知识库切换后首页问答仍使用旧知识库的问题
- 修复重新进入知识库页面时 vault 选择被重置为第一个的问题

### 根因

`App.tsx` 和 `useKnowledge` hook 各自维护独立的 `activeVault` 状态，互不通信：
- KB 页面切换 vault 只更新 `useKnowledge` 的内部状态，`App.tsx` 的 `activeVault` 不变 → chat `cwd` 发送错误的值
- 每次进入 KB 页面 `useKnowledge` 重新 mount，本地 state 从 0 开始，自动选 `list[0]`

### 修复

新增 `vaultStore`（基于 `useSyncExternalStore`）作为 active vault 选择的唯一数据源：
- `App.tsx` 通过 `useActiveVault()` 订阅 store，chat 的 `cwd` 始终跟随最新选择
- `useKnowledge` 通过 `useActiveVaultId()` 读取 store，所有 vault 操作（select/create/open/delete）同步回 store
- store 的 `setVaults` 仅在 `!activeVaultId` 时 auto-select，避免重置已有选择

## Test plan

- [ ] 启动 `pnpm dev`，验证首页问答使用正确的知识库
- [ ] 在知识库页面切换 vault → 返回首页 → 确认问答使用了新的知识库
- [ ] 未选择库时新建/打开知识库 → 返回首页 → 确认问答使用了新库
- [ ] 切换 vault → 重新进入知识库页面 → 确认 vault 选择不被重置
- [ ] `pnpm typecheck` 通过
- [ ] `pnpm test` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)