### PR TITLE
fix(ci): impact-analysis 用 git diff 替代 gh pr diff

### DIFF
--- a/.github/workflows/impact-analysis.yml
+++ b/.github/workflows/impact-analysis.yml
@@ -32,7 +32,11 @@ jobs:
 
       - name: Get PR diff
         run: |
-          gh pr diff ${{ github.event.pull_request.number }} > pr.diff
+          # Use local git diff instead of `gh pr diff` — GitHub's API caps diff
+          # responses at 20000 lines and returns HTTP 406 for larger PRs, which
+          # silently breaks impact analysis on big PRs (e.g. #127). With
+          # fetch-depth: 0 above, both SHAs are already local.
+          git diff "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" > pr.diff
           gh pr view ${{ github.event.pull_request.number }} --json title,body > pr-meta.json
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## 问题

PR #127 的 Impact Analysis workflow 失败，PR 上没有影响分析评论。

根因：`.github/workflows/impact-analysis.yml` 的 "Get PR diff" 步骤用 `gh pr diff`，GitHub API 对 diff 响应有 **20000 行硬限制**，超过返回 HTTP 406：

```
could not find pull request diff: HTTP 406:
Sorry, the diff exceeded the maximum number of lines (20000)
PullRequest.diff too_large
```

PR #127 改动 36394 行（删 4 个旧 skill + 加 docling + 测试），直接触发上限，workflow 第一步 exit 1。

## 修复

改用本地 `git diff base...head`：

```yaml
git diff "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" > pr.diff
```

- workflow 已经 `fetch-depth: 0`，base/head SHA 都在本地，不经过 API，无行数上限
- 输出仍是标准 unified diff，`codegraph-impact.mjs` 解析逻辑（`+++ b/path` + `+/-` 行）完全兼容，下游脚本和 PR 评论逻辑不动

## 影响范围

只改 workflow，CI 配置变更，不影响代码运行时行为。

## Test plan

- [ ] 此 PR 触发 Impact Analysis workflow 应成功并发布评论
- [ ] PR #127 重跑（synchronize 或手动 rerun）后应正常出评论