### PR TITLE
feat(web): KB 聊天状态跨导航持久化

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import { useAgents } from './hooks/useAgents';
 import { useChat } from './hooks/useChat';
+import { useKbChat, type KbChatState } from './hooks/useKbChat';
 import { HomePage } from './components/HomePage';
 
 import { NavRail } from './components/NavRail';
@@ -36,6 +37,15 @@ export default function App() {
   const [locale, setLocale] = useState<Locale>('zh');
   const [configLoaded, setConfigLoaded] = useState(false);
   const chat = useChat({ agentId: selectedAgent, cwd: activeVault?.path });
+
+  // KB Chat — lifted to App level so chat state survives route navigation
+  const kbChatOnCompleteRef = useRef<() => void>(() => {});
+  const kbChat = useKbChat({
+    agentId: selectedAgent,
+    vaultPath: activeVault?.path ?? null,
+    onComplete: () => kbChatOnCompleteRef.current(),
+  });
+  const [kbChatOpen, setKbChatOpen] = useState(false);
 
   // Persist current route on change
   useEffect(() => {
@@ -168,6 +178,11 @@ export default function App() {
             <Route path="/knowledge" element={
             <KnowledgeBasePage
               agentId={selectedAgent}
+              // KB Chat — owned by App for navigation persistence
+              kbChat={kbChat}
+              kbChatOpen={kbChatOpen}
+              onKbChatOpenChange={setKbChatOpen}
+              registerKbChatOnComplete={(fn) => { kbChatOnCompleteRef.current = fn; }}
               onOpenConversation={(conversationId) => {
                 void chat.loadConversationById(conversationId).then(() => {
                   navigate('/');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import { useAgents } from './hooks/useAgents';
 import { useChat } from './hooks/useChat';
@@ -46,6 +46,12 @@ export default function App() {
     onComplete: () => kbChatOnCompleteRef.current(),
   });
   const [kbChatOpen, setKbChatOpen] = useState(false);
+
+  // Stable callback so KnowledgeBasePage's registerKbChatOnComplete effect
+  // doesn't re-run on every App render.
+  const registerKbChatOnComplete = useCallback((fn: () => void) => {
+    kbChatOnCompleteRef.current = fn;
+  }, []);
 
   // Persist current route on change
   useEffect(() => {
@@ -182,7 +188,7 @@ export default function App() {
               kbChat={kbChat}
               kbChatOpen={kbChatOpen}
               onKbChatOpenChange={setKbChatOpen}
-              registerKbChatOnComplete={(fn) => { kbChatOnCompleteRef.current = fn; }}
+              registerKbChatOnComplete={registerKbChatOnComplete}
               onOpenConversation={(conversationId) => {
                 void chat.loadConversationById(conversationId).then(() => {
                   navigate('/');

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -56,6 +56,9 @@ export function buildAttachmentPrefix(fileRefs: FileRef[], pastedImages: PastedI
   return parts.length > 0 ? parts.join('\n\n') : '';
 }
 
+/** Module-level draft cache — survives component unmount during navigation. */
+const drafts = new Map<string, string>();
+
 interface Props {
   isRunning: boolean;
   onSend: (message: string, fileRefs: FileRef[], pastedImages: PastedImage[]) => void;
@@ -66,6 +69,8 @@ interface Props {
   initialFileRefs?: FileRef[];
   /** Callback when user selects a conversation from history. */
   onOpenConversation?: (conversationId: string) => void;
+  /** Stable key for persisting draft text across navigation. */
+  composerKey?: string;
 }
 
 export function ChatComposer({
@@ -76,9 +81,10 @@ export function ChatComposer({
   disabledPlaceholder,
   initialFileRefs,
   onOpenConversation,
+  composerKey,
 }: Props) {
   const { t } = useI18n();
-  const [text, setText] = useState('');
+  const [text, setText] = useState(() => (composerKey ? drafts.get(composerKey) ?? '' : ''));
   const [fileRefs, setFileRefs] = useState<FileRef[]>(initialFileRefs ?? []);
   const [pastedImages, setPastedImages] = useState<PastedImage[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -99,6 +105,16 @@ export function ChatComposer({
       el.style.height = Math.min(el.scrollHeight, 184) + 'px';
     }
   }, [text]);
+
+  // Persist draft text to module-level cache so it survives navigation
+  useEffect(() => {
+    if (!composerKey) return;
+    if (text) {
+      drafts.set(composerKey, text);
+    } else {
+      drafts.delete(composerKey);
+    }
+  }, [text, composerKey]);
 
   // Focus on mount and when run completes
   useEffect(() => {

--- a/apps/web/src/components/HomePage.tsx
+++ b/apps/web/src/components/HomePage.tsx
@@ -134,6 +134,7 @@ export function HomePage({
         {/* Composer at the bottom */}
         <div className="home-composer-bar">
           <ChatComposer
+            composerKey="home"
             isRunning={isRunning}
             onSend={handleSend}
             onCancel={onCancel}
@@ -162,6 +163,7 @@ export function HomePage({
         {/* Composer */}
         <div className="home-composer-wrap">
           <ChatComposer
+            composerKey="home"
             isRunning={isRunning}
             onSend={handleSend}
             onCancel={onCancel}

--- a/apps/web/src/components/kb/KbChatPanel.tsx
+++ b/apps/web/src/components/kb/KbChatPanel.tsx
@@ -21,11 +21,13 @@ interface KbChatPanelProps {
   onClose: () => void;
   onSubmitToolResult: (toolUseId: string, content: string) => Promise<void>;
   onOpenConversation?: (conversationId: string) => void;
+  /** Stable key for persisting composer draft text across navigation. */
+  composerKey?: string;
 }
 
 export function KbChatPanel({
   mode, messages, isRunning, filePath, vaultId, selectedText,
-  onSend, onCancel, onClose, onSubmitToolResult, onOpenConversation,
+  onSend, onCancel, onClose, onSubmitToolResult, onOpenConversation, composerKey,
 }: KbChatPanelProps) {
   const { t } = useI18n();
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -159,6 +161,7 @@ export function KbChatPanel({
       <div className="file-chat-input">
         <ChatComposer
           key={mode === 'qa' ? (filePath ?? undefined) : (mode ?? undefined)}
+          composerKey={composerKey}
           isRunning={isRunning}
           onSend={onSend}
           onCancel={onCancel}

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -751,6 +751,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
       {/* Unified KB Chat Panel (right side) */}
       {kbChatOpen && (
         <KbChatPanel
+          composerKey="kb"
           mode={kbChat.mode}
           messages={kbChat.messages}
           isRunning={kbChat.isRunning}

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -351,8 +351,8 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
   }, [agentId, kbChat, confirmRunningOp]);
 
   const handleCloseChat = useCallback(() => {
-    onKbChatOpenChange(false);
     kbChat.close();
+    onKbChatOpenChange(false);
   }, [kbChat, onKbChatOpenChange]);
 
   // Wrap send to prepend selected text as context for QA mode

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import type { TreeNode } from '@molio/contracts';
 import { useKnowledge } from '../../hooks/useKnowledge';
-import { useKbChat } from '../../hooks/useKbChat';
+import type { KbChatState } from '../../hooks/useKbChat';
 import { useKbTabs } from '../../hooks/useKbTabs';
 import { kbTabsStore } from '../../stores/kbTabsStore';
 import { vaultStore } from '../../stores/vaultStore';
@@ -26,6 +26,11 @@ import { useI18n } from '../../i18n';
 
 interface KnowledgeBasePageProps {
   agentId: string | null;
+  // KB Chat — owned by App for navigation persistence
+  kbChat: KbChatState;
+  kbChatOpen: boolean;
+  onKbChatOpenChange: (open: boolean) => void;
+  registerKbChatOnComplete: (fn: () => void) => void;
   onOpenConversation?: (conversationId: string) => void;
 }
 
@@ -47,14 +52,14 @@ function resolveUrlFileNavigation(
   return { vaultId, filePath };
 }
 
-export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBasePageProps) {
+export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenChange, registerKbChatOnComplete, onOpenConversation }: KnowledgeBasePageProps) {
   const { t } = useI18n();
   const kb = useKnowledge();
   const tabs = useKbTabs();
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
-  const [chatOpen, setChatOpen] = useState(false);
+
   const [qaSelectedText, setQaSelectedText] = useState<string | null>(null);
   const [pendingUrlNav, setPendingUrlNav] = useState<UrlFileNavigation | null>(null);
   const [showOutline, setShowOutline] = useState(false);
@@ -120,25 +125,25 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
     onConfirm: () => void;
   }>({ show: false, title: '', message: '', onConfirm: () => {} });
 
-  // Unified KB chat hook — covers QA, build, lint, ingest
-  const kbChat = useKbChat({
-    agentId,
-    vaultPath: kb.activeVault?.path ?? null,
-    onComplete: () => { kb.refreshTree(); },
-  });
+  // Register onComplete callback with App so wiki builds trigger tree refresh.
+  // Cleanup resets to noop when this page unmounts.
+  useEffect(() => {
+    registerKbChatOnComplete(() => { kb.refreshTree(); });
+    return () => registerKbChatOnComplete(() => {});
+  }, [kb.refreshTree, registerKbChatOnComplete]);
 
   const handleOpenQa = useCallback(() => {
     if (!kb.selectedFile) return;
     setQaSelectedText(null);
     kbChat.openQa();
-    setChatOpen(true);
+    onKbChatOpenChange(true);
   }, [kb.selectedFile, kbChat]);
 
   const handleAskAboutSelection = useCallback((selectedText: string) => {
     if (!kb.selectedFile) return;
     setQaSelectedText(selectedText);
     kbChat.openQa();
-    setChatOpen(true);
+    onKbChatOpenChange(true);
   }, [kb.selectedFile, kbChat]);
 
   // ─── Tab-aware file selection ───
@@ -313,8 +318,8 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
   }, []);
 
   const handleOpenWikiOp = useCallback((type: 'build' | 'lint') => {
-    const interrupt = () => { kbChat.openWikiOp(type); setChatOpen(true); };
-    const queue = () => { kbChat.queueWikiOp(type); setChatOpen(true); };
+    const interrupt = () => { kbChat.openWikiOp(type); onKbChatOpenChange(true); };
+    const queue = () => { kbChat.queueWikiOp(type); onKbChatOpenChange(true); };
     if (kbChat.isRunning) {
       confirmRunningOp({
         title: '当前任务进行中',
@@ -331,8 +336,8 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
 
   const handleIngestFile = useCallback((filePath: string) => {
     if (!agentId) return;
-    const interrupt = () => { kbChat.openIngest(filePath); setChatOpen(true); };
-    const queue = () => { kbChat.queueIngest(filePath); setChatOpen(true); };
+    const interrupt = () => { kbChat.openIngest(filePath); onKbChatOpenChange(true); };
+    const queue = () => { kbChat.queueIngest(filePath); onKbChatOpenChange(true); };
     if (kbChat.isRunning) {
       confirmRunningOp({
         title: '当前任务进行中',
@@ -346,9 +351,9 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
   }, [agentId, kbChat, confirmRunningOp]);
 
   const handleCloseChat = useCallback(() => {
-    setChatOpen(false);
+    onKbChatOpenChange(false);
     kbChat.close();
-  }, [kbChat]);
+  }, [kbChat, onKbChatOpenChange]);
 
   // Wrap send to prepend selected text as context for QA mode
   const handleKbChatSend = useCallback(
@@ -389,7 +394,7 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
         if (!kb.selectedFile) return;
         setQaSelectedText(null);
         kbChat.openQa();
-        setChatOpen(true);
+        onKbChatOpenChange(true);
       }
     };
     window.addEventListener('keydown', handler);
@@ -408,7 +413,7 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
         if (!kb.selectedFile) return;
         setQaSelectedText(null);
         kbChat.openQa();
-        setChatOpen(true);
+        onKbChatOpenChange(true);
       }
     };
     document.addEventListener('keydown', handler);
@@ -514,7 +519,7 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
           }
           setQaSelectedText(null);
           kbChat.openQa();
-          setChatOpen(true);
+          onKbChatOpenChange(true);
         },
       });
     } else {
@@ -744,7 +749,7 @@ export function KnowledgeBasePage({ agentId, onOpenConversation }: KnowledgeBase
       </div>
 
       {/* Unified KB Chat Panel (right side) */}
-      {chatOpen && (
+      {kbChatOpen && (
         <KbChatPanel
           mode={kbChat.mode}
           messages={kbChat.messages}


### PR DESCRIPTION
## 问题

知识库页面打开问答聊天后，切换到其他页面再回来，聊天面板关闭、消息丢失。输入框草稿文字同样丢失。

## 根因

React Router 在导航时卸载路由组件，`KnowledgeBasePage` 的本地状态随卸载销毁。

## 修复

1. **KB 聊天状态提升到 App 层** — `useKbChat` + `chatOpen` 从 `KnowledgeBasePage` 移到 `App.tsx`，和首页 `useChat` 并列，App 永不卸载 → 状态在导航中保留
2. **输入框草稿持久化** — `ChatComposer` 加模块级缓存，按 `composerKey`（home/kb）分别存草稿，挂载恢复，发送清除
3. **onComplete 回调桥接** — ref 模式让 App 层的 `useKbChat` 能调 KnowledgeBasePage 的 `refreshTree`，卸载时自动置空

## 改动文件

| 文件 | 改动 |
|------|------|
| `App.tsx` | +25/-3 新增 useKbChat、kbChatOpen、回调桥接 |
| `KnowledgeBasePage.tsx` | +27/-19 改为 props 接收，移除本地状态 |
| `ChatComposer.tsx` | +14/-1 模块级草稿缓存 |
| `HomePage.tsx` | +2/-0 传 composerKey=\home\ |
| `KbChatPanel.tsx` | +4/-1 透传 composerKey |

## 验证

- typecheck: 4/4 包通过
- E2E: 96 passed, 0 failures