### PR TITLE
fix(web): 修复知识库打开大文件卡死（如 4MB .json）

### DIFF
--- a/apps/web/e2e/area-map.json
+++ b/apps/web/e2e/area-map.json
@@ -30,7 +30,7 @@
         "apps/daemon/src/core/db.ts",
         "apps/daemon/src/routes/knowledge.ts"
       ],
-      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry"]
+      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry", "kb-large-file"]
     },
     "publish": {
       "paths": [
@@ -111,6 +111,7 @@
     "knowledge": { "priority": "P0", "file": "knowledge.spec.ts" },
     "kb-tree-sort-locate": { "priority": "P1", "file": "kb-tree-sort-locate.spec.ts" },
     "kb-chat-entry": { "priority": "P1", "file": "kb-chat-entry.spec.ts" },
+    "kb-large-file": { "priority": "P0", "file": "kb-large-file.spec.ts" },
         "markdown-render": { "priority": "P1", "file": "markdown-render.spec.ts" },
     "navigation": { "priority": "P1", "file": "navigation.spec.ts" },
     "publish-flow": { "priority": "P0", "file": "publish-flow.spec.ts" },

--- a/apps/web/e2e/kb-large-file.spec.ts
+++ b/apps/web/e2e/kb-large-file.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * @area kb
+ * @priority P0
+ *
+ * Regression test for the test.json freeze: a large text file (e.g. a 4 MB
+ * `.json`) used to be fed straight into the doocs/md pipeline (`marked` +
+ * `DOMPurify.sanitize` on a multi-MB string), which blocked the main thread
+ * and froze the UI. Because the KB tab store re-opens the last-active file on
+ * restart, the app stayed bricked until localStorage was wiped.
+ *
+ * Now files beyond LARGE_TEXT_THRESHOLD (256 KB) render as a full,
+ * non-wrapping monospace `<pre>` (no truncation) and skip `countWords`,
+ * so the UI stays responsive.
+ */
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { gotoHome, clickNav } from './helpers/navigation';
+import { createTempVault, cleanupTempVault, type TempVault } from './helpers/cleanup';
+
+let vault: TempVault;
+
+test.describe('KB large-text file', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-large-file');
+    // A >256 KB JSON file — big enough to trip LARGE_TEXT_THRESHOLD but small
+    // enough to keep the test fast. Each entry ~100 bytes; 4000 entries ≈ 400 KB.
+    const entries = Array.from({ length: 4000 }, (_, i) => ({
+      id: i,
+      name: `entity-${i}`,
+      description: '五专业59本建筑规范实体特征上下位跨规范引用统一知识库占位文本',
+    }));
+    fs.writeFileSync(path.join(vault.path, 'big.json'), JSON.stringify(entries, null, 2));
+  });
+  test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
+
+  test('renders lightweight preview without freezing the UI', async ({ page }) => {
+    await gotoHome(page);
+    await clickNav(page, 'knowledge');
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+
+    const fileNode = page.locator('.kb-tree-item').filter({ hasText: 'big.json' });
+    await fileNode.waitFor({ state: 'visible', timeout: 10_000 });
+
+    // The proof that we did NOT freeze: the preview appears quickly. If the
+    // old code path ran, marked + DOMPurify on ~400 KB would block for many
+    // seconds and this assertion would time out.
+    await fileNode.click();
+    const preview = page.locator('[data-testid="kb-large-text-preview"]');
+    await expect(preview).toBeVisible({ timeout: 8_000 });
+
+    // The <pre> must actually contain file content, not a blank.
+    await expect(preview.locator('.kb-large-text-pre')).not.toBeEmpty();
+    // The full file is shown (no truncation): the last generated entry is
+    // present. If a cap were reintroduced, this would fail.
+    await expect(preview.locator('.kb-large-text-pre')).toContainText('entity-3999');
+    // Notice mentions the file name and that rendering was skipped.
+    await expect(preview.locator('.kb-large-text-notice')).toContainText('big.json');
+
+    // Status bar shows size (not the expensive word count) for large files.
+    const statusBar = page.locator('[data-testid="kb-status-bar"]');
+    await expect(statusBar).toBeVisible({ timeout: 5_000 });
+    await expect(statusBar).toContainText('大小');
+
+    // UI is still responsive — clicking another nav target works immediately.
+    await clickNav(page, 'home');
+    await expect(page.locator('.kb-shell')).toHaveCount(0, { timeout: 5_000 });
+  });
+});

--- a/apps/web/src/components/kb/KbMainContent.tsx
+++ b/apps/web/src/components/kb/KbMainContent.tsx
@@ -40,6 +40,17 @@ type FileCategory = 'text' | 'image' | 'binary';
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico']);
 const BINARY_EXTS = new Set(['.pdf', '.docx', '.doc', '.pptx', '.ppt', '.xlsx', '.xls']);
 
+/**
+ * Files larger than this are NOT run through the doocs/md pipeline
+ * (`marked` tokenization + `DOMPurify.sanitize` on a multi-MB string builds a
+ * full DOM tree and walks it synchronously on the main thread → UI freeze).
+ * Instead they render as a full, non-wrapping monospace `<pre>` (horizontal
+ * scroll for long lines, no truncation). This is still O(whole-file) for
+ * layout — fine up to ~tens of MB; a virtualized viewer (CodeMirror) is the
+ * proper fix for truly huge files. See test.json (4.3 MB) freeze bug.
+ */
+const LARGE_TEXT_THRESHOLD = 256 * 1024; // 256 KB (string length, i.e. UTF-16 chars)
+
 function getFileCategory(fileName: string): FileCategory {
   const ext = fileName.slice(fileName.lastIndexOf('.')).toLowerCase();
   if (IMAGE_EXTS.has(ext)) return 'image';
@@ -131,11 +142,26 @@ export function KbMainContent({
   const contentRef = useRef<HTMLDivElement>(null);
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
 
+  // Raw text for the current file — the source of truth for both the
+  // markdown pipeline and the large-text fallback. Memoized so downstream
+  // memos / child components don't see a fresh string on unrelated re-renders.
+  const rawContent = useMemo(
+    () => editedContent ?? fileContent?.content ?? '',
+    [editedContent, fileContent?.content],
+  );
+
+  // Large text files bypass the doocs/md pipeline entirely (see
+  // LARGE_TEXT_THRESHOLD). This also short-circuits the three global-regex
+  // preprocessing passes below, which are O(n) over the whole string.
+  const isLargeText = rawContent.length > LARGE_TEXT_THRESHOLD;
+
   // Memoize the rendered markdown content so MdRenderer (wrapped in memo)
   // doesn't see a new string prop on unrelated re-renders.
   const renderedContent = useMemo(
-    () => proxyExternalImages(preprocessWikiEmbeds(stripTrackingPixels(editedContent ?? fileContent?.content ?? ''), vaultId ?? '')),
-    [editedContent, fileContent?.content, vaultId],
+    () => isLargeText
+      ? rawContent
+      : proxyExternalImages(preprocessWikiEmbeds(stripTrackingPixels(rawContent), vaultId ?? '')),
+    [rawContent, isLargeText, vaultId],
   );
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
@@ -361,7 +387,7 @@ export function KbMainContent({
           <p className="kb-load-error-path">{selectedFile}</p>
           <p className="kb-load-error-hint">{t('kb.fileNotFound')}</p>
         </div>
-      ) : category === 'text' && isTypesetMode ? (
+      ) : category === 'text' && isTypesetMode && !isLargeText ? (
         <MdTypesetEditor
           key={selectedFile}
           initialContent={fileContent?.content ?? ''}
@@ -369,7 +395,7 @@ export function KbMainContent({
           vaultId={vaultId ?? ''}
           selectedFile={selectedFile}
         />
-      ) : category === 'text' && isEditMode ? (
+      ) : category === 'text' && isEditMode && !isLargeText ? (
         // Edit mode: Milkdown WYSIWYG Markdown editor
         <MdEditor
           initialContent={fileContent?.content ?? ''}
@@ -379,8 +405,25 @@ export function KbMainContent({
       ) : category === 'text' ? (
         <div className="kb-content-area" ref={contentRef} onContextMenu={handleContextMenu}>
           {fileContent ? (
-            // 优先使用编辑后的内容（未保存的更改），否则使用原始文件内容
-            <MdRenderer content={renderedContent} themeConfig={themeConfig} />
+            isLargeText ? (
+              // Large text: skip marked + DOMPurify (would freeze the main
+              // thread). Render the FULL content as a monospace, non-wrapping
+              // <pre> (horizontal scroll for long lines) — no truncation.
+              // Still O(whole-file) for layout; a virtualized viewer is the
+              // proper fix for huge files (see follow-up plan).
+              <div className="kb-large-text-preview" data-testid="kb-large-text-preview">
+                <div className="kb-large-text-notice">
+                  {t('kb.largeFileNotice', {
+                    name: fileName,
+                    size: formatFileSize(fileContent.size),
+                  })}
+                </div>
+                <pre className="kb-large-text-pre">{rawContent}</pre>
+              </div>
+            ) : (
+              // 优先使用编辑后的内容（未保存的更改），否则使用原始文件内容
+              <MdRenderer content={renderedContent} themeConfig={themeConfig} />
+            )
           ) : (
             <div className="kb-empty-state"><p>Loading...</p></div>
           )}
@@ -513,6 +556,17 @@ export function KbMainContent({
         <div className="kb-status-bar" data-testid="kb-status-bar">
           {(() => {
             const text = editedContent ?? fileContent?.content ?? '';
+            // Skip the two regex scans in countWords for large files — they
+            // run on every render and are O(n) over a multi-MB string.
+            if (text.length > LARGE_TEXT_THRESHOLD) {
+              return (
+                <>
+                  <span>{t('kb.statsSize')}: {formatFileSize(text.length)}</span>
+                  <span className="kb-status-sep">/</span>
+                  <span>{t('kb.statsChars')}: {text.length.toLocaleString()}</span>
+                </>
+              );
+            }
             const words = countWords(text);
             const chars = text.length;
             return (

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -260,6 +260,8 @@ const en: Record<string, string> = {
   'kb.statsChars': 'Chars',
   'kb.statsReadTime': 'Read',
   'kb.statsReadTimeSuffix': 'min',
+  'kb.statsSize': 'Size',
+  'kb.largeFileNotice': '{name} · {size}: file too large, skipped Markdown rendering, shown as plain text.',
   'kb.askAboutFile': 'Ask AI',
   'kb.askSelection': 'Ask about this',
   'kb.cannotOpen': 'Cannot open file',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -260,6 +260,8 @@ const zh: Record<string, string> = {
   'kb.statsChars': '字符',
   'kb.statsReadTime': '阅读时间',
   'kb.statsReadTimeSuffix': '分钟',
+  'kb.statsSize': '大小',
+  'kb.largeFileNotice': '{name} · {size}：文件过大，已跳过 Markdown 渲染，以纯文本显示。',
   'kb.askAboutFile': '问答',
   'kb.askSelection': '就此提问',
   'kb.cannotOpen': '无法打开文件',

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -904,6 +904,41 @@
   opacity: 0.5;
 }
 
+/* ── Large-text fallback preview ──
+   Files beyond LARGE_TEXT_THRESHOLD bypass doocs/md (marked + DOMPurify
+   would freeze the main thread). Shown as a truncated monospace block. */
+.kb-large-text-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.kb-large-text-notice {
+  padding: 10px 14px;
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.kb-large-text-pre {
+  margin: 0;
+  padding: 16px 20px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 13px;
+  line-height: 1.5;
+  /* No wrapping: long lines scroll horizontally. Avoids the O(n) wrap
+     recalculation that pre-wrap does on every resize/scroll for big files. */
+  white-space: pre;
+  overflow: auto;
+  max-height: 70vh;
+  color: var(--text);
+}
+
 /* ══════════ Edit Mode Editor ══════════ */
 
 .kb-edit-mode {


### PR DESCRIPTION
## 问题

打开大文本文件（如 `test.json` 4.3MB / 11 万行）时，Molio 把它当成普通文本文档走完整 doocs/md 渲染管线，主线程被 `marked` 全量分词 + `DOMPurify.sanitize`（在多 MB HTML 上建整棵 DOM 树遍历）同步阻塞数秒，界面完全卡死。

更糟：`kbTabsStore` 把上次打开的标签记在 localStorage，重启时自动恢复打开该文件 → 一开机又卡死 → 死循环，只能手动清 localStorage 才能解锁。

## 根因

`KbMainContent` 把 `.json` 归为 `'text'` 后无条件交给 `MdRenderer`，整条链路无尺寸保护：
- 3 遍全文正则预处理（`stripTrackingPixels` / `preprocessWikiEmbeds` / `proxyExternalImages`）
- `marked.parse` 全量分词
- `DOMPurify.sanitize` 在多 MB HTML 上建 DOM 树遍历 ← 卡死元凶
- 多 MB HTML `dangerouslySetInnerHTML` 注入
- 状态栏 `countWords` 每次渲染对全文跑两遍正则

`hljs` 和 `JSON.parse` 是红鲱鱼：裸 JSON 没有 `\`\`\` 围栏，`hljs` 不会被触发；也没有 `JSON.parse`。

## 修复

加一道 `LARGE_TEXT_THRESHOLD = 256KB` 闸门。超过该大小的文本文件**绕过整条 doocs/md 流水线**，改走轻量路径：直接渲染为全量、不换行的等宽 `<pre>`（横向滚动，无截断）。

| 环节 | 之前 | 现在（>256KB） |
|---|---|---|
| 预处理 | 3 遍全文正则 | 跳过 |
| 渲染 | marked + DOMPurify | 跳过，直接 `<pre>` 纯文本 |
| HTML 注入 | 多 MB innerHTML | 单文本节点 |
| 排版/编辑模式 | 也会卡 | 同样被闸门挡掉，走 `<pre>` |
| 状态栏 | `countWords` 全文正则 | 跳过，只显示大小+字符数 |

256KB 是故意卡在 "DOMPurify 开始变重之前" 的安全线（~50~250ms 无感），保证闸门以下文件渲染不延迟。

## 改动文件

- `apps/web/src/components/kb/KbMainContent.tsx`：`LARGE_TEXT_THRESHOLD` 闸门 + 大文件 `<pre>` 预览分支 + 跳过预处理/`countWords`
- `apps/web/src/styles/knowledge.css`：`.kb-large-text-preview` / `.kb-large-text-pre` 样式
- `apps/web/src/i18n/locales/{zh,en}.ts`：`kb.largeFileNotice` + `kb.statsSize`
- `apps/web/e2e/kb-large-file.spec.ts`：新增 P0 回归测试
- `apps/web/e2e/area-map.json`：登记为新 P0 spec

## 测试

- 新 E2E `kb-large-file.spec.ts`：造 400KB JSON，点开，断言预览 8s 内出现、最后一条记录 `entity-3999` 可见（证明无截断）、界面仍可响应。临时关闭闸门后该测试 8s 超时失败，证明能抓回归。
- 全量 KB/knowledge/markdown/navigation E2E 共 46 项全绿（小文件渲染未受影响）。
- `pnpm typecheck` 全包通过。

## 已知限制 / 后续

- 大文件无 Markdown 排版和语法高亮（`<pre>` 纯文本）。这是有意为之：这类文件走 Markdown 渲染本来就是错的（JSON 渲染成乱段落）。
- `<pre>` 仍是 O(whole-file) 排版，几十 MB 以上会掉帧。**治本方案**是引入虚拟化代码查看器（CodeMirror，只渲染可见行），已记录为后续 follow-up，等真实大文件掉帧需求再启动，不为单个 4MB 文件过度工程。
- 没有动 daemon / `api.readFile` / vault 数据，只改前端渲染。
- 缓存导致的重启死循环未直接改 `kbTabsStore`，但被化解：现在打开大文件不再卡，重启自动恢复也只是秒开预览。