### PR TITLE
feat(desktop+web): active-vault clipper + reliable molio://open navigation

### DIFF
--- a/apps/daemon/src/core/db.ts
+++ b/apps/daemon/src/core/db.ts
@@ -132,6 +132,12 @@ function migrate(db: SqliteDb): void {
 
     CREATE INDEX IF NOT EXISTS idx_kb_history_vault
       ON kb_history(vault_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS kv (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
   `);
 
   addColumnIfMissing(db, 'conversations', 'channel_type', "TEXT NOT NULL DEFAULT 'desktop'");
@@ -469,6 +475,48 @@ export function createVault(db: SqliteDb, name: string, vaultPath: string, descr
 
 export function deleteVault(db: SqliteDb, id: string): void {
   db.prepare('DELETE FROM vaults WHERE id = ?').run(id);
+  // Clear active-vault if it pointed at the deleted vault.
+  if (getActiveVaultId(db) === id) {
+    setActiveVaultId(db, null);
+  }
+}
+
+// ─── Key/value store (active-vault etc.) ───
+
+export function getKv(db: SqliteDb, key: string): string | null {
+  const row = db.prepare('SELECT value FROM kv WHERE key = ?').get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value ?? null;
+}
+
+export function setKv(db: SqliteDb, key: string, value: string): void {
+  db.prepare(
+    `INSERT INTO kv (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+  ).run(key, value, Date.now());
+}
+
+export function deleteKv(db: SqliteDb, key: string): void {
+  db.prepare('DELETE FROM kv WHERE key = ?').run(key);
+}
+
+// ─── Active vault ───
+
+const ACTIVE_VAULT_KEY = 'active_vault';
+
+/** Returns the id of the user's currently-selected vault, or null. */
+export function getActiveVaultId(db: SqliteDb): string | null {
+  return getKv(db, ACTIVE_VAULT_KEY);
+}
+
+/** Set/clear the active vault. Pass null to clear. */
+export function setActiveVaultId(db: SqliteDb, id: string | null): void {
+  if (id) {
+    setKv(db, ACTIVE_VAULT_KEY, id);
+  } else {
+    deleteKv(db, ACTIVE_VAULT_KEY);
+  }
 }
 
 // ─── KB History ───

--- a/apps/daemon/src/routes/knowledge.ts
+++ b/apps/daemon/src/routes/knowledge.ts
@@ -17,6 +17,8 @@ import {
   deleteVault,
   listKbHistory,
   addKbHistory,
+  getActiveVaultId,
+  setActiveVaultId,
 } from '../core/db.js';
 import {
   scanTree,
@@ -83,6 +85,42 @@ export function knowledgeRoutes(
     deleteVault(db, c.req.param('id'));
     void vaultWatcher.unwatch(c.req.param('id'));
     return c.body(null, 204);
+  });
+
+  // ─── Active vault ───
+
+  // GET /api/knowledge/active-vault — the user's currently-selected vault.
+  // Used by external clients (e.g. the Molio-forked Web Clipper) to know which
+  // vault a new clip should land in, mirroring "save to the open vault".
+  app.get('/active-vault', (c) => {
+    const id = getActiveVaultId(db);
+    if (!id) {
+      return c.json({ vaultId: null, vault: null });
+    }
+    const vault = getVault(db, id);
+    if (!vault) {
+      // Stale pointer — vault was deleted out of band. Clear it.
+      setActiveVaultId(db, null);
+      return c.json({ vaultId: null, vault: null });
+    }
+    return c.json({ vaultId: id, vault: { ...vault, fileCount: countFilesSafe(vault.path) } });
+  });
+
+  // POST /api/knowledge/active-vault { id } — set the active vault.
+  // Called by the web/desktop UI whenever the user switches vault, so external
+  // clients reading GET /active-vault follow along.
+  app.post('/active-vault', async (c) => {
+    const body = await c.req.json<{ id: string | null }>();
+    if (body.id === null || body.id === undefined) {
+      setActiveVaultId(db, null);
+      return c.json({ ok: true, vaultId: null });
+    }
+    const vault = getVault(db, body.id);
+    if (!vault) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'Vault not found' } }, 404);
+    }
+    setActiveVaultId(db, body.id);
+    return c.json({ ok: true, vaultId: body.id });
   });
 
   // ─── File tree ───

--- a/apps/daemon/test/core/db.test.ts
+++ b/apps/daemon/test/core/db.test.ts
@@ -20,6 +20,13 @@ import {
   listMessages,
   upsertMessage,
   appendMessageEvent,
+  createVault,
+  deleteVault,
+  getActiveVaultId,
+  setActiveVaultId,
+  getKv,
+  setKv,
+  deleteKv,
 } from '../../src/core/db.js';
 import type { ChatMessage } from '@molio/contracts';
 import type Database from 'better-sqlite3';
@@ -277,6 +284,41 @@ describe('SQLite persistence', () => {
       // Messages should be gone
       const messages = listMessages(db, conv.id);
       assert.equal(messages.length, 0);
+    });
+  });
+
+  describe('kv store', () => {
+    it('should set, get, and delete a key', () => {
+      assert.equal(getKv(db, 'missing'), null);
+      setKv(db, 'foo', 'bar');
+      assert.equal(getKv(db, 'foo'), 'bar');
+      // Upsert — second set overwrites
+      setKv(db, 'foo', 'baz');
+      assert.equal(getKv(db, 'foo'), 'baz');
+      deleteKv(db, 'foo');
+      assert.equal(getKv(db, 'foo'), null);
+    });
+  });
+
+  describe('active vault', () => {
+    it('should default to null and round-trip an id', () => {
+      assert.equal(getActiveVaultId(db), null);
+      const vault = createVault(db, 'Active Test', join(tempDir, 'active-test-vault'));
+      setActiveVaultId(db, vault.id);
+      assert.equal(getActiveVaultId(db), vault.id);
+      // Clear via null
+      setActiveVaultId(db, null);
+      assert.equal(getActiveVaultId(db), null);
+    });
+
+    it('should clear active-vault when its vault is deleted', () => {
+      const vault = createVault(db, 'Doomed', join(tempDir, 'doomed-vault'));
+      setActiveVaultId(db, vault.id);
+      assert.equal(getActiveVaultId(db), vault.id);
+
+      deleteVault(db, vault.id);
+      // deleteVault self-clears the active-vault pointer
+      assert.equal(getActiveVaultId(db), null);
     });
   });
 });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molio/desktop",
-  "version": "0.3.2",
+  "version": "0.3.30",
   "description": "Molio - AI writing & knowledge management platform",
   "author": "Molio Team",
   "type": "module",

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -192,9 +192,21 @@ function navigateFromProtocolUrl(protocolUrl) {
   try {
     const target = parseMolioProtocolUrl(protocolUrl);
     if (target?.action === 'open-file') {
-      const appUrl = buildKnowledgeUrlFromProtocolTarget(target);
-      log('info', 'main', `navigating to ${appUrl}`);
-      mainWindow.loadURL(appUrl);
+      // Cold start: window still on splash → renderer isn't ready for IPC, so
+      // do a full loadURL to the knowledge route (initial app load, no flash).
+      // Warm start: app already loaded → send an IPC so the SPA navigates
+      // in-page to the file without a full reload (no flash, no state loss).
+      if (isShowingSplash()) {
+        const appUrl = buildKnowledgeUrlFromProtocolTarget(target);
+        log('info', 'main', `navigating to ${appUrl}`);
+        mainWindow.loadURL(appUrl);
+      } else {
+        log('info', 'main', `in-page navigate: vault=${target.vaultId ?? '(active)'} file=${target.filePath}`);
+        mainWindow.webContents.send('molio:navigate', {
+          vaultId: target.vaultId,
+          filePath: target.filePath,
+        });
+      }
       return;
     }
 

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -18,6 +18,16 @@ app.name = 'Molio';
 let mainWindow = null;
 let daemonProcess = null;
 
+// Whether the renderer has mounted and registered its `molio:navigate`
+// listener yet. On cold start the SPA doesn't mount until after the daemon is
+// up and loadApp() runs — which is *after* the clipper's /api/health poll
+// already reports ready. So a molio://open/... that fires right after launch
+// (warm second-instance path) would reach a renderer that isn't listening yet
+// and the IPC would be dropped, leaving the just-saved file unopened. We queue
+// such navigations and flush them once the renderer signals readiness.
+let rendererReady = false;
+let pendingNavigation = null;
+
 /** Whether the app is running in development mode (not packaged) */
 function isDevMode() {
   return !app.isPackaged;
@@ -109,6 +119,15 @@ function createWindow() {
     mainWindow?.show();
   });
 
+  // A full page load (cold-start loadApp, or any reload) recreates the
+  // renderer context, so the previous molio:navigate listener is gone and
+  // molio:renderer-ready will fire again once the SPA re-mounts. Re-arm on
+  // every did-start-loading so a queued navigation never gets delivered to a
+  // stale listener that no longer exists.
+  mainWindow.webContents.on('did-start-loading', () => {
+    rendererReady = false;
+  });
+
   // Intercept window.open() — open in system browser instead of Electron
   // This is critical for the COSE publish flow: the bridge page must run
   // in the user's real Chrome (where the COSE extension is installed),
@@ -176,6 +195,35 @@ function buildKnowledgeUrlFromProtocolTarget(target) {
 }
 
 /**
+ * Deliver an open-file navigation to the renderer (warm-start path).
+ *
+ * If the renderer has mounted and registered its `molio:navigate` listener,
+ * send the IPC for in-page routing (no reload, no state loss).
+ *
+ * If it hasn't yet — e.g. a clip just cold-launched Molio and the SPA is still
+ * booting after loadApp() — queue the navigation. The renderer flushes it via
+ * `molio:renderer-ready` once its listener is wired up. Without this queue,
+ * the IPC would be delivered before the listener exists and the just-saved
+ * file would never open.
+ */
+function deliverNavigation(target) {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (rendererReady) {
+    log('info', 'main', `in-page navigate: vault=${target.vaultId ?? '(active)'} file=${target.filePath}`);
+    mainWindow.webContents.send('molio:navigate', {
+      vaultId: target.vaultId,
+      filePath: target.filePath,
+    });
+  } else {
+    pendingNavigation = {
+      vaultId: target.vaultId,
+      filePath: target.filePath,
+    };
+    log('info', 'main', `renderer not ready — queued navigate: vault=${target.vaultId ?? '(active)'} file=${target.filePath}`);
+  }
+}
+
+/**
  * Parse a molio:// protocol URL and navigate the Electron window accordingly.
  *
  * Uses path-style URLs (not query params) because Windows shell mangles `?` and
@@ -192,20 +240,20 @@ function navigateFromProtocolUrl(protocolUrl) {
   try {
     const target = parseMolioProtocolUrl(protocolUrl);
     if (target?.action === 'open-file') {
-      // Cold start: window still on splash → renderer isn't ready for IPC, so
-      // do a full loadURL to the knowledge route (initial app load, no flash).
-      // Warm start: app already loaded → send an IPC so the SPA navigates
-      // in-page to the file without a full reload (no flash, no state loss).
-      if (isShowingSplash()) {
+      // Splash, error page, or renderer not yet ready: the in-page IPC path
+      // can't deliver (no SPA listener, or a non-SPA page like the daemon
+      // error page that never sends molio:renderer-ready, so a queued nav
+      // would be dropped and the just-saved file never opens). Fall back to
+      // a full loadURL of the knowledge route — the SPA reads ?vault=&file=
+      // and opens the file. Reload is fine here since the renderer is already
+      // in a broken/transient state; the warm healthy path uses IPC below.
+      if (isShowingSplash() || !rendererReady) {
         const appUrl = buildKnowledgeUrlFromProtocolTarget(target);
-        log('info', 'main', `navigating to ${appUrl}`);
+        log('info', 'main', `navigating to ${appUrl} (renderer ${rendererReady ? 'on splash' : 'not ready'})`);
+        pendingNavigation = null; // loadURL supersedes any stale queued nav
         mainWindow.loadURL(appUrl);
       } else {
-        log('info', 'main', `in-page navigate: vault=${target.vaultId ?? '(active)'} file=${target.filePath}`);
-        mainWindow.webContents.send('molio:navigate', {
-          vaultId: target.vaultId,
-          filePath: target.filePath,
-        });
+        deliverNavigation(target);
       }
       return;
     }
@@ -276,8 +324,9 @@ if (!singleLock) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();
     }
-    // Handle molio:// protocol URL for navigation
-    // Format: molio://open?vault=<vaultId>&file=<filePath>
+    // Handle molio:// protocol URL for navigation (path-style — see
+    // parseMolioProtocolUrl; query-param form was abandoned due to Windows
+    // mangling '?' and '&').
     const protocolUrl = commandLine.find(arg => arg.startsWith('molio://'));
     if (protocolUrl) {
       log('info', 'main', `second-instance triggered via ${protocolUrl}`);
@@ -454,6 +503,22 @@ app.on('before-quit', (event) => {
 });
 
 // ─── IPC handlers ───
+
+// Renderer signals it has mounted and registered its `molio:navigate`
+// listener. Flush any navigation that was queued during cold start (before the
+// listener existed), so a molio://open/... fired right after launch still
+// opens the just-saved file instead of being dropped.
+ipcMain.on('molio:renderer-ready', () => {
+  rendererReady = true;
+  if (pendingNavigation && mainWindow && !mainWindow.isDestroyed()) {
+    const nav = pendingNavigation;
+    pendingNavigation = null;
+    log('info', 'main', `renderer ready — flushing queued navigate: vault=${nav.vaultId ?? '(active)'} file=${nav.filePath}`);
+    mainWindow.webContents.send('molio:navigate', nav);
+  } else {
+    log('info', 'main', 'renderer ready (no queued navigation to flush)');
+  }
+});
 
 ipcMain.handle('show-directory-picker', async () => {
   const focusedWindow = BrowserWindow.getFocusedWindow();

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -33,6 +33,18 @@ const desktopAPI = {
 
   /** Rename a local file (oldPath -> newPath). */
   renameFile: (oldPath, newPath) => ipcRenderer.invoke('rename-file', oldPath, newPath),
+
+  /**
+   * Subscribe to in-page navigation requests from the main process
+   * (triggered by molio://open/... when the app is already running).
+   * Avoids a full reload — the SPA routes to the file via React Router.
+   * Returns an unsubscribe function.
+   */
+  onNavigate: (callback) => {
+    const handler = (_event, payload) => callback(payload);
+    ipcRenderer.on('molio:navigate', handler);
+    return () => ipcRenderer.removeListener('molio:navigate', handler);
+  },
 };
 
 // Updater API — event listeners + actions

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -45,6 +45,14 @@ const desktopAPI = {
     ipcRenderer.on('molio:navigate', handler);
     return () => ipcRenderer.removeListener('molio:navigate', handler);
   },
+
+  /**
+   * Tell the main process the renderer has mounted and registered its
+   * molio:navigate listener. Main uses this to flush any navigation that was
+   * queued during cold start (before this listener existed), so a
+   * molio://open/... fired right after launch still opens the target file.
+   */
+  notifyReady: () => ipcRenderer.send('molio:renderer-ready'),
 };
 
 // Updater API — event listeners + actions

--- a/apps/desktop/test/daemon-startup.test.js
+++ b/apps/desktop/test/daemon-startup.test.js
@@ -161,7 +161,10 @@ describe('main.js: protocol launch should leave splash after daemon is ready', (
     const navigatePos = mainJs.indexOf('function navigateFromProtocolUrl');
     assert.ok(navigatePos !== -1, 'navigateFromProtocolUrl must exist');
 
-    const navigateBlock = mainJs.slice(navigatePos, navigatePos + 900);
+    // Window must cover the whole navigateFromProtocolUrl body, including the
+    // open-file branch — otherwise the launch branch (which comes after it)
+    // falls outside the slice and the assertions falsely fail.
+    const navigateBlock = mainJs.slice(navigatePos, navigatePos + 2000);
     assert.ok(
       navigateBlock.includes("target?.action === 'launch'"),
       'navigateFromProtocolUrl must handle parsed launch actions'
@@ -184,6 +187,26 @@ describe('main.js: protocol launch should leave splash after daemon is ready', (
     assert.ok(
       mainJs.includes("params.set('file', target.filePath)"),
       'file-only protocol target must navigate to the knowledge page with a file param'
+    );
+  });
+
+  it('molio://open should fall back to loadURL when the renderer is not ready', () => {
+    // Regression: when a stale Molio process holds the single-instance lock
+    // with a dead daemon, the window shows the static daemon-error page (not
+    // the SPA), so molio:renderer-ready never fires and a queued navigation
+    // was silently dropped — the clip saved but the file never opened.
+    // The fix: if rendererReady is false, loadURL the knowledge route
+    // directly instead of queuing.
+    const navigatePos = mainJs.indexOf('function navigateFromProtocolUrl');
+    assert.ok(navigatePos !== -1, 'navigateFromProtocolUrl must exist');
+    const navigateBlock = mainJs.slice(navigatePos, navigatePos + 2000);
+    assert.ok(
+      navigateBlock.includes('!rendererReady'),
+      'open-file navigation must fall back to loadURL when the renderer is not ready'
+    );
+    assert.ok(
+      /isShowingSplash\(\)\s*\|\|\s*!rendererReady/.test(navigateBlock),
+      'the loadURL fallback condition must cover both splash and not-ready states'
     );
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -56,6 +56,18 @@ export default function App() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // In-page navigation from molio:// protocol (desktop main → renderer IPC).
+  // When a clip lands and molio://open/... fires while the app is already open,
+  // the main process sends `molio:navigate` instead of reloading the window,
+  // so we route to the file via React Router with no flash/state loss.
+  useEffect(() => {
+    const electron = window.__electron__;
+    if (!electron?.onNavigate) return; // absent in plain browser dev
+    return electron.onNavigate(({ vaultId, filePath }) => {
+      navigate('/knowledge', { state: { openFile: filePath, vaultId: vaultId ?? undefined } });
+    });
+  }, [navigate]);
+
   // Load config to get defaultAgentId and locale
   useEffect(() => {
     api.getConfig()

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -63,9 +63,13 @@ export default function App() {
   useEffect(() => {
     const electron = window.__electron__;
     if (!electron?.onNavigate) return; // absent in plain browser dev
-    return electron.onNavigate(({ vaultId, filePath }) => {
+    const unsub = electron.onNavigate(({ vaultId, filePath }) => {
       navigate('/knowledge', { state: { openFile: filePath, vaultId: vaultId ?? undefined } });
     });
+    // Signal readiness so main flushes any molio://open that arrived during
+    // cold start (before this listener was registered) instead of dropping it.
+    electron.notifyReady?.();
+    return unsub;
   }, [navigate]);
 
   // Load config to get defaultAgentId and locale

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -353,6 +353,23 @@ export const api = {
     await fetch(`${BASE}/knowledge/vaults/${id}`, { method: 'DELETE' });
   },
 
+  /** Returns the user's currently-active vault (the one external clippers target). */
+  async getActiveVault(): Promise<{ vaultId: string | null; vault: (Vault & { fileCount: number }) | null }> {
+    const res = await fetch(`${BASE}/knowledge/active-vault`);
+    if (!res.ok) throw new Error(`Failed to fetch active vault: ${res.status}`);
+    return res.json();
+  },
+
+  /** Set the active vault. Pass null to clear. Fire-and-forget safe. */
+  async setActiveVault(id: string | null): Promise<void> {
+    const res = await fetch(`${BASE}/knowledge/active-vault`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+    if (!res.ok) throw new Error(`Failed to set active vault: ${res.status}`);
+  },
+
   async getFileTree(vaultId: string): Promise<TreeNode[]> {
     const res = await fetch(`${BASE}/knowledge/vaults/${vaultId}/tree`);
     if (!res.ok) throw new Error(`Failed to fetch file tree: ${res.status}`);

--- a/apps/web/src/stores/vaultStore.ts
+++ b/apps/web/src/stores/vaultStore.ts
@@ -7,6 +7,7 @@
 
 import { useSyncExternalStore } from 'react';
 import type { Vault } from '@molio/contracts';
+import { api } from '../api/client.js';
 
 type Listener = () => void;
 
@@ -40,6 +41,19 @@ function emit() {
   for (const l of listeners) l();
 }
 
+/**
+ * Push the current active vault id to the daemon so external clients
+ * (e.g. the Molio-forked Web Clipper) can follow "save to the open vault".
+ * Fire-and-forget — failing to sync is non-fatal (UI keeps working locally).
+ */
+function syncActiveVaultToServer(id: string | null): void {
+  void api.setActiveVault(id).catch((err) => {
+    // Swallow: the daemon may be down or unreachable; localStorage still holds
+    // the source of truth for the UI.
+    console.warn('[vaultStore] failed to sync active vault to daemon:', err);
+  });
+}
+
 export const vaultStore = {
   subscribe(cb: Listener) {
     listeners.add(cb);
@@ -59,6 +73,7 @@ export const vaultStore = {
       activeVaultId = id;
       persistVaultId(id);
       emit();
+      syncActiveVaultToServer(id);
     }
   },
 
@@ -76,6 +91,9 @@ export const vaultStore = {
       persistVaultId(activeVaultId);
     }
     emit();
+    // Sync the resolved id to the daemon so external clients (Web Clipper)
+    // follow the user's selection. Idempotent — safe to call on every refresh.
+    syncActiveVaultToServer(activeVaultId);
   },
 };
 

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -27,6 +27,8 @@ interface DesktopAPI {
   renameFile: (oldPath: string, newPath: string) => Promise<string>;
   /** Subscribe to in-page navigation requests from molio:// (no full reload). */
   onNavigate: (callback: (payload: { vaultId: string | null; filePath: string }) => void) => () => void;
+  /** Signal the renderer has mounted its onNavigate listener; main flushes any queued navigation. */
+  notifyReady: () => void;
 }
 
 declare global {

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -25,6 +25,8 @@ interface DesktopAPI {
   openPath: (filePath: string) => Promise<string>;
   showItemInFolder: (filePath: string) => Promise<void>;
   renameFile: (oldPath: string, newPath: string) => Promise<string>;
+  /** Subscribe to in-page navigation requests from molio:// (no full reload). */
+  onNavigate: (callback: (payload: { vaultId: string | null; filePath: string }) => void) => () => void;
 }
 
 declare global {


### PR DESCRIPTION
## Summary

Brings the active-vault clipper ingest feature to desktop + web, and makes `molio://open` reliably open the just-clipped file across every renderer state (cold start, warm, and broken-renderer).

## Problem

When Molio was already running, saving a clip from the Molio-Connect browser extension saved the file to disk but **did not open it** in the app. Logs (`%APPDATA%/Molio/logs/updater.log`) showed:

```
second-instance triggered via molio://open/vault/<id>/file/<path>   ✓ received
renderer not ready — queued navigate: ...                          ✗ queued
(never flushed — file never opened)
```

A stale Molio process holding the single-instance lock with a dead daemon shows the static `daemon-error.html` page (not the SPA), so it never sends `molio:renderer-ready` and the queued navigation was silently dropped. The clip still saved because port 3100 was served by an orphaned daemon, but `molio://open` landed on the broken window and disappeared.

## Changes

**Active-vault + clipper ingest** (commit 8657471, already on branch)
- Daemon exposes the active vault; `molio://open` targets it so clips land where the user is looking.

**Reliable molio://open navigation** (this commit)
- `rendererReady` gate + `pendingNavigation` queue with a `molio:renderer-ready` handshake (`preload.notifyReady` + `App.tsx`) — a cold-start `molio://open` fired before the SPA mounts is no longer dropped.
- `navigateFromProtocolUrl` open-file branch now falls back to a full `loadURL(knowledge route ?vault=&file=)` whenever `rendererReady` is false (splash / error page / mid-reload), instead of queuing. The SPA reads the query params (`KnowledgeBasePage.tsx`) and opens the file. The warm/healthy path still uses in-page IPC (no reload, no state loss).
- `did-start-loading` re-arms `rendererReady` so a queued nav is never delivered to a stale listener after a full reload.
- Bump `@molio/desktop` to 0.3.30.
- Tests: add a regression assertion for the `!rendererReady` → `loadURL` fallback; widen the fragile 900-char source-scan window in `daemon-startup.test.js` to 2000 (the `launch` branch had fallen outside it after the `deliverNavigation` refactor, causing a pre-existing false failure).

## Verification

- `node --test test/**/*.test.js` in `apps/desktop`: **125/125 pass** (was 124/125 with 1 pre-existing false failure).
- `node --check apps/desktop/src/main.js`: clean.

## Notes

- Smoke-testing the actual open behavior requires rebuilding/packaging the desktop app (`pnpm --filter @molio/desktop package:win`) and reinstalling — the user's currently installed v0.3.30 does not contain this fix.
- A deeper root-cause follow-up (why a stale process acquires the single-instance lock during the close→open transition) is left for a separate investigation; the `loadURL` fallback is a robust safety net regardless of that cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)