### PR TITLE
fix(kb): guard KaTeX renderer against missing MathJax

### DIFF
--- a/apps/web/e2e/markdown-render.spec.ts
+++ b/apps/web/e2e/markdown-render.spec.ts
@@ -28,6 +28,22 @@ import { gotoHome, clickNav } from './helpers/navigation';
 
 const DAEMON_API = 'http://localhost:3100/api';
 
+// Reproduces the WeChat-clipping citation-marker crash: articles use
+// `\\[1\\]` `\\[2\\]` as escaped-bracket reference markers, which the KaTeX
+// extension's blockLatexRule mistook for LaTeX `\\[ ... \\]` block math and
+// tried to call window.MathJax (never loaded) → "Cannot read properties of
+// undefined (reading 'texReset')". See katex.ts guard.
+const CITATION_TEST_MD = `飞樰 *2026年5月13日 08:30*
+
+开源了一个名为"LLM-Wiki"的项目\\[1\\]，核心是 Markdown 文件\\[2\\]。
+
+References
+
+\\[1\\] LLM-Wiki：https://example.com/1
+
+\\[2\\] AI Maker：https://example.com/2
+`;
+
 const RENDER_TEST_MD = `# Test Markdown Rendering
 
 ## Table
@@ -68,7 +84,7 @@ const vaultName = `e2e-render-${Date.now()}`;
  * only fetches vaults on page mount. We reload once so the store picks up the
  * new vault before opening the vault switcher.
  */
-async function openRenderTestFile(page: import('@playwright/test').Page) {
+async function openRenderTestFile(page: import('@playwright/test').Page, filename = 'render-test.md') {
   await gotoHome(page);
   // Reload to re-fetch vault list from daemon (picks up vault created in beforeAll)
   await page.reload({ waitUntil: 'networkidle' });
@@ -84,8 +100,8 @@ async function openRenderTestFile(page: import('@playwright/test').Page) {
   await vaultItem.click({ timeout: 5_000 });
   await page.waitForTimeout(1_000);
 
-  // Click render-test.md in the file tree
-  const fileItem = page.locator('.kb-tree-item').filter({ hasText: 'render-test.md' });
+  // Click the target file in the file tree
+  const fileItem = page.locator('.kb-tree-item').filter({ hasText: filename });
   await fileItem.click({ timeout: 10_000 });
 
   // Wait for file content to load
@@ -98,6 +114,7 @@ test.describe('Markdown Rendering', () => {
     // Create a temporary directory with a comprehensive markdown test file
     testVaultPath = mkdtempSync(join(tmpdir(), 'molio-e2e-render-'));
     writeFileSync(join(testVaultPath, 'render-test.md'), RENDER_TEST_MD);
+    writeFileSync(join(testVaultPath, 'citation-test.md'), CITATION_TEST_MD);
 
     // Register the vault via the daemon API
     const res = await fetch(`${DAEMON_API}/knowledge/vaults`, {
@@ -197,5 +214,23 @@ test.describe('Markdown Rendering', () => {
     // Verify even rows have a background color from doocs/md theme
     const evenRow = page.locator('#output .md-table tbody tr:nth-child(even)').first();
     await expect(evenRow).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('escaped-bracket citation markers do not crash MathJax renderer', async ({ page }) => {
+    // Reproduces the WeChat-clipping crash: `\\[1\\]` citation markers must
+    // NOT be treated as LaTeX block math. MathJax is not loaded in Molio, so
+    // any `\\[ ... \\]` / `$ ... $` token reaching the KaTeX renderer crashes
+    // ("Cannot read properties of undefined (reading 'texReset')"). The guard
+    // must fall back to raw text instead.
+    await openRenderTestFile(page, 'citation-test.md');
+
+    // Must NOT render the MdRenderer error fallback
+    await expect(page.locator('#output')).not.toContainText('Error rendering content', { timeout: 5_000 });
+    await expect(page.locator('#output')).not.toContainText('texReset');
+
+    // The `\\[N\\]` markers should render as literal `[N]` text in the body
+    const output = page.locator('#output');
+    await expect(output).toContainText('[1]');
+    await expect(output).toContainText('[2]');
   });
 });

--- a/apps/web/vendor/doocs-md/src/extensions/katex.ts
+++ b/apps/web/vendor/doocs-md/src/extensions/katex.ts
@@ -18,10 +18,28 @@ function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
   return (token: any) => {
     const display = token.displayMode ?? defaultDisplay
 
+    // [MOLIO] Guard: MathJax is loaded lazily and may be absent (not yet
+    // loaded, offline, CDN failure, SSR/test env). Without this guard any
+    // `\[ ... \]` / `$ ... $` token reaching the renderer crashes with
+    // "Cannot read properties of undefined (reading 'texReset')". WeChat
+    // clippings use `\[1\]` citation markers which collide with the LaTeX
+    // block rule, so this path is hit by ordinary articles, not just math.
+    // Fall back to raw text so the document still renders.
     // @ts-expect-error MathJax is a global variable
-    window.MathJax.texReset()
-    // @ts-expect-error MathJax is a global variable
-    const mjxContainer = window.MathJax.tex2svg(token.text, { display })
+    const mathjax = window.MathJax
+    if (!mathjax?.texReset || !mathjax?.tex2svg) {
+      // Render as standard markdown would: strip the backslash before brackets
+      // / parens so `\[1\]` → `[1]` and `\(x\)` → `(x)` (these are escaped
+      // brackets in CommonMark, which is how WeChat clippings use them as
+      // citation markers). `$...$` / `$$...$$` are kept literal.
+      const raw = escapeHtml((token.raw ?? token.text).replace(/\\([()\[\]])/g, `$1`))
+      return display
+        ? `<section class="katex-block" data-math-display="true" data-math-raw="${raw}">${raw}</section>`
+        : `<span class="katex-inline" data-math-display="false" data-math-raw="${raw}">${raw}</span>`
+    }
+
+    mathjax.texReset()
+    const mjxContainer = mathjax.tex2svg(token.text, { display })
     const svg = mjxContainer.firstChild
     const width = svg.style[`min-width`] || svg.getAttribute(`width`)
     svg.removeAttribute(`width`)


### PR DESCRIPTION
## 问题

打开微信剪藏文章（如 `深度解析LLM Wiki / Obsidian-Wiki / GBrain`）时知识库渲染崩溃：

```
Markdown rendering error: TypeError: Cannot read properties of undefined (reading "texReset")
    at katex.ts:22:20
```

整篇文档无法渲染。实际影响范围：任何 markdown 含 `\[...\]` / `\(...\)` / `$...$` 的文档都会触发，只是普通笔记没有这类分隔符，平时没遇到。

## 根因

两层叠加：

1. **直接原因**：`katex.ts:22` 无条件调用 `window.MathJax.texReset()`，但 Molio 从未加载 MathJax（`index.html` 无 script、`public/` 不存在、`src/**` 与 `vendor/` 均无加载逻辑），`window.MathJax` 为 undefined → 抛错。
2. **触发原因**：微信剪藏用 `\[1\]` 作引用角标（CommonMark 里是转义中括号，应渲染成字面量 `[1]`）。但 `renderer-impl.ts:473` 无条件注册了 KaTeX 扩展，其 `blockLatexRule` 把 `\[ ... \]` 当成 LaTeX 块级公式，`\[1\]` 命中 → 产出 `blockLatexKatex` token → 调 `window.MathJax` → 崩溃。

一句话：扩展期待 MathJax 已加载，但 Molio 根本没加载 MathJax；平时没公式文档触发不到，这篇剪藏的 `\[1\]` 角标被误判成 LaTeX 公式，把这条未加保护的路径点炸了。

## 修复

`apps/web/vendor/doocs-md/src/extensions/katex.ts` 的 `createRenderer` 加 MathJax guard：

- MathJax 缺失（未加载 / 离线 / CDN 失败 / SSR）时不再崩，降级为原始文本渲染。
- 降级按 CommonMark 语义：`\[1\]`→`[1]`、`\(x\)`→`(x)`（剥反斜杠转义），`$...$` 保持字面量。
- 后续 `tex2svg` 改用本地 `mathjax` 变量，保持一致。
- 该 guard 也是将来按需懒加载 MathJax（异步未 ready / CDN 失败 / 离线 / SSR）必须的安全网，不冲突、可叠加。

## 测试

按错误驱动测试规则在 `apps/web/e2e/markdown-render.spec.ts` 新增用例 `escaped-bracket citation markers do not crash MathJax renderer`：

- 复现崩溃（红 phase 实测抛出 `Error rendering content: TypeError: Cannot read properties of undefined (reading "texReset")`）。
- 修复后断言无错误回退 + `[1]`/`[2]` 正确渲染（绿 phase 通过）。

## 验证

- 新测试 ✅ 通过
- 全量 `markdown-render.spec`（7 条）✅ 全绿，无回归
- `pnpm typecheck` ✅ 全包通过

## 改动文件

- `apps/web/vendor/doocs-md/src/extensions/katex.ts`（+24/-6）
- `apps/web/e2e/markdown-render.spec.ts`（+35/-0，含复现用例与夹具）