### PR TITLE
fix(ci): fix release workflow YAML parsing and OSS upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,18 +385,35 @@ jobs:
           echo "✅ OIDC token obtained (${#ID_TOKEN} chars)"
           echo "::endgroup::"
 
-          # Call STS AssumeRoleWithOIDC directly via curl
+          # Call STS AssumeRoleWithOIDC via Python (handles signing automatically)
           echo "::group::STS AssumeRoleWithOIDC"
-          CREDENTIALS=$(curl -s "https://sts.aliyuncs.com/?Action=AssumeRoleWithOIDC&Version=2015-04-01&Format=JSON&RoleArn=${ALIYUN_ROLE_ARN}&OIDCProviderArn=${ALIYUN_OIDC_PROVIDER_ARN}&OIDCToken=${ID_TOKEN}&RoleSessionName=github-actions-${{ github.run_id }}&DurationSeconds=3600")
+          pip install -q alibabacloud_sts20150401
+          CREDENTIALS=$(python3 -c "
+import json, os
+from alibabacloud_sts20150401.client import Client as StsClient
+from alibabacloud_sts20150401 import models as sts_models
+from alibabacloud_tea_openapi import models as open_api_models
+
+config = open_api_models.Config(
+    access_key_id='',
+    access_key_secret='',
+    credential=open_api_models.CredentialConfig(
+        bearer_token=os.environ['ID_TOKEN'],
+    ),
+    region_id='cn-guangzhou',
+)
+client = StsClient(config=config)
+req = sts_models.AssumeRoleWithOIDCRequest(
+    role_arn='${{ vars.ALIYUN_ROLE_ARN }}',
+    oidc_provider_arn='${{ vars.ALIYUN_OIDC_PROVIDER_ARN }}',
+    role_session_name='github-actions-${{ github.run_id }}',
+    duration_seconds=3600,
+)
+resp = client.assume_role_with_oidc(req)
+print(json.dumps(resp.body.to_map()))
+" 2>&1)
           echo "STS response: $CREDENTIALS"
           echo "::endgroup::"
-
-          # Check for errors
-          ERROR_CODE=$(echo "$CREDENTIALS" | jq -r '.Code // empty')
-          if [ -n "$ERROR_CODE" ]; then
-            echo "❌ STS API error: $ERROR_CODE - $(echo "$CREDENTIALS" | jq -r '.Message')"
-            exit 1
-          fi
 
           # Extract credentials
           AK_ID=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeyId')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,11 +388,18 @@ jobs:
           # Call STS AssumeRoleWithOIDC via Python script (handles signing automatically)
           echo "::group::STS AssumeRoleWithOIDC"
           pip install -q alibabacloud_sts20150401
+          set +e
           CREDENTIALS=$(python3 scripts/sts_oidc.py \
             --role-arn "${ALIYUN_ROLE_ARN}" \
             --oidc-provider-arn "${ALIYUN_OIDC_PROVIDER_ARN}" \
-            --session-name "github-actions-${{ github.run_id }}" \
-            2>&1)
+            --session-name "github-actions-${{ github.run_id }}")
+          PY_EXIT=$?
+          set -e
+          if [ $PY_EXIT -ne 0 ]; then
+            echo "❌ Python script failed with exit code $PY_EXIT"
+            echo "Output: $CREDENTIALS"
+            exit 1
+          fi
           echo "STS response: $CREDENTIALS"
           echo "::endgroup::"
 
@@ -403,6 +410,7 @@ jobs:
 
           if [ -z "$AK_ID" ] || [ "$AK_ID" = "null" ]; then
             echo "❌ Failed to extract credentials from STS response"
+            echo "Raw response: $CREDENTIALS"
             exit 1
           fi
           echo "✅ STS credentials obtained"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,15 +376,38 @@ jobs:
           ALIYUN_OIDC_PROVIDER_ARN: ${{ vars.ALIYUN_OIDC_PROVIDER_ARN }}
         run: |
           # Get OIDC token from GitHub
+          echo "::group::OIDC Token Request"
           ID_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.aliyuncs.com" | jq -r '.value')
+          if [ -z "$ID_TOKEN" ] || [ "$ID_TOKEN" = "null" ]; then
+            echo "❌ Failed to get OIDC token from GitHub"
+            exit 1
+          fi
+          echo "✅ OIDC token obtained (${#ID_TOKEN} chars)"
+          echo "::endgroup::"
 
           # Call STS AssumeRoleWithOIDC directly via curl
+          echo "::group::STS AssumeRoleWithOIDC"
           CREDENTIALS=$(curl -s "https://sts.aliyuncs.com/?Action=AssumeRoleWithOIDC&Version=2015-04-01&Format=JSON&RoleArn=${ALIYUN_ROLE_ARN}&OIDCProviderArn=${ALIYUN_OIDC_PROVIDER_ARN}&OIDCToken=${ID_TOKEN}&RoleSessionName=github-actions-${{ github.run_id }}&DurationSeconds=3600")
+          echo "STS response: $CREDENTIALS"
+          echo "::endgroup::"
+
+          # Check for errors
+          ERROR_CODE=$(echo "$CREDENTIALS" | jq -r '.Code // empty')
+          if [ -n "$ERROR_CODE" ]; then
+            echo "❌ STS API error: $ERROR_CODE - $(echo "$CREDENTIALS" | jq -r '.Message')"
+            exit 1
+          fi
 
           # Extract credentials
           AK_ID=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeyId')
           AK_SECRET=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeySecret')
           STS_TOKEN=$(echo "$CREDENTIALS" | jq -r '.Credentials.SecurityToken')
+
+          if [ -z "$AK_ID" ] || [ "$AK_ID" = "null" ]; then
+            echo "❌ Failed to extract credentials from STS response"
+            exit 1
+          fi
+          echo "✅ STS credentials obtained"
 
           # Persist for subsequent steps
           echo "OSS_ACCESS_KEY_ID=$AK_ID" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,10 +385,18 @@ jobs:
           echo "✅ OIDC token obtained (${#ID_TOKEN} chars)"
           echo "::endgroup::"
 
-          # Call STS AssumeRoleWithOIDC (no signing required — OIDC token is the credential)
+          # Call STS AssumeRoleWithOIDC via POST (OIDC token too long for URL query string)
           echo "::group::STS AssumeRoleWithOIDC"
-          CREDENTIALS=$(curl -sf "https://sts.aliyuncs.com/?Action=AssumeRoleWithOIDC&Version=2015-04-01&Format=JSON&RoleArn=${ALIYUN_ROLE_ARN}&OIDCProviderArn=${ALIYUN_OIDC_PROVIDER_ARN}&OIDCToken=${ID_TOKEN}&RoleSessionName=github-actions-${{ github.run_id }}&DurationSeconds=3600")
-          echo "STS response received ($(echo "$CREDENTIALS" | wc -c) bytes)"
+          CREDENTIALS=$(curl -s -X POST "https://sts.aliyuncs.com/" \
+            -d "Action=AssumeRoleWithOIDC" \
+            -d "Version=2015-04-01" \
+            -d "Format=JSON" \
+            -d "RoleArn=${ALIYUN_ROLE_ARN}" \
+            -d "OIDCProviderArn=${ALIYUN_OIDC_PROVIDER_ARN}" \
+            -d "OIDCToken=${ID_TOKEN}" \
+            -d "RoleSessionName=github-actions-${{ github.run_id }}" \
+            -d "DurationSeconds=3600")
+          echo "STS response: $CREDENTIALS"
           echo "::endgroup::"
 
           # Extract credentials

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
-      - "v*.*.*-test"
+      - "v*"
       - "!v*-dirty*"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,22 +385,16 @@ jobs:
           echo "✅ OIDC token obtained (${#ID_TOKEN} chars)"
           echo "::endgroup::"
 
-          # Call STS AssumeRoleWithOIDC via Python script (handles signing automatically)
+          # Call STS AssumeRoleWithOIDC (no signing required — OIDC token is the credential)
           echo "::group::STS AssumeRoleWithOIDC"
-          pip install -q alibabacloud_sts20150401
-          python3 scripts/sts_oidc.py \
-            --role-arn "${ALIYUN_ROLE_ARN}" \
-            --oidc-provider-arn "${ALIYUN_OIDC_PROVIDER_ARN}" \
-            --session-name "github-actions-${{ github.run_id }}" \
-            > /tmp/sts_output.json
-          CREDENTIALS=$(cat /tmp/sts_output.json)
-          echo "STS response: $CREDENTIALS"
+          CREDENTIALS=$(curl -sf "https://sts.aliyuncs.com/?Action=AssumeRoleWithOIDC&Version=2015-04-01&Format=JSON&RoleArn=${ALIYUN_ROLE_ARN}&OIDCProviderArn=${ALIYUN_OIDC_PROVIDER_ARN}&OIDCToken=${ID_TOKEN}&RoleSessionName=github-actions-${{ github.run_id }}&DurationSeconds=3600")
+          echo "STS response received ($(echo "$CREDENTIALS" | wc -c) bytes)"
           echo "::endgroup::"
 
           # Extract credentials
-          AK_ID=$(echo "$CREDENTIALS" | jq -r '.AccessKeyId')
-          AK_SECRET=$(echo "$CREDENTIALS" | jq -r '.AccessKeySecret')
-          STS_TOKEN=$(echo "$CREDENTIALS" | jq -r '.SecurityToken')
+          AK_ID=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeyId')
+          AK_SECRET=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeySecret')
+          STS_TOKEN=$(echo "$CREDENTIALS" | jq -r '.Credentials.SecurityToken')
 
           if [ -z "$AK_ID" ] || [ "$AK_ID" = "null" ]; then
             echo "❌ Failed to extract credentials from STS response"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,18 +388,12 @@ jobs:
           # Call STS AssumeRoleWithOIDC via Python script (handles signing automatically)
           echo "::group::STS AssumeRoleWithOIDC"
           pip install -q alibabacloud_sts20150401
-          set +e
-          CREDENTIALS=$(python3 scripts/sts_oidc.py \
+          python3 scripts/sts_oidc.py \
             --role-arn "${ALIYUN_ROLE_ARN}" \
             --oidc-provider-arn "${ALIYUN_OIDC_PROVIDER_ARN}" \
-            --session-name "github-actions-${{ github.run_id }}")
-          PY_EXIT=$?
-          set -e
-          if [ $PY_EXIT -ne 0 ]; then
-            echo "❌ Python script failed with exit code $PY_EXIT"
-            echo "Output: $CREDENTIALS"
-            exit 1
-          fi
+            --session-name "github-actions-${{ github.run_id }}" \
+            > /tmp/sts_output.json
+          CREDENTIALS=$(cat /tmp/sts_output.json)
           echo "STS response: $CREDENTIALS"
           echo "::endgroup::"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,6 +416,10 @@ jobs:
 
       - name: Upload release assets to OSS
         shell: bash
+        env:
+          OSS_ACCESS_KEY_ID: ${{ env.OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ env.OSS_ACCESS_KEY_SECRET }}
+          OSS_SECURITY_TOKEN: ${{ env.OSS_SECURITY_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="v${VERSION}"
@@ -425,6 +429,9 @@ jobs:
             filename=$(basename "$file")
             ossutil cp "$file" oss://${{ vars.OSS_BUCKET }}/releases/${TAG}/${filename} \
               --endpoint=${{ vars.OSS_ENDPOINT }} \
+              -i "${OSS_ACCESS_KEY_ID}" \
+              -k "${OSS_ACCESS_KEY_SECRET}" \
+              -t "${OSS_SECURITY_TOKEN}" \
               --update
           done
 
@@ -434,6 +441,9 @@ jobs:
           EOF
           ossutil cp /tmp/latest.json oss://${{ vars.OSS_BUCKET }}/releases/latest.json \
             --endpoint=${{ vars.OSS_ENDPOINT }} \
+            -i "${OSS_ACCESS_KEY_ID}" \
+            -k "${OSS_ACCESS_KEY_SECRET}" \
+            -t "${OSS_SECURITY_TOKEN}" \
             --meta Cache-Control:no-cache
 
           echo "✅ Uploaded ${TAG} to oss://${{ vars.OSS_BUCKET }}/releases/${TAG}/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,40 +385,21 @@ jobs:
           echo "✅ OIDC token obtained (${#ID_TOKEN} chars)"
           echo "::endgroup::"
 
-          # Call STS AssumeRoleWithOIDC via Python (handles signing automatically)
+          # Call STS AssumeRoleWithOIDC via Python script (handles signing automatically)
           echo "::group::STS AssumeRoleWithOIDC"
           pip install -q alibabacloud_sts20150401
-          CREDENTIALS=$(python3 -c "
-import json, os
-from alibabacloud_sts20150401.client import Client as StsClient
-from alibabacloud_sts20150401 import models as sts_models
-from alibabacloud_tea_openapi import models as open_api_models
-
-config = open_api_models.Config(
-    access_key_id='',
-    access_key_secret='',
-    credential=open_api_models.CredentialConfig(
-        bearer_token=os.environ['ID_TOKEN'],
-    ),
-    region_id='cn-guangzhou',
-)
-client = StsClient(config=config)
-req = sts_models.AssumeRoleWithOIDCRequest(
-    role_arn='${{ vars.ALIYUN_ROLE_ARN }}',
-    oidc_provider_arn='${{ vars.ALIYUN_OIDC_PROVIDER_ARN }}',
-    role_session_name='github-actions-${{ github.run_id }}',
-    duration_seconds=3600,
-)
-resp = client.assume_role_with_oidc(req)
-print(json.dumps(resp.body.to_map()))
-" 2>&1)
+          CREDENTIALS=$(python3 scripts/sts_oidc.py \
+            --role-arn "${ALIYUN_ROLE_ARN}" \
+            --oidc-provider-arn "${ALIYUN_OIDC_PROVIDER_ARN}" \
+            --session-name "github-actions-${{ github.run_id }}" \
+            2>&1)
           echo "STS response: $CREDENTIALS"
           echo "::endgroup::"
 
           # Extract credentials
-          AK_ID=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeyId')
-          AK_SECRET=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeySecret')
-          STS_TOKEN=$(echo "$CREDENTIALS" | jq -r '.Credentials.SecurityToken')
+          AK_ID=$(echo "$CREDENTIALS" | jq -r '.AccessKeyId')
+          AK_SECRET=$(echo "$CREDENTIALS" | jq -r '.AccessKeySecret')
+          STS_TOKEN=$(echo "$CREDENTIALS" | jq -r '.SecurityToken')
 
           if [ -z "$AK_ID" ] || [ "$AK_ID" = "null" ]; then
             echo "❌ Failed to extract credentials from STS response"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "v*.*.*-test"
       - "!v*-dirty*"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,24 +385,22 @@ jobs:
           echo "✅ OIDC token obtained (${#ID_TOKEN} chars)"
           echo "::endgroup::"
 
-          # Call STS AssumeRoleWithOIDC via POST (OIDC token too long for URL query string)
+          # Call STS AssumeRoleWithOIDC via Python SDK with OIDC credential type
           echo "::group::STS AssumeRoleWithOIDC"
-          CREDENTIALS=$(curl -s -X POST "https://sts.aliyuncs.com/" \
-            -d "Action=AssumeRoleWithOIDC" \
-            -d "Version=2015-04-01" \
-            -d "Format=JSON" \
-            -d "RoleArn=${ALIYUN_ROLE_ARN}" \
-            -d "OIDCProviderArn=${ALIYUN_OIDC_PROVIDER_ARN}" \
-            -d "OIDCToken=${ID_TOKEN}" \
-            -d "RoleSessionName=github-actions-${{ github.run_id }}" \
-            -d "DurationSeconds=3600")
+          pip install -q alibabacloud_sts20150401 alibabacloud_credentials
+          python3 scripts/sts_oidc.py \
+            --role-arn "${ALIYUN_ROLE_ARN}" \
+            --oidc-provider-arn "${ALIYUN_OIDC_PROVIDER_ARN}" \
+            --session-name "github-actions-${{ github.run_id }}" \
+            > /tmp/sts_output.json
+          CREDENTIALS=$(cat /tmp/sts_output.json)
           echo "STS response: $CREDENTIALS"
           echo "::endgroup::"
 
           # Extract credentials
-          AK_ID=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeyId')
-          AK_SECRET=$(echo "$CREDENTIALS" | jq -r '.Credentials.AccessKeySecret')
-          STS_TOKEN=$(echo "$CREDENTIALS" | jq -r '.Credentials.SecurityToken')
+          AK_ID=$(echo "$CREDENTIALS" | jq -r '.AccessKeyId')
+          AK_SECRET=$(echo "$CREDENTIALS" | jq -r '.AccessKeySecret')
+          STS_TOKEN=$(echo "$CREDENTIALS" | jq -r '.SecurityToken')
 
           if [ -z "$AK_ID" ] || [ "$AK_ID" = "null" ]; then
             echo "❌ Failed to extract credentials from STS response"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
         run: |
           # Get OIDC token from GitHub
           echo "::group::OIDC Token Request"
-          ID_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.aliyuncs.com" | jq -r '.value')
+          export ID_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.aliyuncs.com" | jq -r '.value')
           if [ -z "$ID_TOKEN" ] || [ "$ID_TOKEN" = "null" ]; then
             echo "❌ Failed to get OIDC token from GitHub"
             exit 1

--- a/scripts/sts_oidc.py
+++ b/scripts/sts_oidc.py
@@ -2,13 +2,11 @@
 """Obtain Alibaba Cloud STS credentials via OIDC (GitHub Actions).
 
 Usage:
+    export ID_TOKEN=<github-oidc-token>
     python3 scripts/sts_oidc.py \
         --role-arn <ROLE_ARN> \
         --oidc-provider-arn <OIDC_PROVIDER_ARN> \
         --session-name <SESSION_NAME>
-
-Environment:
-    ID_TOKEN  – GitHub Actions OIDC token (set by the workflow step)
 
 Output (JSON to stdout):
     { "AccessKeyId": "...", "AccessKeySecret": "...", "SecurityToken": "..." }
@@ -18,6 +16,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 
 
 def main():
@@ -33,21 +32,36 @@ def main():
         print("ERROR: ID_TOKEN environment variable is not set", file=sys.stderr)
         sys.exit(1)
 
+    # Write OIDC token to a temp file (alibabacloud_credentials reads from file)
+    token_file = os.path.join(tempfile.gettempdir(), "github_oidc_token")
+    with open(token_file, "w") as f:
+        f.write(id_token)
+
     try:
+        from alibabacloud_credentials.client import Client as CredClient
+        from alibabacloud_credentials.models import Config as CredConfig
         from alibabacloud_sts20150401.client import Client as StsClient
         from alibabacloud_sts20150401 import models as sts_models
         from alibabacloud_tea_openapi import models as open_api_models
     except ImportError as e:
         print(f"ERROR: Missing dependency: {e}", file=sys.stderr)
-        print("Run: pip install alibabacloud_sts20150401", file=sys.stderr)
+        print("Run: pip install alibabacloud_sts20150401 alibabacloud_credentials", file=sys.stderr)
         sys.exit(1)
 
+    # Create credential client using OIDC role ARN type
+    cred_config = CredConfig(
+        type="oidc_role_arn",
+        oidc_provider_arn=args.oidc_provider_arn,
+        role_arn=args.role_arn,
+        oidc_token_file_path=token_file,
+        role_session_name=args.session_name,
+        role_session_expiration=args.duration_seconds,
+    )
+    cred_client = CredClient(config=cred_config)
+
+    # Use the credential client to create STS client
     config = open_api_models.Config(
-        access_key_id="",
-        access_key_secret="",
-        credential=open_api_models.CredentialConfig(
-            bearer_token=id_token,
-        ),
+        credential=cred_client,
         region_id="cn-guangzhou",
     )
     client = StsClient(config=config)
@@ -57,6 +71,7 @@ def main():
         oidc_provider_arn=args.oidc_provider_arn,
         role_session_name=args.session_name,
         duration_seconds=args.duration_seconds,
+        oidc_token=id_token,
     )
 
     try:

--- a/scripts/sts_oidc.py
+++ b/scripts/sts_oidc.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Obtain Alibaba Cloud STS credentials via OIDC (GitHub Actions).
+
+Usage:
+    python3 scripts/sts_oidc.py \
+        --role-arn <ROLE_ARN> \
+        --oidc-provider-arn <OIDC_PROVIDER_ARN> \
+        --session-name <SESSION_NAME>
+
+Environment:
+    ID_TOKEN  – GitHub Actions OIDC token (set by the workflow step)
+
+Output (JSON to stdout):
+    { "AccessKeyId": "...", "AccessKeySecret": "...", "SecurityToken": "..." }
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="STS AssumeRoleWithOIDC")
+    parser.add_argument("--role-arn", required=True)
+    parser.add_argument("--oidc-provider-arn", required=True)
+    parser.add_argument("--session-name", required=True)
+    parser.add_argument("--duration-seconds", type=int, default=3600)
+    args = parser.parse_args()
+
+    id_token = os.environ.get("ID_TOKEN", "")
+    if not id_token:
+        print("ERROR: ID_TOKEN environment variable is not set", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        from alibabacloud_sts20150401.client import Client as StsClient
+        from alibabacloud_sts20150401 import models as sts_models
+        from alibabacloud_tea_openapi import models as open_api_models
+    except ImportError as e:
+        print(f"ERROR: Missing dependency: {e}", file=sys.stderr)
+        print("Run: pip install alibabacloud_sts20150401", file=sys.stderr)
+        sys.exit(1)
+
+    config = open_api_models.Config(
+        access_key_id="",
+        access_key_secret="",
+        credential=open_api_models.CredentialConfig(
+            bearer_token=id_token,
+        ),
+        region_id="cn-guangzhou",
+    )
+    client = StsClient(config=config)
+
+    req = sts_models.AssumeRoleWithOIDCRequest(
+        role_arn=args.role_arn,
+        oidc_provider_arn=args.oidc_provider_arn,
+        role_session_name=args.session_name,
+        duration_seconds=args.duration_seconds,
+    )
+
+    try:
+        resp = client.assume_role_with_oidc(req)
+    except Exception as e:
+        print(f"ERROR: STS AssumeRoleWithOIDC failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    creds = resp.body.credentials
+    result = {
+        "AccessKeyId": creds.access_key_id,
+        "AccessKeySecret": creds.access_key_secret,
+        "SecurityToken": creds.security_token,
+    }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sts_oidc.py
+++ b/scripts/sts_oidc.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Obtain Alibaba Cloud STS credentials via OIDC (GitHub Actions).
 
+Uses alibabacloud_credentials with type='oidc_role_arn' to automatically
+exchange a GitHub Actions OIDC token for temporary STS credentials.
+
 Usage:
     export ID_TOKEN=<github-oidc-token>
     python3 scripts/sts_oidc.py \
@@ -40,15 +43,12 @@ def main():
     try:
         from alibabacloud_credentials.client import Client as CredClient
         from alibabacloud_credentials.models import Config as CredConfig
-        from alibabacloud_sts20150401.client import Client as StsClient
-        from alibabacloud_sts20150401 import models as sts_models
-        from alibabacloud_tea_openapi import models as open_api_models
     except ImportError as e:
         print(f"ERROR: Missing dependency: {e}", file=sys.stderr)
-        print("Run: pip install alibabacloud_sts20150401 alibabacloud_credentials", file=sys.stderr)
+        print("Run: pip install alibabacloud_credentials", file=sys.stderr)
         sys.exit(1)
 
-    # Create credential client using OIDC role ARN type
+    # Use OIDC credential type — automatically calls AssumeRoleWithOIDC
     cred_config = CredConfig(
         type="oidc_role_arn",
         oidc_provider_arn=args.oidc_provider_arn,
@@ -57,34 +57,19 @@ def main():
         role_session_name=args.session_name,
         role_session_expiration=args.duration_seconds,
     )
-    cred_client = CredClient(config=cred_config)
-
-    # Use the credential client to create STS client
-    config = open_api_models.Config(
-        credential=cred_client,
-        region_id="cn-guangzhou",
-    )
-    client = StsClient(config=config)
-
-    req = sts_models.AssumeRoleWithOIDCRequest(
-        role_arn=args.role_arn,
-        oidc_provider_arn=args.oidc_provider_arn,
-        role_session_name=args.session_name,
-        duration_seconds=args.duration_seconds,
-        oidc_token=id_token,
-    )
 
     try:
-        resp = client.assume_role_with_oidc(req)
+        cred_client = CredClient(config=cred_config)
+        # get_credential() triggers the OIDC → STS exchange
+        credential = cred_client.get_credential()
     except Exception as e:
-        print(f"ERROR: STS AssumeRoleWithOIDC failed: {e}", file=sys.stderr)
+        print(f"ERROR: Failed to obtain STS credentials: {e}", file=sys.stderr)
         sys.exit(1)
 
-    creds = resp.body.credentials
     result = {
-        "AccessKeyId": creds.access_key_id,
-        "AccessKeySecret": creds.access_key_secret,
-        "SecurityToken": creds.security_token,
+        "AccessKeyId": credential.access_key_id,
+        "AccessKeySecret": credential.access_key_secret,
+        "SecurityToken": credential.security_token,
     }
     print(json.dumps(result))
 


### PR DESCRIPTION
## 问题

Release workflow 在 `fix/oss-upload-debug` 分支上无法通过 tag push 触发，且 OSS upload 步骤持续失败。

## 根因与修复

### 1. YAML 语法错误（导致所有 tag-triggered run 0s 失败）
多行 Python 代码嵌入 `run: |` 块时缺少必要缩进，YAML parser 将其误认为新的 mapping key。
- **修复**：提取为独立脚本 `scripts/sts_oidc.py`

### 2. ID_TOKEN 未 export
OIDC token 仅作为 shell 变量存在，Python 子进程通过 `os.environ` 读不到。
- **修复**：`export ID_TOKEN=...`

### 3. alibabacloud_tea_openapi.models.CredentialConfig 不存在
SDK API 变更导致 `CredentialConfig` 类已移除。
- **修复**：改用 `alibabacloud_credentials` 库的 `type='oidc_role_arn'` 方式，自动完成 OIDC→STS 交换

### 4. ossutil 不读取环境变量
ossutil 不会自动识别 `OSS_ACCESS_KEY_ID` 等环境变量。
- **修复**：通过 `-i/-k/-t` 命令行参数显式传入 STS 凭证

## 验证

已在分支上通过 `v0.3.21-test` tag 触发完整 release workflow，5 个 job 全部通过：
- ✅ Smoke test (Windows x64)
- ✅ Smoke test (macOS arm64)
- ✅ Build Windows x64
- ✅ Build macOS arm64
- ✅ Upload to Alibaba Cloud OSS

Run: https://github.com/zhuzhaoyun/Molio/actions/runs/27634186450