### PR TITLE
fix(ci): make OCR_LLM_USE_ANTHROPIC optional in ocr-review workflow

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -91,10 +91,15 @@ jobs:
 
       - name: Configure OCR
         run: |
-          ocr config set llm.url ${{ secrets.OCR_LLM_URL }}
-          ocr config set llm.auth_token ${{ secrets.OCR_LLM_AUTH_TOKEN }}
-          ocr config set llm.model ${{ secrets.OCR_LLM_MODEL }}
-          ocr config set llm.use_anthropic ${{ secrets.OCR_LLM_USE_ANTHROPIC }}
+          # Quote values so empty secrets don't collapse into a missing argument.
+          # OCR_LLM_USE_ANTHROPIC is optional — only set when configured, otherwise
+          # `ocr config set llm.use_anthropic` with no value fails the step.
+          ocr config set llm.url "${{ secrets.OCR_LLM_URL }}"
+          ocr config set llm.auth_token "${{ secrets.OCR_LLM_AUTH_TOKEN }}"
+          ocr config set llm.model "${{ secrets.OCR_LLM_MODEL }}"
+          if [ -n "${{ secrets.OCR_LLM_USE_ANTHROPIC }}" ]; then
+            ocr config set llm.use_anthropic "${{ secrets.OCR_LLM_USE_ANTHROPIC }}"
+          fi
           ocr config set llm.extra_body '{"thinking": {"type": "disabled"}}'
 
       - name: Run OpenCodeReview


### PR DESCRIPTION
## Summary

- PR #100 的 Open Code Review check 失败，根因是 Configure OCR 步骤里 `ocr config set llm.use_anthropic \${{ secrets.OCR_LLM_USE_ANTHROPIC }}` 在该 secret 未配置时被 shell 展开为空，OCR CLI 收到缺 value 的命令直接退出（`Error: usage: ocr config set <key> <value>`）。
- `OCR_LLM_USE_ANTHROPIC` 在 workflow 注释里本就是 optional（只有用 Claude 模型时才设为 `true`），不应让缺省导致 CI fail。
- 修复：对所有 `ocr config set` 加引号防止空值丢参数；对 `use_anthropic` 用 `if [ -n ... ]` 守卫，未配置时跳过该 set。

## Test plan

- [ ] 合并后对 PR #100 重新触发 OCR review（评论 \`/open-code-review\`），确认 Configure OCR 步骤通过、后续 review 正常生成。
- [ ] 后续带 Anthropic 模型的 PR（secret 配置为 \`true\`）也能正常 set。