### PR TITLE
feat(daemon): fix Gemini CLI runtime integration

### DIFF
--- a/apps/daemon/src/core/runtimes/env.ts
+++ b/apps/daemon/src/core/runtimes/env.ts
@@ -1,13 +1,53 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as os from 'node:os';
 import type { RuntimeAgentDef } from '@molio/contracts';
+
+/**
+ * Load a `.env` file and return key-value pairs.
+ * Minimal parser — handles `KEY=VALUE` lines, ignores comments and blanks.
+ */
+function loadDotEnv(filePath: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    for (const raw of content.split('\n')) {
+      const line = raw.trim();
+      if (!line || line.startsWith('#')) continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let value = line.slice(eq + 1).trim();
+      // Strip surrounding quotes
+      if ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      result[key] = value;
+    }
+  } catch {
+    // File doesn't exist or unreadable — that's fine
+  }
+  return result;
+}
+
+/**
+ * Resolve the config directory for an agent and load its `.env` file.
+ * Convention: ~/.{agentId}/.env  (e.g. ~/.gemini/.env)
+ */
+function loadAgentDotEnv(agentId: string): Record<string, string> {
+  const configDir = path.join(os.homedir(), `.${agentId}`);
+  return loadDotEnv(path.join(configDir, '.env'));
+}
 
 export function buildSpawnEnv(
   def: RuntimeAgentDef,
   baseEnv?: Record<string, string>,
 ): NodeJS.ProcessEnv {
+  // Priority: daemon config > parent process env > agent .env file
+  const agentDotEnv = loadAgentDotEnv(def.id);
   const source = baseEnv ?? (process.env as Record<string, string>);
-  const env: NodeJS.ProcessEnv = { ...source, ...(def.env ?? {}) };
+  const env: NodeJS.ProcessEnv = { ...agentDotEnv, ...source, ...(def.env ?? {}) };
 
   // Inject Molio runtime identity so the agent CLI knows which runtime
   // it is running as (e.g. when the user asks "which runtime is this?").

--- a/apps/daemon/src/core/runtimes/gemini.ts
+++ b/apps/daemon/src/core/runtimes/gemini.ts
@@ -13,7 +13,12 @@ export const geminiAgentDef: RuntimeAgentDef = {
   ],
 
   buildArgs: (_prompt, options = {}) => {
-    const args: string[] = [];
+    const args: string[] = [
+      '-p', '.', // headless (non-interactive) mode; actual prompt arrives via stdin
+      '--output-format', 'stream-json', // JSONL events on stdout
+      '--yolo', // auto-approve all tool calls (daemon has no human in the loop)
+      '--skip-trust', // bypass workspace trust check (headless/automated environment)
+    ];
     if (options.model && options.model !== 'default') {
       args.push('--model', options.model);
     }

--- a/apps/daemon/src/core/streams/json-event-stream.ts
+++ b/apps/daemon/src/core/streams/json-event-stream.ts
@@ -130,6 +130,14 @@ function handleCodexEvent(obj: unknown, onEvent: (ev: AgentEvent) => void): bool
 }
 
 // ─── Gemini handler ───
+//
+// Actual Gemini CLI stream-json event shapes (v0.46.0):
+//   init:         { type: "init", timestamp, session_id, model }
+//   message:      { type: "message", timestamp, role: "user"|"assistant", content, delta?: true }
+//   tool_use:     { type: "tool_use", timestamp, tool_name, tool_id, parameters }
+//   tool_result:  { type: "tool_result", timestamp, tool_id, status: "success"|"error", output, error?: { type, message } }
+//   error:        { type: "error", timestamp, severity: "warning"|"error", message }
+//   result:       { type: "result", timestamp, status: "success"|"error", error?: { type, message }, stats: { total_tokens, input_tokens, output_tokens, cached, input, duration_ms, tool_calls, models } }
 
 function handleGeminiEvent(obj: unknown, onEvent: (ev: AgentEvent) => void): boolean {
   if (!isRecord(obj)) return false;
@@ -140,38 +148,77 @@ function handleGeminiEvent(obj: unknown, onEvent: (ev: AgentEvent) => void): boo
     return true;
   }
 
-  // Text message
+  // Text message — only emit assistant messages (skip user echo)
   if (obj.type === 'message' && typeof obj.content === 'string') {
-    onEvent({ type: 'text_delta', delta: obj.content });
+    if (obj.role !== 'user') {
+      onEvent({ type: 'text_delta', delta: obj.content });
+    }
     return true;
   }
 
-  // Alternative text format
+  // Alternative text format (fallback, not seen in v0.46 but kept for safety)
   if (obj.type === 'text' && typeof obj.text === 'string') {
     onEvent({ type: 'text_delta', delta: obj.text });
     return true;
   }
 
-  // Result / usage
-  if (obj.type === 'result') {
-    const usage: UsageInfo = {};
-    if (isRecord(obj.usage)) {
-      if (typeof obj.usage.input_tokens === 'number') usage.input_tokens = obj.usage.input_tokens;
-      if (typeof obj.usage.output_tokens === 'number') usage.output_tokens = obj.usage.output_tokens;
-    }
-    onEvent({ type: 'usage', usage });
+  // Tool use
+  if (obj.type === 'tool_use' && typeof obj.tool_id === 'string') {
+    onEvent({
+      type: 'tool_use',
+      id: obj.tool_id,
+      name: typeof obj.tool_name === 'string' ? obj.tool_name : 'unknown',
+      input: isRecord(obj.parameters) ? obj.parameters : {},
+    });
     return true;
   }
 
-  // Turn end
-  if (obj.type === 'turn_end' || obj.type === 'done') {
-    onEvent({ type: 'turn_end', stopReason: typeof obj.stop_reason === 'string' ? obj.stop_reason : 'end_turn' });
+  // Tool result
+  if (obj.type === 'tool_result' && typeof obj.tool_id === 'string') {
+    onEvent({
+      type: 'tool_result',
+      toolUseId: obj.tool_id,
+      content: typeof obj.output === 'string' ? obj.output : '',
+      isError: obj.status === 'error',
+    });
     return true;
   }
 
-  // Error
+  // Error (non-fatal warnings and errors during the stream)
   if (obj.type === 'error' && typeof obj.message === 'string') {
     onEvent({ type: 'error', message: obj.message });
+    return true;
+  }
+
+  // Result — final event: usage stats + turn completion
+  if (obj.type === 'result') {
+    // Emit error if the result indicates failure
+    if (obj.status === 'error' && isRecord(obj.error) && typeof obj.error.message === 'string') {
+      onEvent({ type: 'error', message: obj.error.message });
+    }
+
+    // Emit usage stats from the `stats` field
+    if (isRecord(obj.stats)) {
+      const usage: UsageInfo = {};
+      if (typeof obj.stats.input_tokens === 'number') usage.input_tokens = obj.stats.input_tokens;
+      if (typeof obj.stats.output_tokens === 'number') usage.output_tokens = obj.stats.output_tokens;
+      if (typeof obj.stats.cached === 'number') usage.cached_read_tokens = obj.stats.cached;
+      if (Object.keys(usage).length > 0) {
+        onEvent({ type: 'usage', usage });
+      }
+    }
+
+    // Emit turn_end to signal completion
+    onEvent({
+      type: 'turn_end',
+      stopReason: obj.status === 'error' ? 'error' : 'end_turn',
+    });
+    return true;
+  }
+
+  // Legacy turn_end / done (kept for backward compat, not emitted by v0.46)
+  if (obj.type === 'turn_end' || obj.type === 'done') {
+    onEvent({ type: 'turn_end', stopReason: typeof obj.stop_reason === 'string' ? obj.stop_reason : 'end_turn' });
     return true;
   }
 

--- a/apps/daemon/test/runtimes/env.test.ts
+++ b/apps/daemon/test/runtimes/env.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { buildSpawnEnv } from '../../src/core/runtimes/env.js';
 import type { RuntimeAgentDef } from '@molio/contracts';
 
@@ -282,6 +285,78 @@ describe('buildSpawnEnv', () => {
       const env = buildSpawnEnv(def, {});
 
       assert.equal(env['CLAUDE_CODE_GIT_BASH_PATH'], undefined);
+    });
+  });
+
+  describe('agent .env file loading', () => {
+    const testAgentId = '_molio_test_agent';
+    const configDir = path.join(os.homedir(), `.${testAgentId}`);
+    const envFile = path.join(configDir, '.env');
+
+    afterEach(() => {
+      // Clean up test config directory
+      try { fs.rmSync(configDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    it('should load vars from ~/.{agentId}/.env', () => {
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(envFile, 'TEST_API_KEY=sk-test-123\nTEST_MODEL=gpt-4\n');
+
+      const def = makeDef({ id: testAgentId });
+      const env = buildSpawnEnv(def, {});
+
+      assert.equal(env['TEST_API_KEY'], 'sk-test-123');
+      assert.equal(env['TEST_MODEL'], 'gpt-4');
+    });
+
+    it('should let process.env override .env file', () => {
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(envFile, 'SHARED_KEY=from-dotenv\n');
+
+      const def = makeDef({ id: testAgentId });
+      const env = buildSpawnEnv(def, { SHARED_KEY: 'from-process' });
+
+      assert.equal(env['SHARED_KEY'], 'from-process');
+    });
+
+    it('should let def.env override both .env and process.env', () => {
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(envFile, 'MY_KEY=from-dotenv\n');
+
+      const def = makeDef({ id: testAgentId, env: { MY_KEY: 'from-def' } });
+      const env = buildSpawnEnv(def, { MY_KEY: 'from-process' });
+
+      assert.equal(env['MY_KEY'], 'from-def');
+    });
+
+    it('should handle quoted values in .env', () => {
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(envFile, 'QUOTED_DOUBLE="hello world"\nQUOTED_SINGLE=\'single quoted\'\n');
+
+      const def = makeDef({ id: testAgentId });
+      const env = buildSpawnEnv(def, {});
+
+      assert.equal(env['QUOTED_DOUBLE'], 'hello world');
+      assert.equal(env['QUOTED_SINGLE'], 'single quoted');
+    });
+
+    it('should skip comments and blank lines', () => {
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(envFile, '# this is a comment\n\nKEY_A=1\n  # another comment\nKEY_B=2\n');
+
+      const def = makeDef({ id: testAgentId });
+      const env = buildSpawnEnv(def, {});
+
+      assert.equal(env['KEY_A'], '1');
+      assert.equal(env['KEY_B'], '2');
+      assert.equal(env['# this is a comment'], undefined);
+    });
+
+    it('should not fail when .env does not exist', () => {
+      const def = makeDef({ id: testAgentId });
+      const env = buildSpawnEnv(def, { SAFE: 'yes' });
+
+      assert.equal(env['SAFE'], 'yes');
     });
   });
 });

--- a/apps/daemon/test/runtimes/gemini-stream-json.test.ts
+++ b/apps/daemon/test/runtimes/gemini-stream-json.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { geminiAgentDef } from '../../src/core/runtimes/gemini.js';
+
+/**
+ * Error-driven test: Gemini CLI runtime must emit parseable events.
+ *
+ * Bug: buildArgs was empty (only --model), so Gemini CLI ran in its default
+ * interactive TUI mode with plain-text output. The json-event-stream parser
+ * received no valid JSON and silently produced zero events — the user sees
+ * "no response".
+ *
+ * Fix: Pass -p (headless), --output-format stream-json (JSONL events on
+ * stdout), and --yolo (auto-approve tool calls — daemon has no human in
+ * the loop to click "yes").
+ */
+
+describe('Gemini CLI runtime stream-json configuration', () => {
+  it('should use json-event-stream as streamFormat', () => {
+    assert.equal(
+      geminiAgentDef.streamFormat,
+      'json-event-stream',
+      'streamFormat must be json-event-stream so selectParser uses createJsonEventStreamHandler',
+    );
+  });
+
+  it('should use gemini as eventParser', () => {
+    assert.equal(
+      geminiAgentDef.eventParser,
+      'gemini',
+      'eventParser must be gemini so the dispatcher routes to handleGeminiEvent',
+    );
+  });
+
+  it('should use promptViaStdin', () => {
+    assert.equal(
+      geminiAgentDef.promptViaStdin,
+      true,
+      'prompt must be delivered via stdin',
+    );
+  });
+
+  it('should include --output-format stream-json in buildArgs', () => {
+    const args = geminiAgentDef.buildArgs('test prompt', {}, {});
+    const idx = args.indexOf('--output-format');
+    assert.ok(idx !== -1, 'should have --output-format flag');
+    assert.equal(args[idx + 1], 'stream-json');
+  });
+
+  it('should include -p flag for headless/prompt mode', () => {
+    const args = geminiAgentDef.buildArgs('test prompt', {}, {});
+    assert.ok(args.includes('-p'), 'should have -p flag for non-interactive (headless) mode');
+  });
+
+  it('should include --yolo for auto-approving tool calls', () => {
+    const args = geminiAgentDef.buildArgs('test prompt', {}, {});
+    assert.ok(args.includes('--yolo'), 'should have --yolo to auto-approve tools (daemon has no human in the loop)');
+  });
+
+  it('should add --model flag when model is specified', () => {
+    const args = geminiAgentDef.buildArgs('test', { model: 'gemini-2.5-pro' }, {});
+    const idx = args.indexOf('--model');
+    assert.ok(idx !== -1, 'should have --model flag');
+    assert.equal(args[idx + 1], 'gemini-2.5-pro');
+  });
+
+  it('should NOT add --model flag for default model', () => {
+    const args = geminiAgentDef.buildArgs('test', { model: 'default' }, {});
+    assert.ok(!args.includes('--model'), 'should not have --model for default');
+  });
+});

--- a/apps/daemon/test/streams/json-event-stream.test.ts
+++ b/apps/daemon/test/streams/json-event-stream.test.ts
@@ -85,7 +85,7 @@ describe('json-event-stream dispatcher', () => {
   describe('gemini events', () => {
     it('should parse init event as status', () => {
       const events = collectEvents('gemini', [
-        JSON.stringify({ type: 'init' }),
+        JSON.stringify({ type: 'init', session_id: 'abc', model: 'gemini-2.5-pro' }),
       ]);
       assert.equal(events.length, 1);
       assert.equal(events[0]!.type, 'status');
@@ -94,9 +94,9 @@ describe('json-event-stream dispatcher', () => {
       }
     });
 
-    it('should parse message event as text_delta', () => {
+    it('should parse assistant message event as text_delta', () => {
       const events = collectEvents('gemini', [
-        JSON.stringify({ type: 'message', content: 'Hello from Gemini' }),
+        JSON.stringify({ type: 'message', role: 'assistant', content: 'Hello from Gemini', delta: true }),
       ]);
       assert.equal(events.length, 1);
       assert.equal(events[0]!.type, 'text_delta');
@@ -105,15 +105,130 @@ describe('json-event-stream dispatcher', () => {
       }
     });
 
-    it('should parse result event as usage', () => {
+    it('should skip user message echo', () => {
       const events = collectEvents('gemini', [
-        JSON.stringify({ type: 'result', usage: { input_tokens: 200, output_tokens: 80 } }),
+        JSON.stringify({ type: 'message', role: 'user', content: 'my prompt' }),
       ]);
-      assert.equal(events.length, 1);
-      assert.equal(events[0]!.type, 'usage');
+      assert.equal(events.length, 0);
     });
 
-    it('should parse done event as turn_end', () => {
+    it('should parse tool_use event', () => {
+      const events = collectEvents('gemini', [
+        JSON.stringify({
+          type: 'tool_use',
+          tool_name: 'read_file',
+          tool_id: 'tool-123',
+          parameters: { path: '/tmp/test.txt' },
+        }),
+      ]);
+      assert.equal(events.length, 1);
+      assert.equal(events[0]!.type, 'tool_use');
+      if (events[0]!.type === 'tool_use') {
+        assert.equal(events[0]!.id, 'tool-123');
+        assert.equal(events[0]!.name, 'read_file');
+        assert.deepEqual(events[0]!.input, { path: '/tmp/test.txt' });
+      }
+    });
+
+    it('should parse tool_result event (success)', () => {
+      const events = collectEvents('gemini', [
+        JSON.stringify({
+          type: 'tool_result',
+          tool_id: 'tool-123',
+          status: 'success',
+          output: 'file contents here',
+        }),
+      ]);
+      assert.equal(events.length, 1);
+      assert.equal(events[0]!.type, 'tool_result');
+      if (events[0]!.type === 'tool_result') {
+        assert.equal(events[0]!.toolUseId, 'tool-123');
+        assert.equal(events[0]!.content, 'file contents here');
+        assert.equal(events[0]!.isError, false);
+      }
+    });
+
+    it('should parse tool_result event (error)', () => {
+      const events = collectEvents('gemini', [
+        JSON.stringify({
+          type: 'tool_result',
+          tool_id: 'tool-456',
+          status: 'error',
+          output: '',
+          error: { type: 'TOOL_EXECUTION_ERROR', message: 'permission denied' },
+        }),
+      ]);
+      assert.equal(events.length, 1);
+      assert.equal(events[0]!.type, 'tool_result');
+      if (events[0]!.type === 'tool_result') {
+        assert.equal(events[0]!.toolUseId, 'tool-456');
+        assert.equal(events[0]!.isError, true);
+      }
+    });
+
+    it('should parse error event', () => {
+      const events = collectEvents('gemini', [
+        JSON.stringify({ type: 'error', severity: 'warning', message: 'Rate limit approaching' }),
+      ]);
+      assert.equal(events.length, 1);
+      assert.equal(events[0]!.type, 'error');
+      if (events[0]!.type === 'error') {
+        assert.equal(events[0]!.message, 'Rate limit approaching');
+      }
+    });
+
+    it('should parse result event as usage + turn_end', () => {
+      const events = collectEvents('gemini', [
+        JSON.stringify({
+          type: 'result',
+          status: 'success',
+          stats: {
+            total_tokens: 280,
+            input_tokens: 200,
+            output_tokens: 80,
+            cached: 50,
+            duration_ms: 1234,
+            tool_calls: 0,
+            models: {},
+          },
+        }),
+      ]);
+      assert.equal(events.length, 2);
+      assert.equal(events[0]!.type, 'usage');
+      if (events[0]!.type === 'usage') {
+        assert.equal(events[0]!.usage?.input_tokens, 200);
+        assert.equal(events[0]!.usage?.output_tokens, 80);
+        assert.equal(events[0]!.usage?.cached_read_tokens, 50);
+      }
+      assert.equal(events[1]!.type, 'turn_end');
+      if (events[1]!.type === 'turn_end') {
+        assert.equal(events[1]!.stopReason, 'end_turn');
+      }
+    });
+
+    it('should parse result event with error status', () => {
+      const events = collectEvents('gemini', [
+        JSON.stringify({
+          type: 'result',
+          status: 'error',
+          error: { type: 'API_ERROR', message: 'Quota exceeded' },
+          stats: { total_tokens: 0, input_tokens: 0, output_tokens: 0, cached: 0, duration_ms: 100, tool_calls: 0, models: {} },
+        }),
+      ]);
+      // error + usage (0 is still a number) + turn_end
+      assert.equal(events.length, 3);
+      assert.equal(events[0]!.type, 'error');
+      if (events[0]!.type === 'error') {
+        assert.equal(events[0]!.message, 'Quota exceeded');
+      }
+      assert.equal(events[1]!.type, 'usage');
+      assert.equal(events[2]!.type, 'turn_end');
+      if (events[2]!.type === 'turn_end') {
+        assert.equal(events[2]!.stopReason, 'error');
+      }
+    });
+
+    it('should parse legacy done event as turn_end', () => {
       const events = collectEvents('gemini', [
         JSON.stringify({ type: 'done' }),
       ]);


### PR DESCRIPTION
- Add required CLI args to buildArgs: -p (headless mode), --output-format stream-json, --yolo (auto-approve tools), --skip-trust (bypass workspace trust check)
- Rewrite handleGeminiEvent to match actual Gemini CLI v0.46.0 output format: init, message (filter user echo), tool_use, tool_result, error, result (stats→usage + turn_end)
- Load agent .env files from ~/.{agentId}/.env into spawn env so API keys and custom base URLs are passed to child processes
- Add 6 tests for .env loading, 8 tests for Gemini buildArgs, update 10 Gemini event parser tests (4→10 coverage)