### PR TITLE
chore: E2E test improvements and data-view selectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,84 @@ pnpm package:dir    # 仅生成未打包目录 (不生成安装包)
 
 **核心原则**：WebUI first，Electron 只是壳。E2E 直接测 web 层。
 
-- 使用 kimi-webbridge 或 Playwright 对 `http://localhost:5173` 进行浏览器自动化测试
+- 使用 Playwright 对 `http://localhost:5173` 进行浏览器自动化测试
 - 测试 UI 交互行为（选择 agent → 发送消息 → 查看 SSE 事件流 → 提交 tool result）
 - Electron 壳后期只需测试窗口管理和系统集成
+
+#### 前置条件
+
+E2E 测试需要 daemon 和 web 同时运行：
+
+```bash
+pnpm dev   # 启动 daemon(:3100) + web(:5173)，保持运行
+```
+
+#### 常用命令（在 `apps/web/` 目录执行）
+
+```bash
+# 跑所有 E2E
+npx playwright test
+
+# 只跑某个文件
+npx playwright test e2e/create-vault-form.spec.ts
+
+# 只跑名称匹配的用例
+npx playwright test -g "browse button"
+
+# 交互式 UI 模式（推荐开发时用，左侧选用例，右侧看 DOM 快照和截图）
+npx playwright test --ui
+
+# 调试模式（弹出浏览器 + 断点）
+npx playwright test --debug
+
+# 有头模式（显示浏览器窗口）
+npx playwright test --headed
+```
+
+#### 编写规范
+
+- **定位策略**：优先用 `data-testid`，其次 CSS class，不依赖文本内容（避免中英文切换问题）
+- **测试文件位置**：`apps/web/e2e/*.spec.ts`
+- **baseURL**：已在 `playwright.config.ts` 配置为 `http://localhost:5173`，`page.goto('/')` 即可
+- **清理状态**：测试结尾主动清理创建的数据（如 `fetch(..., { method: 'DELETE' })`），避免残留影响后续测试
+- **等待策略**：用 `waitForEvent`/`waitForRequest` 等 Playwright 内置等待，避免硬编码 `waitForTimeout`（仅用于 UI 动画过渡）
+
+#### UI 改动与测试同步（强制规则）
+
+E2E 测试绑定 DOM 结构，**界面调整必须同步修改对应测试**，两者放在同一个 commit 提交，禁止中间断档。
+
+**影响判断表**：
+
+| UI 改动类型 | 是否影响测试 |
+|---|---|
+| 改 CSS class 名 | ✅ 必须改测试中对应的 locator |
+| 改组件层级/结构 | ✅ 影响 `.nth()`、`.first()` 等索引定位 |
+| 删除/重命名一个功能 | ✅ 对应测试要删或重写 |
+| 改按钮文案（不影响逻辑） | ❌ 用 class/testid 定位则不影响 |
+| 纯样式调整（颜色、间距） | ❌ 不影响 |
+| 新增 UI 元素 | ❌ 旧测试不受影响，但应补新测试 |
+
+**减少维护成本的做法**：给关键交互元素加 `data-testid`，比依赖 CSS class 更稳定：
+
+```tsx
+// 组件里
+<button data-testid="create-vault-btn" className={styles.submit}>创建</button>
+
+// 测试里 — class 怎么改都不影响
+page.locator('[data-testid="create-vault-btn"]')
+```
+
+**开发习惯**：改完 UI 顺手跑 `npx playwright test --ui`，有红的同步修 locator，全绿再提交。
+
+#### 典型开发流程
+
+```
+写 spec（用 --ui 模式逐步验证定位器）
+→ 确认测试失败（红）
+→ 改代码
+→ 重跑确认通过（绿）
+→ 提交
+```
 
 ## External Dependencies (Planned Integration)
 

--- a/apps/web/e2e/create-vault-form.spec.ts
+++ b/apps/web/e2e/create-vault-form.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the Create Vault form.
+ *
+ * Regression: the "浏览" (Browse) button had no onClick handler, so clicking
+ * it did nothing. The "创建" (Create) button stayed disabled because users
+ * couldn't fill the path field without a working directory picker.
+ *
+ * In browser mode (no Electron), the Browse button must be hidden and users
+ * must type the path manually. In Electron mode, Browse must open a native
+ * directory picker dialog.
+ *
+ * Prerequisites: `pnpm dev` running (daemon :3100, web :5173)
+ */
+
+const DAEMON_API = 'http://localhost:3100/api';
+
+async function navigateToCreateForm(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  // Navigate to knowledge base view (left nav rail)
+  const kbNav = page.locator('[data-view="knowledge"]');
+  await kbNav.click();
+  await page.waitForTimeout(500);
+
+  // Open the vault manager modal by clicking the vault bar in the file panel
+  const vaultBar = page.locator('.kb-vault-bar').first();
+  await vaultBar.click({ timeout: 5_000 });
+  await page.waitForTimeout(300);
+
+  // Click the "创建" action button in the VaultActionPanel to open the create form
+  const createAction = page.locator('.vm-action-btn-primary').filter({ hasText: '创建' });
+  await createAction.click({ timeout: 5_000 });
+  await page.waitForTimeout(300);
+
+  // Verify the create form is visible
+  await expect(page.locator('.vm-create-form')).toBeVisible();
+}
+
+test.describe('Create vault form', () => {
+  test('browse button should always be visible; shows alert in browser mode', async ({ page }) => {
+    await navigateToCreateForm(page);
+
+    // Browse button must always be visible (even without Electron)
+    const browseBtn = page.locator('.vm-browse-btn');
+    await expect(browseBtn).toBeVisible();
+
+    // In browser mode (no Electron), clicking Browse shows an informational alert.
+    // Use page.on('dialog') instead of waitForEvent to avoid a race condition
+    // where alert() blocks the page and prevents click() from returning.
+    const dialogPromise = new Promise<string>((resolve) => {
+      const handler = (dialog: import('@playwright/test').Dialog) => {
+        resolve(dialog.message());
+        dialog.accept();
+        page.off('dialog', handler);
+      };
+      page.on('dialog', handler);
+    });
+
+    await browseBtn.click();
+
+    const message = await dialogPromise;
+    expect(message).toContain('桌面客户端');
+  });
+
+  test('create button should be disabled when path is empty, enabled when path is filled', async ({ page }) => {
+    await navigateToCreateForm(page);
+
+    const submitBtn = page.locator('.vm-submit-btn').filter({ hasText: /创建/ });
+    await expect(submitBtn).toBeVisible();
+
+    // Path empty → disabled (regardless of name)
+    await expect(submitBtn).toBeDisabled();
+
+    const nameInput = page.locator('.vm-form-input').first();
+    await nameInput.fill('test-vault');
+    await expect(submitBtn).toBeDisabled(); // still disabled without path
+
+    // Path filled, name empty → enabled (name auto-derives from path)
+    await nameInput.fill('');
+    const pathInput = page.locator('.vm-form-input').nth(1);
+    await pathInput.fill('/tmp/test-vault');
+    await expect(submitBtn).toBeEnabled();
+  });
+
+  test('create button should be enabled when both name and path are filled', async ({ page }) => {
+    await navigateToCreateForm(page);
+
+    const nameInput = page.locator('.vm-form-input').first();
+    const pathInput = page.locator('.vm-form-input').nth(1);
+    const submitBtn = page.locator('.vm-submit-btn').filter({ hasText: /创建/ });
+
+    await nameInput.fill('e2e-test-vault');
+    await pathInput.fill('/tmp/e2e-test-vault-nonexistent');
+
+    await expect(submitBtn).toBeEnabled();
+  });
+
+  test('creating with empty name should derive name from path', async ({ page }) => {
+    const testVaultPath = `/tmp/e2e-derive-name-${Date.now()}`;
+
+    await navigateToCreateForm(page);
+
+    const pathInput = page.locator('.vm-form-input').nth(1);
+    const submitBtn = page.locator('.vm-submit-btn').filter({ hasText: /创建/ });
+
+    // Leave name empty, only fill path
+    await pathInput.fill(testVaultPath);
+    await expect(submitBtn).toBeEnabled();
+
+    const apiRequest = page.waitForRequest(
+      (req) => req.url().includes('/knowledge/vaults') && req.method() === 'POST',
+      { timeout: 10_000 },
+    );
+
+    await submitBtn.click();
+
+    const req = await apiRequest;
+    const body = req.postDataJSON();
+    // Name should be auto-derived from the last path segment
+    const expectedName = testVaultPath.split('/').pop();
+    expect(body.name).toBe(expectedName);
+    expect(body.path).toBe(testVaultPath);
+
+    // Cleanup
+    const listRes = await fetch(`${DAEMON_API}/knowledge/vaults`);
+    const { vaults } = await listRes.json();
+    const created = vaults.find((v: { path: string }) => v.path === testVaultPath);
+    if (created) {
+      await fetch(`${DAEMON_API}/knowledge/vaults/${created.id}`, { method: 'DELETE' });
+    }
+  });
+
+  test('submitting the form should call the daemon API and create a vault', async ({ page }) => {
+    const testVaultName = 'e2e-create-test-' + Date.now();
+    const testVaultPath = `/tmp/${testVaultName}`;
+
+    await navigateToCreateForm(page);
+
+    const nameInput = page.locator('.vm-form-input').first();
+    const pathInput = page.locator('.vm-form-input').nth(1);
+    const submitBtn = page.locator('.vm-submit-btn').filter({ hasText: /创建/ });
+
+    await nameInput.fill(testVaultName);
+    await pathInput.fill(testVaultPath);
+    await expect(submitBtn).toBeEnabled();
+
+    // Listen for the API request
+    const apiRequest = page.waitForRequest(
+      (req) => req.url().includes('/knowledge/vaults') && req.method() === 'POST',
+      { timeout: 10_000 },
+    );
+
+    await submitBtn.click();
+
+    // Verify the API was called
+    const req = await apiRequest;
+    const body = req.postDataJSON();
+    expect(body.name).toBe(testVaultName);
+    expect(body.path).toBe(testVaultPath);
+
+    // Wait for the form to disappear (view switches back to list)
+    await expect(page.locator('.vm-create-form')).toBeHidden({ timeout: 10_000 });
+
+    // Cleanup: delete the vault we just created
+    const listRes = await fetch(`${DAEMON_API}/knowledge/vaults`);
+    const { vaults } = await listRes.json();
+    const created = vaults.find((v: { name: string }) => v.name === testVaultName);
+    if (created) {
+      await fetch(`${DAEMON_API}/knowledge/vaults/${created.id}`, { method: 'DELETE' });
+    }
+  });
+
+  test('Enter key should submit when both fields are filled', async ({ page }) => {
+    const testVaultName = 'e2e-enter-test-' + Date.now();
+    const testVaultPath = `/tmp/${testVaultName}`;
+
+    await navigateToCreateForm(page);
+
+    const nameInput = page.locator('.vm-form-input').first();
+    const pathInput = page.locator('.vm-form-input').nth(1);
+
+    await nameInput.fill(testVaultName);
+    await pathInput.fill(testVaultPath);
+
+    // Listen for the API call
+    const apiRequest = page.waitForRequest(
+      (req) => req.url().includes('/knowledge/vaults') && req.method() === 'POST',
+      { timeout: 10_000 },
+    );
+
+    // Press Enter on the path input
+    await pathInput.press('Enter');
+
+    // Verify the API was called
+    const req = await apiRequest;
+    const body = req.postDataJSON();
+    expect(body.name).toBe(testVaultName);
+
+    // Cleanup
+    const listRes = await fetch(`${DAEMON_API}/knowledge/vaults`);
+    const { vaults } = await listRes.json();
+    const created = vaults.find((v: { name: string }) => v.name === testVaultName);
+    if (created) {
+      await fetch(`${DAEMON_API}/knowledge/vaults/${created.id}`, { method: 'DELETE' });
+    }
+  });
+});

--- a/apps/web/e2e/publish-flow.spec.ts
+++ b/apps/web/e2e/publish-flow.spec.ts
@@ -55,7 +55,7 @@ async function navigateToTestFile(page: any) {
   await page.waitForLoadState('networkidle');
 
   // Navigate to knowledge base view
-  await page.locator('[data-tooltip="Knowledge Base"]').click();
+  await page.locator('[data-view="knowledge"]').first().click();
   await page.waitForTimeout(500);
 
   // Open vault switcher

--- a/apps/web/e2e/publish-flow.spec.ts
+++ b/apps/web/e2e/publish-flow.spec.ts
@@ -48,7 +48,7 @@ test.afterAll(async () => {
 });
 
 /**
- * Helper: navigate to knowledge base and select the test vault + first file.
+ * Helper: navigate to knowledge base, select the test vault, and open a file.
  */
 async function navigateToTestFile(page: any) {
   await page.goto('/');

--- a/apps/web/src/components/NavRail.tsx
+++ b/apps/web/src/components/NavRail.tsx
@@ -11,6 +11,7 @@ export function NavRail() {
         <NavLink
           to="/"
           end
+          data-view="home"
           className={({ isActive }) =>
             `entry-nav-rail__btn ${isActive ? 'is-active' : ''}`
           }
@@ -32,6 +33,7 @@ export function NavRail() {
         {/* Knowledge Base */}
         <NavLink
           to="/knowledge"
+          data-view="knowledge"
           className={({ isActive }) =>
             `entry-nav-rail__btn ${isActive ? 'is-active' : ''}`
           }
@@ -80,6 +82,7 @@ export function NavRail() {
         {/* Runtimes */}
         <NavLink
           to="/runtimes"
+          data-view="runtimes"
           className={({ isActive }) =>
             `entry-nav-rail__btn ${isActive ? 'is-active' : ''}`
           }
@@ -103,6 +106,7 @@ export function NavRail() {
       <div className="entry-nav-rail__group">
         <NavLink
           to="/settings"
+          data-view="settings"
           className={({ isActive }) =>
             `entry-nav-rail__btn ${isActive ? 'is-active' : ''}`
           }


### PR DESCRIPTION
## Summary

- Add `data-view` attributes to NavRail for stable E2E selectors
- Fix publish-flow E2E: `navigateToTestFile` helper with vault switching
- Add create-vault-form E2E test with dialog race condition fix
- Expand E2E testing guide in CLAUDE.md

## Test plan

- [ ] `pnpm dev` then `npx playwright test` in `apps/web/`
- [ ] Verify all E2E specs pass (publish-flow, create-vault-form)