### PR TITLE
fix(web): @ 指令提示语补全文件夹/目录支持

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -25,7 +25,7 @@ const en: Record<string, string> = {
   'composer.stop': 'Stop',
   'composer.send': 'Send',
   'composer.hint': 'Shift+Enter for new line',
-  'composer.hintFileRef': 'Reference files',
+  'composer.hintFileRef': 'Reference files/folders',
   'composer.hintCommand': 'Commands',
   'composer.hintSend': 'Send',
   'composer.hintNewline': 'New line',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -25,7 +25,7 @@ const zh: Record<string, string> = {
   'composer.stop': '停止',
   'composer.send': '发送',
   'composer.hint': 'Shift+Enter 换行',
-  'composer.hintFileRef': '引用文件',
+  'composer.hintFileRef': '引用文件/目录',
   'composer.hintCommand': '命令',
   'composer.hintSend': '发送',
   'composer.hintNewline': '换行',


### PR DESCRIPTION
## 背景

聊天输入框底部 hint 里 `@` 指令的描述文案来自 i18n key `composer.hintFileRef`（`ChatComposer.tsx:599` 引用）。原文案只写「引用文件 / Reference files」，但 `@` 指令实际同时支持文件**和**文件夹（`FileRef.isDirectory`，`buildAttachmentPrefix` 还会给文件夹加 `/` 后缀和"请读取其下所有相关文件"的提示），文案名不副实。

## 改动

| 语言 | 旧 | 新 |
|---|---|---|
| zh | 引用文件 | 引用文件/目录 |
| en | Reference files | Reference files/folders |

中文用「目录」替代「文件夹」，少一字且技术语境更利落，不丢语义。

## 测试

纯文案改动，不涉及 `data-testid` 或交互结构，按 E2E 同步规则无需改测试。