### PR TITLE
fix(web): 首次发送后输入框未清空（landing→chat-active 重挂载竞态）

### DIFF
--- a/apps/web/e2e/chat-single.spec.ts
+++ b/apps/web/e2e/chat-single.spec.ts
@@ -107,4 +107,29 @@ test.describe('Chat — single turn', () => {
     // Chat header should be visible
     await expect(page.locator('.home-header')).toBeVisible();
   });
+
+  test('composer input is cleared after first send (landing → chat-active remount)', async ({ page }) => {
+    // Regression: the landing-page composer and the chat-active composer are
+    // different component instances sharing the `home` draft cache. On the
+    // first send, HomePage switches branches and unmounts the landing
+    // composer before its draft-sync effect can run for the queued
+    // setText(''), so the chat-active composer rehydrated from the stale
+    // draft and the input was not cleared.
+    await gotoHome(page);
+
+    const textarea = page.locator('[data-testid="composer-input"]');
+    await sendMessage(page, 'Hello world');
+
+    // User bubble must be present (send actually happened)
+    await expect(page.locator('[data-testid="user-message"]')).toBeVisible({ timeout: 5_000 });
+
+    // Input must be cleared after the branch switch
+    await expect(textarea).toHaveValue('');
+
+    // And the draft must not resurrect on the next render — type again, send
+    // a second message, and confirm the input clears once more.
+    await textarea.fill('Second message');
+    await textarea.press('Enter');
+    await expect(textarea).toHaveValue('');
+  });
 });

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -199,6 +199,14 @@ export function ChatComposer({
     if (hasContent && !isRunning) {
       onSend(trimmed, fileRefs, doneImages);
       setText('');
+      // Clear the draft cache synchronously *before* the parent re-renders.
+      // On the home page, the first send flips HomePage from the landing
+      // branch to the chat-active branch, which unmounts this ChatComposer
+      // and mounts a fresh one. That unmount happens before the draft-sync
+      // effect (which depends on `text`) can run for the just-queued
+      // setText(''), so the new instance would otherwise rehydrate from the
+      // stale draft and the input would not be cleared.
+      if (composerKey) drafts.delete(composerKey);
       setFileRefs([]);
       // Revoke any remaining blob URLs (error/uploading thumbs) before clearing.
       for (const img of pastedImages) {


### PR DESCRIPTION
## 问题

主页空会话第一次发送消息后，输入框里的文本没被清空，仍保留刚发出去的内容。

## 根因

`HomePage` 有两个渲染分支，都渲染了 `composerKey=\"home\"` 的 `ChatComposer`：

- landing 分支（`messages.length === 0`）：ChatComposer 位于 `home-hero-view > home-composer-wrap`
- chat-active 分支（`messages.length > 0`）：ChatComposer 位于 `home-composer-bar`

首次发送时 `useChatCore.send` 同步乐观追加 user+assistant 消息，`messages.length` 立刻变 >0，HomePage 切到 chat-active 分支。由于两个分支下 ChatComposer 的父子链不同，React 把旧的卸载、挂一个全新实例。旧实例里 `setText('')` 还没提交就被丢弃，依赖 `[text]` 的 draft-sync `useEffect` 也没机会跑，于是 `drafts.get('home')` 仍是刚发送的文本 → 新实例回填 → 输入框没清空。

第 2 条及以后的消息不会触发，因为此时已在 chat-active 分支，ChatComposer 不再 unmount/remount，`setText('')` 正常提交。

## 引入

`8cd56e3` feat(web): KB 聊天状态跨导航持久化 (#132) 引入了 module-level draft 缓存 + `useState(() => drafts.get(composerKey) ?? '')`。之前用 `useState('')` 不存在此问题。

Regression-Of: #132

## 修复

在 `ChatComposer.handleSend` 里，于 `onSend` 之后、`setText('')` 之外**同步**删除 draft 缓存条目，确保父组件重渲染并重挂载 composer 之前 draft 已清空，新实例读到空串。

## 验证

- 本地 `pnpm dev` + Playwright 跑 `chat-single.spec.ts` 全绿（含新增用例）。
- 新增 P0 回归用例 `composer input is cleared after first send (landing → chat-active remount)`：覆盖首次发送（触发分支切换）+ 第二次发送后输入框均为空。

## 影响范围

- 触及 `ChatComposer.tsx`（属 E2E 核心流程保护清单），已同步 E2E，同 commit 提交。
- 改动仅 `handleSend` 内一行 `drafts.delete(composerKey)`，不影响 KB / file-chat 等其它 host（它们不发生分支切换重挂载，行为不变）。