### PR TITLE
fix(web): graph double-click now correctly navigates to file in knowledge base

### DIFF
--- a/apps/web/e2e/knowledge.spec.ts
+++ b/apps/web/e2e/knowledge.spec.ts
@@ -99,4 +99,23 @@ test.describe('Knowledge Base', () => {
     const mainContent = page.locator('.kb-main');
     await expect(mainContent).toBeVisible({ timeout: 5_000 });
   });
+
+  test('file is selected when navigated via URL params', async ({ page }) => {
+    await gotoHome(page);
+    await clickNav(page, 'knowledge');
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await page.waitForTimeout(1000);
+
+    // Navigate directly with URL params (same pendingUrlNav mechanism
+    // used by the location.state handler for graph double-click navigation)
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}&file=test.md`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+
+    // Wait for file tree to load and file to be selected (and cleared from URL)
+    await expect(page).toHaveURL(/knowledge$/, { timeout: 10_000 });
+
+    // The file content should be rendered in the main area
+    const mainContent = page.locator('.kb-main');
+    await expect(mainContent).toContainText('Test', { timeout: 10_000 });
+  });
 });

--- a/apps/web/src/components/graph/GraphPage.tsx
+++ b/apps/web/src/components/graph/GraphPage.tsx
@@ -437,7 +437,7 @@ export function GraphPage() {
         if (isDoubleClick) {
           const path = graph.getNodeAttribute(node, 'path') as string | undefined;
           if (path) {
-            navigate('/knowledge', { state: { openFile: path } });
+            navigate('/knowledge', { state: { openFile: path, vaultId: activeVaultId } });
           }
           lastClickTime = 0;
           lastClickNode = null;

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import type { TreeNode } from '@molio/contracts';
 import { useKnowledge } from '../../hooks/useKnowledge';
 import { useWikiChat } from '../../hooks/useWikiChat';
@@ -43,6 +43,8 @@ export function KnowledgeBasePage({ agentId }: KnowledgeBasePageProps) {
   const kb = useKnowledge();
   const tabs = useKbTabs();
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const navigate = useNavigate();
   const [showChatPanel, setShowChatPanel] = useState(false);
   const [pendingUrlNav, setPendingUrlNav] = useState<UrlFileNavigation | null>(null);
 
@@ -57,6 +59,21 @@ export function KnowledgeBasePage({ agentId }: KnowledgeBasePageProps) {
     // Clear query params after handling (keeps URL clean)
     setSearchParams({}, { replace: true });
   }, [searchParams, kb.vaults, kb.activeVault?.id, setSearchParams]);
+
+  // Handle location.state for in-app navigation (e.g., from graph double-click)
+  useEffect(() => {
+    const state = location.state as { openFile?: string; vaultId?: string } | null;
+    if (!state?.openFile) return;
+    if (kb.vaults.length === 0) return;
+
+    const vaultId = state.vaultId || kb.activeVault?.id || kb.vaults[0]?.id;
+    if (!vaultId) return;
+
+    setPendingUrlNav({ vaultId, filePath: state.openFile });
+    vaultStore.setActiveVaultId(vaultId);
+    // Clear state to prevent re-processing on re-renders
+    navigate('.', { replace: true, state: {} });
+  }, [location.state, kb.vaults, kb.activeVault?.id, navigate]);
 
   useEffect(() => {
     if (!pendingUrlNav) return;


### PR DESCRIPTION
## 问题

知识图谱双击节点后，跳转到了知识库页面，但没有打开对应的文件。

## 根因

[GraphPage.tsx:440](apps/web/src/components/graph/GraphPage.tsx#L440) 双击节点时通过 React Router 的 `state` 传递文件路径：

```typescript
navigate("/knowledge", { state: { openFile: path } });
```

但 [KnowledgeBasePage.tsx](apps/web/src/components/kb/KnowledgeBasePage.tsx) 只处理 URL 查询参数（`?vault=<id>&file=<path>`），完全不读取 `location.state`。数据发到了 state 通道，但接收方只在 searchParams 通道上监听 — 文件路径被静默丢弃。

## 修复

| 文件 | 改动 |
|------|------|
| `GraphPage.tsx:440` | `state` 中增加 `vaultId` |
| `KnowledgeBasePage.tsx:46-76` | 新增 `useEffect` 读取 `location.state`，复用了已有的 `pendingUrlNav` 机制（与 molio:// 协议 URL 参数使用相同的两步 effect 模式） |
| `knowledge.spec.ts` | 新增 E2E 测试覆盖 URL 参数文件选择流程 |

### 数据流（修复后）

```
GraphPage 双击
  └─ navigate("/knowledge", { state: { openFile, vaultId } })
       │
       ▼
KnowledgeBasePage
  ├─ useEffect #1: 读取 location.state → setPendingUrlNav + activateVault
  │                  （新增，复刻 URL 参数的逻辑）
  └─ useEffect #2: 等待 vault + tree 就绪 → kb.selectFile(path)
                     （已有，不变）
```

## 验证

- [x] TypeScript 类型检查通过
- [x] 全部 88 个单元测试通过
- [x] E2E 测试通过（URL 参数 → 文件选择流程）
- [x] 手动复测通过