### PR TITLE
fix(e2e): mock /api/agents and /api/config in chat tests to enable composer

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
         default: ''
   pull_request:
     branches: [main]
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   e2e:

--- a/apps/web/e2e/helpers/mock-sse.ts
+++ b/apps/web/e2e/helpers/mock-sse.ts
@@ -124,6 +124,40 @@ export async function mockChatRun(page: Page, opts: MockRunOptions = {}) {
       body: JSON.stringify({ ok: true }),
     });
   });
+
+  // 5) GET /api/agents → return a fake available agent so the composer is enabled
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        agents: [
+          {
+            id: 'claude',
+            name: 'Claude',
+            available: true,
+            binary: '/usr/bin/claude',
+            source: 'path',
+            version: '1.0.0',
+            models: [],
+            installUrl: 'https://claude.ai',
+          },
+        ],
+      }),
+    });
+  });
+
+  // 6) GET /api/config → return defaultAgentId so the agent is auto-selected
+  await page.route('**/api/config', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        defaultAgentId: 'claude',
+        locale: 'zh',
+      }),
+    });
+  });
 }
 
 // ── Cleanup ────────────────────────────────────────────────────────────
@@ -137,4 +171,6 @@ export async function unmockAll(page: Page) {
   await page.unroute('**/api/runs/*/events**');
   await page.unroute('**/api/runs/*/messages');
   await page.unroute('**/api/runs/*/tool-result');
+  await page.unroute('**/api/agents');
+  await page.unroute('**/api/config');
 }


### PR DESCRIPTION


CI environments have no real AI agents installed, so /api/agents returns an empty list and the composer textarea stays disabled. This caused all chat tests to fail with 'locator.fill: element is not enabled'.

Add mocks for /api/agents (return a fake available agent) and /api/config (return defaultAgentId) in mockChatRun so the composer is enabled during chat tests. Also add corresponding unroute calls in unmockAll to clean up state.