### PR TITLE
fix(desktop): remove workspace deps from dependencies to fix electron…

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,9 +20,6 @@
     "test": "node --test \"test/**/*.test.js\""
   },
   "dependencies": {
-    "@molio/contracts": "workspace:*",
-    "@molio/daemon": "workspace:*",
-    "@molio/web": "workspace:*",
     "electron-updater": "^6.8.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,10 @@ importers:
 
   apps/desktop:
     dependencies:
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
+    devDependencies:
       '@molio/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -51,10 +55,6 @@ importers:
       '@molio/web':
         specifier: workspace:*
         version: link:../web
-      electron-updater:
-        specifier: ^6.8.3
-        version: 6.8.3
-    devDependencies:
       electron:
         specifier: ^40.0.0
         version: 40.10.2


### PR DESCRIPTION
…-builder

electron-builder tries to include @molio/contracts, @molio/daemon, and @molio/web in the asar archive because they are listed as runtime dependencies. These packages live outside apps/desktop/ causing:
  'packages/contracts/dist/agent.js must be under apps/desktop/'

These workspace packages are only needed at build time (prepare-resources.mjs bundles daemon via esbuild, copies web dist to resources/). The Electron main process does not import them directly. Move them to devDependencies only.