### PR TITLE
fix: macOS/Linux auto-update — OSS manifest + platform dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,7 +437,7 @@ jobs:
 
           # Only update latest.json and latest.yml for stable releases (skip test/beta/alpha/rc)
           if echo "${VERSION}" | grep -qiE '(test|beta|alpha|rc|dirty)'; then
-            echo "⏭️  Skipping latest.json/latest.yml update — ${VERSION} is a pre-release"
+            echo "⏭️  Skipping latest.json and manifest update — ${VERSION} is a pre-release"
           else
             cat > /tmp/latest.json <<EOF
           {"version":"${VERSION}","updatedAt":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
@@ -451,26 +451,33 @@ jobs:
               --force
             echo "✅ Updated latest.json to ${VERSION}"
 
-            # Copy latest.yml from version dir to root for electron-updater generic provider.
-            # The yml's url/path fields are relative filenames (e.g. "Molio-Setup-0.3.22-windows.exe"),
-            # but files live under releases/<tag>/. We must prepend the tag directory so
-            # electron-updater resolves the correct download URL.
-            LATEST_YML="oss://${{ vars.OSS_BUCKET }}/releases/${TAG}/latest.yml"
-            ossutil cp "${LATEST_YML}" /tmp/latest-raw.yml \
-              --endpoint=${{ vars.OSS_ENDPOINT }} \
-              -i "${OSS_ACCESS_KEY_ID}" \
-              -k "${OSS_ACCESS_KEY_SECRET}" \
-              -t "${OSS_SECURITY_TOKEN}" \
-              --force
-            sed -i "s|url: |url: ${TAG}/|g; s|path: |path: ${TAG}/|g" /tmp/latest-raw.yml
-            ossutil cp /tmp/latest-raw.yml oss://${{ vars.OSS_BUCKET }}/releases/latest.yml \
-              --endpoint=${{ vars.OSS_ENDPOINT }} \
-              -i "${OSS_ACCESS_KEY_ID}" \
-              -k "${OSS_ACCESS_KEY_SECRET}" \
-              -t "${OSS_SECURITY_TOKEN}" \
-              --meta Cache-Control:no-cache \
-              --force
-            echo "✅ Updated latest.yml to ${VERSION} (paths prefixed with ${TAG}/)"
+            # Copy platform manifests from version dir to root for electron-updater generic provider.
+            # The yml's url/path fields are relative filenames, but files live under releases/<tag>/.
+            # We must prepend the tag directory so electron-updater resolves the correct download URL.
+            for MANIFEST in latest.yml latest-mac.yml latest-linux.yml; do
+              MANIFEST_SRC="oss://${{ vars.OSS_BUCKET }}/releases/${TAG}/${MANIFEST}"
+
+              # Download from versioned directory — skip gracefully if platform not built
+              ossutil cp "${MANIFEST_SRC}" /tmp/manifest-raw.yml \
+                --endpoint=${{ vars.OSS_ENDPOINT }} \
+                -i "${OSS_ACCESS_KEY_ID}" \
+                -k "${OSS_ACCESS_KEY_SECRET}" \
+                -t "${OSS_SECURITY_TOKEN}" \
+                --force 2>/dev/null || continue
+
+              # Prefix relative url/path with version directory
+              sed -i "s|url: |url: ${TAG}/|g; s|path: |path: ${TAG}/|g" /tmp/manifest-raw.yml
+
+              ossutil cp /tmp/manifest-raw.yml "oss://${{ vars.OSS_BUCKET }}/releases/${MANIFEST}" \
+                --endpoint=${{ vars.OSS_ENDPOINT }} \
+                -i "${OSS_ACCESS_KEY_ID}" \
+                -k "${OSS_ACCESS_KEY_SECRET}" \
+                -t "${OSS_SECURITY_TOKEN}" \
+                --meta Cache-Control:no-cache \
+                --force
+
+              echo "✅ Updated ${MANIFEST} (paths prefixed with ${TAG}/)"
+            done
           fi
 
           echo "✅ Uploaded ${TAG} to oss://${{ vars.OSS_BUCKET }}/releases/${TAG}/"

--- a/apps/desktop/src/updater.js
+++ b/apps/desktop/src/updater.js
@@ -230,17 +230,44 @@ async function installDownloadedUpdate(killDaemon) {
 
   installing = true;
   setState({ status: 'installing', message: null });
-  log('info', 'updater', 'installing update (manual sequence)...');
+  log('info', 'updater', 'installing update...');
 
+  // Always kill daemon first — releases file handles on all platforms
   if (killDaemon) {
     log('info', 'updater', 'killing daemon before install...');
     await killDaemon();
   }
 
-  const installerPath = updaterState.downloadedFile;
-  log('info', 'updater', `spawning installer: ${installerPath}`);
+  if (process.platform === 'win32') {
+    // Windows: manual NSIS spawn to avoid file-lock race condition.
+    // The daemon is already dead — we spawn the installer, confirm it
+    // started, then quit Electron.
+    return spawnInstaller(updaterState.downloadedFile);
+  }
 
-  // --updated: tells the new installer this is an update (skip some prompts)
+  // macOS / Linux: delegate to electron-updater's built-in install.
+  // - macOS: quitAndInstall() mounts DMG, copies .app, relaunches
+  // - Linux: quitAndInstall() handles AppImage/deb
+  // quitAndInstall(isSilent=true, isForceRunAfterUpdate=true):
+  //   isSilent — no user prompts
+  //   isForceRunAfterUpdate — auto-restart after install
+  log('info', 'updater', `delegating install to quitAndInstall (platform=${process.platform})`);
+  autoUpdater.quitAndInstall(true, true);
+  return publicState();
+}
+
+/**
+ * Spawn the Windows NSIS installer and quit the app.
+ * Extracted from installDownloadedUpdate() so the platform dispatch is explicit
+ * and each platform's install strategy is independently testable.
+ *
+ * @param {string} installerPath — path to the NSIS installer .exe
+ * @returns {Promise<object>} publicState after spawn
+ */
+function spawnInstaller(installerPath) {
+  log('info', 'updater', `spawning Windows installer: ${installerPath}`);
+
+  // --updated: tells NSIS this is an update (skip some prompts)
   // /S: silent install (no user interaction)
   // --force-run: restart app after install completes
   const args = ['--updated', '/S', '--force-run'];

--- a/apps/desktop/test/updater/updater-install-dispatch.test.js
+++ b/apps/desktop/test/updater/updater-install-dispatch.test.js
@@ -1,0 +1,141 @@
+/**
+ * Tests for the platform-specific install dispatch logic in updater.js.
+ *
+ * These are STRUCTURAL tests — they read updater.js as text and verify
+ * the platform branching and spawnInstaller extraction are correct.
+ * This catches regressions where someone accidentally:
+ * - calls quitAndInstall() on Windows (file-lock race)
+ * - calls spawn(DMG) on macOS (DMG is not executable)
+ * - removes the platform check
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const updaterJs = readFileSync(
+  path.resolve(import.meta.dirname, '../../src/updater.js'),
+  'utf-8'
+);
+
+// ── Platform dispatch structure ────────────────────────────────
+
+describe('installDownloadedUpdate: must dispatch by platform', () => {
+  it('should check process.platform for win32', () => {
+    assert.ok(
+      updaterJs.includes("process.platform === 'win32'") ||
+        updaterJs.includes('process.platform === "win32"'),
+      'installDownloadedUpdate must branch on process.platform === "win32"'
+    );
+  });
+
+  it('should call killDaemon on ALL platforms (before platform branch)', () => {
+    const fnStart = updaterJs.indexOf('async function installDownloadedUpdate');
+    assert.ok(fnStart !== -1, 'installDownloadedUpdate function must exist');
+
+    const win32CheckPos = updaterJs.indexOf('win32', fnStart);
+    const killDaemonCallPos = updaterJs.indexOf('await killDaemon()', fnStart);
+
+    assert.ok(killDaemonCallPos !== -1, 'must call await killDaemon()');
+    assert.ok(
+      killDaemonCallPos < win32CheckPos,
+      'killDaemon must be called BEFORE the win32 platform check (all platforms)'
+    );
+  });
+});
+
+// ── Windows path: spawnInstaller ────────────────────────────────
+
+describe('spawnInstaller: Windows NSIS path', () => {
+  it('should be defined as a separate function', () => {
+    assert.ok(
+      updaterJs.includes('function spawnInstaller('),
+      'spawnInstaller must be extracted as a standalone function'
+    );
+  });
+
+  it('should use NSIS-specific flags', () => {
+    assert.ok(
+      updaterJs.includes("'--updated'") || updaterJs.includes('"--updated"'),
+      'spawnInstaller must pass --updated flag'
+    );
+    assert.ok(
+      updaterJs.includes("'/S'") || updaterJs.includes('"/S"'),
+      'spawnInstaller must pass /S flag (silent install)'
+    );
+    assert.ok(
+      updaterJs.includes("'--force-run'") || updaterJs.includes('"--force-run"'),
+      'spawnInstaller must pass --force-run flag'
+    );
+  });
+
+  it('should spawn with detached:true', () => {
+    assert.ok(
+      updaterJs.includes('detached: true') || updaterJs.includes('detached:true'),
+      'installer must be spawned with detached:true'
+    );
+  });
+
+  it('should call app.quit() after spawn is confirmed', () => {
+    const appQuitLines = updaterJs.split('\n').filter(line =>
+      /\s+app\.quit\(\)/.test(line) && !line.trim().startsWith('//') && !line.trim().startsWith('*')
+    );
+    assert.ok(
+      appQuitLines.length > 0,
+      'spawnInstaller must call app.quit() in code (not just comments)'
+    );
+  });
+
+  it('should handle spawn errors', () => {
+    assert.ok(
+      updaterJs.includes("installer.once('error'") || updaterJs.includes("installer.on('error'"),
+      'spawnInstaller must handle spawn errors'
+    );
+  });
+
+  it('should NOT call quitAndInstall in the Windows path', () => {
+    const win32Pos = updaterJs.indexOf("process.platform === 'win32'");
+    const quitAndInstallPos = updaterJs.indexOf('autoUpdater.quitAndInstall(');
+    assert.ok(
+      quitAndInstallPos > win32Pos,
+      'quitAndInstall() must appear AFTER the win32 check (macOS/Linux branch only)'
+    );
+  });
+});
+
+// ── macOS/Linux path: quitAndInstall ────────────────────────────
+
+describe('macOS/Linux path: quitAndInstall delegation', () => {
+  it('should call autoUpdater.quitAndInstall', () => {
+    assert.ok(
+      /autoUpdater\.quitAndInstall\s*\(/.test(updaterJs),
+      'macOS/Linux path must call autoUpdater.quitAndInstall()'
+    );
+  });
+
+  it('should pass silent and force-run arguments', () => {
+    assert.ok(
+      updaterJs.includes('quitAndInstall(true, true)'),
+      'quitAndInstall must be called with (true, true) — silent install + force restart'
+    );
+  });
+});
+
+// ── installDownloadedUpdate guards (unchanged from existing) ────
+
+describe('installDownloadedUpdate: guard checks preserved', () => {
+  it('should check installing flag to prevent double install', () => {
+    assert.ok(
+      updaterJs.includes('if (installing) return'),
+      'must guard against double install with installing flag'
+    );
+  });
+
+  it('should check downloadedFile exists', () => {
+    assert.ok(
+      updaterJs.includes('!updaterState.downloadedFile'),
+      'must check downloadedFile exists before installing'
+    );
+  });
+});

--- a/apps/desktop/test/updater/updater-structure.test.js
+++ b/apps/desktop/test/updater/updater-structure.test.js
@@ -94,20 +94,41 @@ describe('main.js: global crash protection must exist', () => {
   });
 });
 
-describe('updater.js: must NOT use quitAndInstall (race condition on Windows)', () => {
+describe('updater.js: must NOT use quitAndInstall on Windows path', () => {
   const updaterJs = readFileSync(
     path.resolve(import.meta.dirname, '../../src/updater.js'),
     'utf-8'
   );
 
-  it('should NOT call autoUpdater.quitAndInstall()', () => {
-    // quitAndInstall() spawns the NSIS installer before app.quit(), causing
-    // "Failed to uninstall old application files" because Electron still
-    // holds file locks. We spawn the installer manually instead.
+  it('should call quitAndInstall() only on non-Windows path', () => {
+    // quitAndInstall() is safe on macOS/Linux (install happens AFTER Electron exits).
+    // On Windows, the manual NSIS spawn in spawnInstaller() avoids the file-lock race.
+    // Verify the call exists AND is guarded by a non-win32 platform check.
     const hasQuitAndInstallCall = /autoUpdater\.quitAndInstall\s*\(/.test(updaterJs);
     assert.ok(
-      !hasQuitAndInstallCall,
-      'updater.js must NOT call autoUpdater.quitAndInstall() — it has a race condition on Windows'
+      hasQuitAndInstallCall,
+      'updater.js must call autoUpdater.quitAndInstall() for macOS/Linux'
+    );
+
+    // Verify the call is NOT reachable on Windows — it must be AFTER a platform check
+    const win32CheckPos = updaterJs.indexOf("process.platform === 'win32'");
+    const quitAndInstallPos = updaterJs.indexOf('autoUpdater.quitAndInstall(');
+    assert.ok(win32CheckPos !== -1, 'must have process.platform check');
+    assert.ok(quitAndInstallPos !== -1, 'must call quitAndInstall');
+    assert.ok(
+      quitAndInstallPos > win32CheckPos,
+      'quitAndInstall() call must appear AFTER the win32 platform check (i.e., in the non-Windows branch)'
+    );
+  });
+
+  it('should have spawnInstaller for Windows path', () => {
+    assert.ok(
+      updaterJs.includes('function spawnInstaller'),
+      'updater.js must extract Windows NSIS logic into spawnInstaller()'
+    );
+    assert.ok(
+      updaterJs.includes("'--updated'") && updaterJs.includes("'/S'") && updaterJs.includes("'--force-run'"),
+      'spawnInstaller must use NSIS-specific flags'
     );
   });
 
@@ -379,6 +400,43 @@ describe('preload.cjs: must expose onUpdateError', () => {
     assert.ok(
       preloadCjs.includes("'updater:error'") || preloadCjs.includes('"updater:error"'),
       "preload.cjs must listen for 'updater:error' IPC event"
+    );
+  });
+});
+
+describe('release.yml: must promote all three platform manifests to OSS root', () => {
+  const releaseYml = readFileSync(
+    path.resolve(import.meta.dirname, '../../../../.github/workflows/release.yml'),
+    'utf-8'
+  );
+
+  it('should loop over all three manifests', () => {
+    assert.ok(
+      releaseYml.includes('latest.yml') && releaseYml.includes('latest-mac.yml') && releaseYml.includes('latest-linux.yml'),
+      'release.yml must reference latest.yml, latest-mac.yml, and latest-linux.yml'
+    );
+    assert.ok(
+      releaseYml.includes('latest-mac.yml') && releaseYml.includes('latest-linux.yml'),
+      'release.yml must promote latest-mac.yml and latest-linux.yml (not just latest.yml)'
+    );
+  });
+
+  it('should use || continue for graceful skip', () => {
+    assert.ok(
+      releaseYml.includes('|| continue'),
+      'release.yml manifest loop must use || continue to skip unbuilt platforms'
+    );
+  });
+
+  it('should apply sed path prefix to all manifests', () => {
+    // The sed command must exist inside the manifest loop
+    assert.ok(
+      releaseYml.includes('s|url: |url: ${TAG}/|g'),
+      'release.yml must have sed path prefix for url field'
+    );
+    assert.ok(
+      releaseYml.includes('s|path: |path: ${TAG}/|g'),
+      'release.yml must have sed path prefix for path field'
     );
   });
 });


### PR DESCRIPTION
## 问题

非 Windows 平台（macOS、Linux）自动更新全链路不可用，两个独立 bug：

1. **OSS 未推送 latest-mac.yml / latest-linux.yml**：release.yml 只处理了 Windows 的 latest.yml，macOS/Linux 的 manifest 被忽略，导致客户端检查更新时 404
2. **安装逻辑硬编码 NSIS**：installDownloadedUpdate() 使用 NSIS 专用参数 spawn 安装器，macOS 上 DMG 不是可执行文件，Linux 上 AppImage/deb 也不是 NSIS 格式

## 修复

### Bug 1: release.yml — 三平台 manifest 循环

将单 manifest 逻辑（latest.yml 硬编码）改为 for 循环处理 latest.yml、latest-mac.yml、latest-linux.yml，用 `|| continue` 优雅跳过未构建平台。

### Bug 2: updater.js — 平台分发安装逻辑

installDownloadedUpdate() 按 `process.platform` 分发：
- **Windows**：保留原有 NSIS spawn 逻辑（提取为 spawnInstaller()），避免文件锁竞态
- **macOS/Linux**：委托给 autoUpdater.quitAndInstall(true, true)，利用 electron-updater 内置的 DMG 挂载/AppImage 处理
- **所有平台统一**先 kill daemon 再安装

## 测试

- 104/104 结构测试通过（含 12 个新增分发逻辑测试 + OSS manifest 断言）
- macOS 实机日志确认：updater 正常启动、检查更新、404 后指数退避重试