### PR TITLE
fix(web): handle stale vault ID on graph page to prevent 404 error

### DIFF
--- a/apps/web/src/components/graph/GraphPage.tsx
+++ b/apps/web/src/components/graph/GraphPage.tsx
@@ -14,7 +14,7 @@ import { NodeCircleProgram } from 'sigma/rendering';
 import { api } from '../../api/client';
 import { useI18n } from '../../i18n';
 import { Minimap } from './Minimap';
-import { useActiveVaultId } from '../../stores/vaultStore';
+import { useActiveVaultId, vaultStore } from '../../stores/vaultStore';
 
 // ── Types ──
 
@@ -102,7 +102,15 @@ export function GraphPage() {
         setGraphData(data);
       })
       .catch((err) => {
-        setError(err.message ?? 'Failed to load graph');
+        if (err.message?.includes('404')) {
+          // Vault no longer exists in DB — clear stale selection.
+          // App.tsx's setVaults() will auto-select a valid vault,
+          // and this useEffect will re-fire with the new activeVaultId.
+          vaultStore.setActiveVaultId(null);
+          setError(null);
+        } else {
+          setError(err.message ?? 'Failed to load graph');
+        }
         setGraphData(null);
       })
       .finally(() => setLoading(false));


### PR DESCRIPTION
## Problem

打开图谱页面时报错 `Failed to fetch graph: 404`。

**根因**：浏览器 localStorage 中缓存的 `activeVaultId` 在 daemon SQLite 数据库中已不存在（数据库被重置或 vault 被删除），导致 `/api/graph/:vaultId` 返回 404。

**时序问题**：`GraphPage` 在 mount 时立即用 stale ID 发请求，而 `App.tsx` 异步加载 vaults 列表后的 `setVaults()` 虽然会清除无效 ID，但此时 GraphPage 已经报错，且清除后只显示空状态不会自动重试。

## Fix

- 当 `getGraph` 返回 404 时，调用 `vaultStore.setActiveVaultId(null)` 清除 stale ID
- 不显示错误消息，等待 `App.tsx` 的 `setVaults()` 自动选择有效 vault
- `useActiveVaultId()` 通过 `useSyncExternalStore` 响应变化，useEffect 自动重新获取图谱

## Testing

1. 手动设置 localStorage 中的 `molio.activeVaultId` 为不存在的 UUID
2. 刷新并导航到图谱页
3. 预期：短暂空白后自动选中第一个可用 vault 并加载图谱，无 404 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)