### PR TITLE
fix(web): keep wiki chat alive across page switches

### DIFF
--- a/apps/daemon/src/core/config.ts
+++ b/apps/daemon/src/core/config.ts
@@ -2,10 +2,18 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
-const CONFIG_DIR = path.join(os.homedir(), '.molio');
-const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
-const CLAUDE_DIR = path.join(os.homedir(), '.claude');
-const CLAUDE_SETTINGS_FILE = path.join(CLAUDE_DIR, 'settings.json');
+function getConfigDir(): string {
+  return path.join(os.homedir(), '.molio');
+}
+function getConfigFile(): string {
+  return path.join(getConfigDir(), 'config.json');
+}
+function getClaudeDir(): string {
+  return path.join(os.homedir(), '.claude');
+}
+function getClaudeSettingsFile(): string {
+  return path.join(getClaudeDir(), 'settings.json');
+}
 const CLAUDE_MANAGED_ENV_KEYS = new Set([
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN',
@@ -51,10 +59,11 @@ interface ClaudeSettingsFile {
 
 export function loadConfig(): AppConfig {
   try {
-    if (!fs.existsSync(CONFIG_FILE)) {
+    const configFile = getConfigFile();
+    if (!fs.existsSync(configFile)) {
       return { ...DEFAULT_CONFIG };
     }
-    const raw = fs.readFileSync(CONFIG_FILE, 'utf8');
+    const raw = fs.readFileSync(configFile, 'utf8');
     const parsed = JSON.parse(raw);
     return {
       ...DEFAULT_CONFIG,
@@ -69,12 +78,14 @@ export function loadConfig(): AppConfig {
 
 export function saveConfig(config: AppConfig): void {
   try {
-    if (!fs.existsSync(CONFIG_DIR)) {
-      fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    const configDir = getConfigDir();
+    const configFile = getConfigFile();
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
     }
-    const tmpFile = CONFIG_FILE + '.tmp';
+    const tmpFile = configFile + '.tmp';
     fs.writeFileSync(tmpFile, JSON.stringify(config, null, 2), 'utf8');
-    fs.renameSync(tmpFile, CONFIG_FILE);
+    fs.renameSync(tmpFile, configFile);
   } catch (err) {
     console.error('Failed to save config:', err);
     throw err;
@@ -155,7 +166,7 @@ export function buildAgentEnv(agentId: string, agentConfig: AgentConfig): Record
 }
 
 function loadClaudeSettingsEnv(): Record<string, string> | null {
-  const settings = readJsonFile<ClaudeSettingsFile>(CLAUDE_SETTINGS_FILE);
+  const settings = readJsonFile<ClaudeSettingsFile>(getClaudeSettingsFile());
   if (!settings?.env || typeof settings.env !== 'object') return null;
 
   const env: Record<string, string> = {};
@@ -167,7 +178,8 @@ function loadClaudeSettingsEnv(): Record<string, string> | null {
 }
 
 function saveClaudeSettingsEnv(agentEnv: Record<string, string>): void {
-  const settings = readJsonFile<ClaudeSettingsFile>(CLAUDE_SETTINGS_FILE) ?? {};
+  const claudeSettingsFile = getClaudeSettingsFile();
+  const settings = readJsonFile<ClaudeSettingsFile>(claudeSettingsFile) ?? {};
   const existingEnv = settings.env && typeof settings.env === 'object'
     ? { ...settings.env }
     : {};
@@ -190,7 +202,7 @@ function saveClaudeSettingsEnv(agentEnv: Record<string, string>): void {
     delete nextSettings.env;
   }
 
-  writeJsonFileAtomic(CLAUDE_SETTINGS_FILE, nextSettings, CLAUDE_DIR);
+  writeJsonFileAtomic(claudeSettingsFile, nextSettings, getClaudeDir());
 }
 
 function pickClaudeManagedEnv(env?: Record<string, string>): Record<string, string> {

--- a/apps/daemon/test/core/config.test.ts
+++ b/apps/daemon/test/core/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, afterEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -99,49 +99,38 @@ describe('Config module', () => {
   });
 
   describe('mergeConfig', () => {
-    const configFile = path.join(os.homedir(), '.molio', 'config.json');
-    const claudeSettingsFile = path.join(os.homedir(), '.claude', 'settings.json');
-    let originalConfig: string | null = null;
-    let originalClaudeSettings: string | null = null;
+    let tempHome: string | null = null;
+    let originalHome: string | undefined;
+    let originalUserProfile: string | undefined;
 
-    afterEach(() => {
-      // Restore original config after each test
-      try {
-        if (originalConfig !== null) {
-          if (originalConfig === '') {
-            fs.unlinkSync(configFile);
-          } else {
-            fs.writeFileSync(configFile, originalConfig, 'utf8');
-          }
-        }
-      } catch { /* ignore */ }
-      try {
-        if (originalClaudeSettings !== null) {
-          fs.mkdirSync(path.dirname(claudeSettingsFile), { recursive: true });
-          if (originalClaudeSettings === '') {
-            fs.unlinkSync(claudeSettingsFile);
-          } else {
-            fs.writeFileSync(claudeSettingsFile, originalClaudeSettings, 'utf8');
-          }
-        }
-      } catch { /* ignore */ }
-    });
-
-    function backupConfig() {
-      try {
-        originalConfig = fs.readFileSync(configFile, 'utf8');
-      } catch {
-        originalConfig = '';
-      }
-      try {
-        originalClaudeSettings = fs.readFileSync(claudeSettingsFile, 'utf8');
-      } catch {
-        originalClaudeSettings = '';
-      }
+    function configFile(): string {
+      return path.join(os.homedir(), '.molio', 'config.json');
+    }
+    function claudeSettingsFile(): string {
+      return path.join(os.homedir(), '.claude', 'settings.json');
     }
 
+    beforeEach(() => {
+      tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'molio-config-test-'));
+      originalHome = process.env.HOME;
+      originalUserProfile = process.env.USERPROFILE;
+      process.env.HOME = tempHome;
+      process.env.USERPROFILE = tempHome;
+    });
+
+    afterEach(() => {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      if (tempHome) {
+        fs.rmSync(tempHome, { recursive: true, force: true });
+      }
+      tempHome = null;
+    });
+
     function setupBaseConfig(agents: AppConfig['agents']) {
-      fs.mkdirSync(path.dirname(configFile), { recursive: true });
+      fs.mkdirSync(path.dirname(configFile()), { recursive: true });
       saveConfig({
         agents: agents ?? {},
         defaultAgentId: 'claude',
@@ -149,7 +138,6 @@ describe('Config module', () => {
     }
 
     it('should preserve agents when partial update does not include agents', () => {
-      backupConfig();
       setupBaseConfig({
         claude: {
           env: {
@@ -169,7 +157,6 @@ describe('Config module', () => {
     });
 
     it('should merge agents at per-agent level', () => {
-      backupConfig();
       setupBaseConfig({
         claude: {
           env: { ANTHROPIC_AUTH_TOKEN: 'sk-claude-key' },
@@ -196,7 +183,6 @@ describe('Config module', () => {
     });
 
     it('should preserve agents when partial update sends only locale', () => {
-      backupConfig();
       setupBaseConfig({
         claude: {
           env: { ANTHROPIC_AUTH_TOKEN: 'sk-key' },
@@ -213,7 +199,6 @@ describe('Config module', () => {
     });
 
     it('should prefer ~/.claude/settings.json env for claude agent reads', () => {
-      backupConfig();
       setupBaseConfig({
         claude: {
           env: {
@@ -222,8 +207,8 @@ describe('Config module', () => {
           },
         },
       });
-      fs.mkdirSync(path.dirname(claudeSettingsFile), { recursive: true });
-      fs.writeFileSync(claudeSettingsFile, JSON.stringify({
+      fs.mkdirSync(path.dirname(claudeSettingsFile()), { recursive: true });
+      fs.writeFileSync(claudeSettingsFile(), JSON.stringify({
         env: {
           ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'deepseek-v4-pro[1M]',
@@ -240,10 +225,9 @@ describe('Config module', () => {
     });
 
     it('should persist claude env to ~/.claude/settings.json without clobbering other settings', () => {
-      backupConfig();
       setupBaseConfig({});
-      fs.mkdirSync(path.dirname(claudeSettingsFile), { recursive: true });
-      fs.writeFileSync(claudeSettingsFile, JSON.stringify({
+      fs.mkdirSync(path.dirname(claudeSettingsFile()), { recursive: true });
+      fs.writeFileSync(claudeSettingsFile(), JSON.stringify({
         enabledPlugins: { foo: true },
         theme: 'auto',
         env: {
@@ -264,7 +248,7 @@ describe('Config module', () => {
         },
       });
 
-      const saved = JSON.parse(fs.readFileSync(claudeSettingsFile, 'utf8'));
+      const saved = JSON.parse(fs.readFileSync(claudeSettingsFile(), 'utf8'));
       assert.equal(saved.theme, 'auto');
       assert.equal(saved.enabledPlugins.foo, true);
       assert.equal(saved.env.KEEP_ME, 'yes');
@@ -274,7 +258,6 @@ describe('Config module', () => {
     });
 
     it('should clean managed Claude env keys from ~/.molio/config.json after save', () => {
-      backupConfig();
       setupBaseConfig({});
 
       setAgentConfig('claude', {
@@ -294,7 +277,6 @@ describe('Config module', () => {
     });
 
     it('should migrate legacy Claude env from ~/.molio/config.json into ~/.claude/settings.json on read', () => {
-      backupConfig();
       setupBaseConfig({
         claude: {
           env: {
@@ -311,7 +293,7 @@ describe('Config module', () => {
       assert.equal(agentConfig.env?.['ANTHROPIC_MODEL'], 'deepseek-v4-pro');
       assert.equal(agentConfig.env?.['KEEP_LOCAL'], 'legacy-local');
 
-      const settings = JSON.parse(fs.readFileSync(claudeSettingsFile, 'utf8'));
+      const settings = JSON.parse(fs.readFileSync(claudeSettingsFile(), 'utf8'));
       assert.equal(settings.env.ANTHROPIC_BASE_URL, 'https://api.deepseek.com/anthropic');
       assert.equal(settings.env.ANTHROPIC_MODEL, 'deepseek-v4-pro');
 
@@ -322,7 +304,6 @@ describe('Config module', () => {
     });
 
     it('should clean duplicated managed Claude env keys from ~/.molio/config.json when settings.json already exists', () => {
-      backupConfig();
       setupBaseConfig({
         claude: {
           env: {
@@ -332,8 +313,8 @@ describe('Config module', () => {
           },
         },
       });
-      fs.mkdirSync(path.dirname(claudeSettingsFile), { recursive: true });
-      fs.writeFileSync(claudeSettingsFile, JSON.stringify({
+      fs.mkdirSync(path.dirname(claudeSettingsFile()), { recursive: true });
+      fs.writeFileSync(claudeSettingsFile(), JSON.stringify({
         env: {
           ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
           ANTHROPIC_MODEL: 'deepseek-v4-pro',

--- a/apps/web/e2e/area-map.json
+++ b/apps/web/e2e/area-map.json
@@ -26,11 +26,12 @@
         "apps/web/src/components/kb/*",
         "apps/web/src/hooks/useKnowledge*",
         "apps/web/src/hooks/useKbTabs*",
+        "apps/web/src/stores/kbTreeRefresh*",
         "apps/daemon/src/core/knowledge.ts",
         "apps/daemon/src/core/db.ts",
         "apps/daemon/src/routes/knowledge.ts"
       ],
-      "specs": ["create-vault-form", "knowledge", "markdown-render"]
+      "specs": ["create-vault-form", "knowledge", "markdown-render", "wiki-chat-persist"]
     },
     "publish": {
       "paths": [
@@ -101,6 +102,7 @@
     "publish-flow": { "priority": "P0", "file": "publish-flow.spec.ts" },
     "runtime-provider-config": { "priority": "P1", "file": "runtime-provider-config.spec.ts" },
     "runtimes-page": { "priority": "P1", "file": "runtimes-page.spec.ts" },
-    "settings": { "priority": "P1", "file": "settings.spec.ts" }
+    "settings": { "priority": "P1", "file": "settings.spec.ts" },
+    "wiki-chat-persist": { "priority": "P1", "file": "wiki-chat-persist.spec.ts" }
   }
 }

--- a/apps/web/e2e/wiki-chat-persist.spec.ts
+++ b/apps/web/e2e/wiki-chat-persist.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { gotoHome, clickNav } from './helpers/navigation';
+import { createTempVault, cleanupTempVault, type TempVault } from './helpers/cleanup';
+import { mockChatRun, unmockAll } from './helpers/mock-sse';
+
+/**
+ * @area kb
+ * @priority P1
+ *
+ * Regression for https://github.com/zhuzhaoyun/Molio/issues/72
+ *
+ * Wiki chat panel must survive page switches: the underlying run keeps
+ * streaming on the daemon side, and when the user returns to /knowledge
+ * the panel reappears with the in-progress conversation intact.
+ *
+ * Prerequisites: `pnpm dev` running (daemon :3100, web :5173)
+ */
+
+let vault: TempVault;
+
+test.describe('Wiki chat panel — page switch persistence', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-wiki-persist');
+  });
+
+  test.afterAll(async () => {
+    if (vault) await cleanupTempVault(vault);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await unmockAll(page);
+  });
+
+  test('panel stays open with progress after navigating away and back', async ({ page }) => {
+    await gotoHome(page);
+    await clickNav(page, 'knowledge');
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+
+    // Ensure a vault is active so the "构建 Wiki" toolbar button renders.
+    // The test vault was registered via the daemon API in beforeAll; we
+    // open the vault switcher and pick it. Wait for the vault list to load
+    // first (useKnowledge fetches on mount).
+    await page.locator('.kb-vault-bar').click();
+    const vaultItem = page.locator('.vm-vault-item').filter({ hasText: vault.name });
+    await expect(vaultItem).toBeVisible({ timeout: 10_000 });
+    await vaultItem.click();
+    // Wait for the file panel to reflect the active vault
+    await expect(page.locator('button[title="构建 Wiki"]')).toBeVisible({ timeout: 5_000 });
+
+    // Mock the wiki run with a script that emits a text delta but never
+    // sends turn_end/usage — so isRunning stays true throughout the test.
+    await mockChatRun(page, {
+      runId: 'run-wiki-persist',
+      convId: 'conv-wiki-persist',
+      script: [
+        { type: 'status', label: 'running', model: 'claude-sonnet-4-5' },
+        { type: 'text_delta', delta: 'Ingesting knowledge base...' },
+      ],
+    });
+
+    // Trigger a wiki operation via the "构建 Wiki" toolbar button.
+    const buildBtn = page.locator('button[title="构建 Wiki"]').first();
+    await buildBtn.click();
+
+    // Chat panel should slide in and show the streaming message.
+    const panel = page.locator('.wiki-chat-panel');
+    await expect(panel).toBeVisible({ timeout: 3_000 });
+    await expect(panel.locator('.wiki-chat-status')).toHaveText(/运行中/);
+    await expect(panel.locator('[data-testid="assistant-message"]').first()).toContainText('Ingesting knowledge base');
+
+    // Navigate away to Home — panel should disappear from the screen
+    // (it's only rendered inside KnowledgeBasePage) but the run continues.
+    await clickNav(page, 'home');
+    await expect(page.locator('.wiki-chat-panel')).toHaveCount(0);
+
+    // Navigate back to /knowledge — panel must reappear with the same
+    // conversation and still be running.
+    await clickNav(page, 'knowledge');
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+
+    const panelAfter = page.locator('.wiki-chat-panel');
+    await expect(panelAfter).toBeVisible({ timeout: 3_000 });
+    await expect(panelAfter.locator('.wiki-chat-status')).toHaveText(/运行中/);
+    await expect(panelAfter.locator('[data-testid="assistant-message"]').first()).toContainText('Ingesting knowledge base');
+  });
+});

--- a/apps/web/e2e/wiki-chat-persist.spec.ts
+++ b/apps/web/e2e/wiki-chat-persist.spec.ts
@@ -32,6 +32,19 @@ test.describe('Wiki chat panel — page switch persistence', () => {
   });
 
   test('panel stays open with progress after navigating away and back', async ({ page }) => {
+    // Mock the wiki run with a script that emits a text delta but never
+    // sends turn_end/usage — so isRunning stays true throughout the test.
+    // Set up before gotoHome so /api/agents and /api/config are mocked when
+    // App resolves selectedAgent (otherwise handleBuildWiki no-ops on null agentId).
+    await mockChatRun(page, {
+      runId: 'run-wiki-persist',
+      convId: 'conv-wiki-persist',
+      script: [
+        { type: 'status', label: 'running', model: 'claude-sonnet-4-5' },
+        { type: 'text_delta', delta: 'Ingesting knowledge base...' },
+      ],
+    });
+
     await gotoHome(page);
     await clickNav(page, 'knowledge');
     await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
@@ -46,17 +59,6 @@ test.describe('Wiki chat panel — page switch persistence', () => {
     await vaultItem.click();
     // Wait for the file panel to reflect the active vault
     await expect(page.locator('button[title="构建 Wiki"]')).toBeVisible({ timeout: 5_000 });
-
-    // Mock the wiki run with a script that emits a text delta but never
-    // sends turn_end/usage — so isRunning stays true throughout the test.
-    await mockChatRun(page, {
-      runId: 'run-wiki-persist',
-      convId: 'conv-wiki-persist',
-      script: [
-        { type: 'status', label: 'running', model: 'claude-sonnet-4-5' },
-        { type: 'text_delta', delta: 'Ingesting knowledge base...' },
-      ],
-    });
 
     // Trigger a wiki operation via the "构建 Wiki" toolbar button.
     const buildBtn = page.locator('button[title="构建 Wiki"]').first();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import { useAgents } from './hooks/useAgents';
 import { useChat } from './hooks/useChat';
@@ -14,6 +14,7 @@ import { LanguageProvider } from './i18n/LanguageProvider';
 import type { Locale } from './i18n';
 import { api } from './api/client';
 import { useActiveVault, vaultStore } from './stores/vaultStore';
+import { kbTreeRefreshStore } from './stores/kbTreeRefresh';
 import './styles/rail.css';
 import './styles/home.css';
 import './styles/knowledge.css';
@@ -36,6 +37,19 @@ export default function App() {
   const [locale, setLocale] = useState<Locale>('zh');
   const [configLoaded, setConfigLoaded] = useState(false);
   const chat = useChat({ agentId: selectedAgent, cwd: activeVault?.path });
+
+  // Wiki chat lives at App level so background ingest/build/lint runs survive
+  // route switches (e.g. user navigating to Home and back to /knowledge).
+  // The chat panel itself still only renders inside KnowledgeBasePage.
+  const [showWikiChatPanel, setShowWikiChatPanel] = useState(false);
+  const onWikiComplete = useCallback(() => kbTreeRefreshStore.refresh(), []);
+  const wikiChat = useChat({
+    agentId: selectedAgent,
+    cwd: activeVault?.path ?? null,
+    mode: 'wiki',
+    vaultId: activeVault?.id ?? null,
+    onComplete: onWikiComplete,
+  });
 
   // Persist current route on change
   useEffect(() => {
@@ -168,6 +182,9 @@ export default function App() {
             <Route path="/knowledge" element={
             <KnowledgeBasePage
               agentId={selectedAgent}
+              wikiChat={wikiChat}
+              showChatPanel={showWikiChatPanel}
+              onShowChatPanelChange={setShowWikiChatPanel}
               onOpenConversation={(conversationId) => {
                 void chat.loadConversationById(conversationId).then(() => {
                   navigate('/');

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -12,6 +12,7 @@ import { useFileChat } from '../../hooks/useFileChat';
 import { useKbTabs } from '../../hooks/useKbTabs';
 import { kbTabsStore } from '../../stores/kbTabsStore';
 import { vaultStore } from '../../stores/vaultStore';
+import { kbTreeRefreshStore } from '../../stores/kbTreeRefresh';
 import { KbFilePanel } from './KbFilePanel';
 import { KbTabBar } from './KbTabBar';
 import { KbMainContent } from './KbMainContent';
@@ -26,6 +27,12 @@ import { useI18n } from '../../i18n';
 
 interface KnowledgeBasePageProps {
   agentId: string | null;
+  /** Wiki chat hook owned by App (survives route switches). */
+  wikiChat: ReturnType<typeof useChat>;
+  /** Whether the wiki chat panel should be visible. */
+  showChatPanel: boolean;
+  /** Setter for showing/hiding the wiki chat panel. */
+  onShowChatPanelChange: (show: boolean) => void;
   onOpenConversation?: (conversationId: string) => void;
 }
 
@@ -47,18 +54,30 @@ function resolveUrlFileNavigation(
   return { vaultId, filePath };
 }
 
-export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBasePageProps) {
+export function KnowledgeBasePage({
+  agentId,
+  wikiChat,
+  showChatPanel,
+  onShowChatPanelChange,
+  onOpenConversation,
+}: KnowledgeBasePageProps) {
   const { t } = useI18n();
   const kb = useKnowledge();
   const tabs = useKbTabs();
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
-  const [showChatPanel, setShowChatPanel] = useState(false);
   const [fileChatOpen, setFileChatOpen] = useState(false);
   const [fileChatFilePath, setFileChatFilePath] = useState<string | null>(null);
   const [fileChatSelectedText, setFileChatSelectedText] = useState<string | null>(null);
   const [pendingUrlNav, setPendingUrlNav] = useState<UrlFileNavigation | null>(null);
+
+  // Register the tree refresher so App-level wikiChat.onComplete can trigger
+  // a tree refresh even after this page has been unmounted (no-op in that case).
+  useEffect(() => {
+    kbTreeRefreshStore.setRefresher(kb.refreshTree);
+    return () => kbTreeRefreshStore.setRefresher(null);
+  }, [kb.refreshTree]);
 
   // Handle ?vault=<vaultId>&file=<filePath> query params for external navigation
   // (e.g. from molio:// protocol triggered by Chrome extension after clip save)
@@ -126,17 +145,6 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
     danger?: boolean;
     onConfirm: () => void;
   }>({ show: false, title: '', message: '', onConfirm: () => {} });
-
-  // Wiki chat hook — refreshes tree on build completion
-  const wikiChat = useChat({
-    agentId,
-    cwd: kb.activeVault?.path ?? null,
-    mode: 'wiki',
-    vaultId: kb.activeVault?.id ?? null,
-    onComplete: () => {
-      kb.refreshTree();
-    },
-  });
 
   // File Q&A chat hook — independent conversation per file
   const fileChat = useFileChat({
@@ -275,37 +283,37 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
   // Wiki operation handlers
   const handleBuildWiki = useCallback(() => {
     if (!agentId) return;
-    setShowChatPanel(true);
+    onShowChatPanelChange(true);
     wikiChat.reset();
     setTimeout(() => {
       wikiChat.startWikiOperation('build', '开始构建 Wiki');
     }, 50);
-  }, [agentId, wikiChat]);
+  }, [agentId, wikiChat, onShowChatPanelChange]);
 
   const handleIngestFile = useCallback((filePath: string) => {
     if (!agentId) return;
-    setShowChatPanel(true);
+    onShowChatPanelChange(true);
     wikiChat.reset();
     setTimeout(() => {
       wikiChat.startWikiOperation('ingest', `把 ${filePath} 加入 Wiki`, { filePath });
     }, 50);
-  }, [agentId, wikiChat]);
+  }, [agentId, wikiChat, onShowChatPanelChange]);
 
   const handleLintWiki = useCallback(() => {
     if (!agentId) return;
-    setShowChatPanel(true);
+    onShowChatPanelChange(true);
     wikiChat.reset();
     setTimeout(() => {
       wikiChat.startWikiOperation('lint', '检查 Wiki 健康状况');
     }, 50);
-  }, [agentId, wikiChat]);
+  }, [agentId, wikiChat, onShowChatPanelChange]);
 
   const handleCloseChat = useCallback(() => {
-    setShowChatPanel(false);
+    onShowChatPanelChange(false);
     if (wikiChat.isRunning) {
       wikiChat.cancel();
     }
-  }, [wikiChat]);
+  }, [wikiChat, onShowChatPanelChange]);
 
   const handleCloseFileChat = useCallback(() => {
     setFileChatOpen(false);

--- a/apps/web/src/stores/kbTreeRefresh.ts
+++ b/apps/web/src/stores/kbTreeRefresh.ts
@@ -1,0 +1,22 @@
+/**
+ * Tree-refresh bridge — lets App-level wikiChat.onComplete trigger
+ * KnowledgeBasePage's kb.refreshTree() without holding a direct reference.
+ *
+ * KnowledgeBasePage registers its refreshTree on mount, clears on unmount.
+ * The App-level wikiChat hook (which lives across route switches) calls
+ * refresh() when a run completes. If the KB page is unmounted at that
+ * moment, the call is a no-op — the page will fetch a fresh tree on remount.
+ */
+
+type Refresher = () => void;
+
+let currentRefresher: Refresher | null = null;
+
+export const kbTreeRefreshStore = {
+  setRefresher(fn: Refresher | null) {
+    currentRefresher = fn;
+  },
+  refresh() {
+    currentRefresher?.();
+  },
+};


### PR DESCRIPTION
## Summary

Fixes #72.

Wiki chat (ingest/build/lint) used to die when users switched pages mid-run because `useChat({mode:'wiki'})` and `showChatPanel` lived inside `KnowledgeBasePage`, which unmounts on route change. The orphaned SSE stream kept running on the daemon but the UI lost all conversation state, so returning to /knowledge showed a closed panel and an apparently interrupted task.

- Lift `wikiChat` (mode='wiki') and `showWikiChatPanel` state up to `App.tsx` so the hook survives route switches. The panel still only renders inside `KnowledgeBasePage`, so it hides on other pages and reappears with the in-progress conversation intact when returning to `/knowledge`.
- Add `kbTreeRefreshStore` (tiny module-level ref) so App-level `onComplete` can call the currently-mounted KB page's `kb.refreshTree()` — no-op if the page is unmounted, and the page re-fetches the tree on next mount anyway.

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `apps/web/e2e/wiki-chat-persist.spec.ts` (new, P1, area kb) — verifies panel + running state + streaming message survive a Home → /knowledge round trip
- [x] `chat-single.spec.ts`, `navigation.spec.ts`, `bootstrap.spec.ts` — still green
- [ ] Reviewer: run affected E2E (`pnpm --filter @molio/web exec playwright test e2e/knowledge.spec.ts e2e/wiki-chat-persist.spec.ts`)