### PR TITLE
fix(kb): persist vault selection and default tree to collapsed

### DIFF
--- a/apps/web/src/components/kb/KbFileTree.tsx
+++ b/apps/web/src/components/kb/KbFileTree.tsx
@@ -53,7 +53,8 @@ interface TreeNodeItemProps {
 }
 
 function TreeNodeItem({ node, selectedFile, searchQuery, onSelectFile, onAddToWiki }: TreeNodeItemProps) {
-  const [expanded, setExpanded] = useState(true);
+  // Default collapsed; auto-expand when searching so results are visible
+  const [expanded, setExpanded] = useState(!!searchQuery);
 
   const toggle = useCallback(() => setExpanded((e) => !e), []);
 

--- a/apps/web/src/stores/vaultStore.ts
+++ b/apps/web/src/stores/vaultStore.ts
@@ -10,7 +10,29 @@ import type { Vault } from '@molio/contracts';
 
 type Listener = () => void;
 
-let activeVaultId: string | null = null;
+const STORAGE_KEY = 'molio.activeVaultId';
+
+/** Read persisted vault ID from localStorage (returns null on error). */
+function readPersistedVaultId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist vault ID to localStorage. */
+function persistVaultId(id: string | null) {
+  try {
+    if (id) {
+      localStorage.setItem(STORAGE_KEY, id);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch { /* storage unavailable */ }
+}
+
+let activeVaultId: string | null = readPersistedVaultId();
 let vaults: Vault[] = [];
 const listeners = new Set<Listener>();
 
@@ -35,15 +57,23 @@ export const vaultStore = {
   setActiveVaultId(id: string | null) {
     if (activeVaultId !== id) {
       activeVaultId = id;
+      persistVaultId(id);
       emit();
     }
   },
 
   setVaults(list: Vault[]) {
     vaults = list;
-    // Auto-select first vault if nothing is selected yet
+    // If persisted vault is still in the list, keep it
+    if (activeVaultId && !list.some((v) => v.id === activeVaultId)) {
+      // Persisted vault no longer exists — clear and fall through to auto-select
+      activeVaultId = null;
+      persistVaultId(null);
+    }
+    // Auto-select first vault only if nothing is selected
     if (!activeVaultId && list.length > 0 && list[0]) {
       activeVaultId = list[0].id;
+      persistVaultId(activeVaultId);
     }
     emit();
   },


### PR DESCRIPTION
## 问题

1. **Vault 选择不持久**：关闭应用后重新打开知识库，总是显示最新创建的 vault，而不是用户上次选择的
2. **目录树默认全部展开**：文件多时视觉混乱，不方便浏览

## 修复

### Vault 选择持久化（vaultStore.ts）
- 用 `localStorage` 存储 `activeVaultId`
- 初始化时读取上次的选择
- 切换 vault 时自动写入
- 如果持久化的 vault 已被删除，自动清除并 fallback 到第一个

### 目录树默认折叠（KbFileTree.tsx）
- `useState(true)` → `useState(false)`，目录默认折叠
- 搜索时自动展开（`!!searchQuery`），确保搜索结果可见