### PR TITLE
feat(kb): backend-authoritative path resolution for doc links

### DIFF
--- a/apps/daemon/src/core/knowledge.ts
+++ b/apps/daemon/src/core/knowledge.ts
@@ -128,10 +128,22 @@ function resolveWithFallbacks(vaultPath: string, relPath: string): string {
     const exact = resolveFilePath(vaultPath, baseRelPath);
     if (fs.existsSync(exact)) return exact;
 
-    // Strategy B: add .md extension
+    // Strategy B: add .md extension (preserve on-disk case by listing entries)
     if (!hasExt) {
       const md = resolveFilePath(vaultPath, baseRelPath + '.md');
-      if (fs.existsSync(md)) return md;
+      const mdDir = path.dirname(md);
+      const mdBase = path.basename(md);
+      try {
+        const mdEntries = fs.readdirSync(mdDir);
+        const mdMatch = mdEntries.find((e) => e.toLowerCase() === mdBase.toLowerCase());
+        if (mdMatch) {
+          const candidate = path.join(mdDir, mdMatch);
+          assertWithinVault(vaultPath, candidate);
+          return candidate;
+        }
+      } catch {
+        // directory not found — continue to next strategy
+      }
     }
 
     // Strategy C: case-insensitive search in the target directory
@@ -142,9 +154,19 @@ function resolveWithFallbacks(vaultPath: string, relPath: string): string {
       const entries = fs.readdirSync(targetDir);
       // Exact case-insensitive match
       let match = entries.find((e) => e.toLowerCase() === targetLower);
-      // Try with .md if original has no extension
+      // Try with .md if original has no extension (.md has priority over other exts)
       if (!match && !hasExt) {
         match = entries.find((e) => e.toLowerCase() === targetLower + '.md');
+      }
+      // Stem match for any other supported extension. .md was already tried
+      // above, so this only fires for non-md files (e.g. [[entities/报告]] →
+      // 报告.pdf). Mirrors the daemon-wide rule that .md is the primary format.
+      if (!match && !hasExt) {
+        match = entries.find((e) => {
+          const eExt = path.extname(e).toLowerCase();
+          if (eExt === '.md' || !ALLOWED_EXTS.includes(eExt)) return false;
+          return path.basename(e, eExt).toLowerCase() === targetLower;
+        });
       }
       if (match) {
         // Re-validate so a matched entry can never bypass the vault boundary
@@ -229,6 +251,37 @@ export function resolveFilePath(vaultPath: string, relPath: string): string {
   const resolved = path.resolve(absFile);
   assertWithinVault(vaultPath, resolved);
   return resolved;
+}
+
+/**
+ * Resolve a vault-relative path to its canonical vault-relative path (with the
+ * real on-disk extension), WITHOUT reading the file. Returns null if no file
+ * matches. Used by the resolve API so the frontend can normalize assistant /
+ * molio:// / wiki-link paths against the same logic readFile uses — keeping
+ * "open from chat link" consistent with "open from directory".
+ */
+export function resolveCanonicalPath(vaultPath: string, relPath: string): string | null {
+  if (!relPath) return null;
+  let resolved: string;
+  try {
+    resolved = resolveFilePath(vaultPath, relPath);
+    if (!fs.existsSync(resolved)) {
+      resolved = resolveWithFallbacks(vaultPath, relPath);
+    }
+  } catch {
+    return null;
+  }
+  if (!fs.existsSync(resolved)) return null;
+  try {
+    // Security: confirm the real path is still inside the vault (symlink-escape
+    // guard). We do NOT use the realpath for the relative path computation —
+    // scanTree stores paths relative to the (non-realpath) vaultPath, so we
+    // match that to keep tree node.path equality correct.
+    resolveRealWithinVault(vaultPath, resolved);
+  } catch {
+    return null;
+  }
+  return path.relative(path.resolve(vaultPath), resolved).split(path.sep).join('/');
 }
 
 /**

--- a/apps/daemon/src/routes/knowledge.ts
+++ b/apps/daemon/src/routes/knowledge.ts
@@ -25,6 +25,7 @@ import {
   countFiles,
   readFile,
   resolveFilePath,
+  resolveCanonicalPath,
   writeFile,
   deleteFile,
   createDirectory,
@@ -175,6 +176,31 @@ export function knowledgeRoutes(
       }
       return c.json({ error: { code: 'INTERNAL', message } }, 500);
     }
+  });
+
+  // GET /api/knowledge/vaults/:id/resolve/* — resolve a (possibly extension-less
+  // or wiki-prefix-less) path to its canonical vault-relative path. Used by the
+  // frontend when opening files from assistant links / molio:// / graph, so the
+  // tab title and tree highlight match the real on-disk file.
+  app.get('/vaults/:id/resolve/*', (c) => {
+    const vault = getVault(db, c.req.param('id'));
+    if (!vault) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'Vault not found' } }, 404);
+    }
+
+    const fullPath = c.req.path;
+    const prefix = `/api/knowledge/vaults/${vault.id}/resolve/`;
+    const relPath = decodeURIComponent(fullPath.slice(prefix.length));
+
+    if (!relPath) {
+      return c.json({ error: { code: 'BAD_REQUEST', message: 'File path is required' } }, 400);
+    }
+
+    const canonical = resolveCanonicalPath(vault.path, relPath);
+    if (canonical === null) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'File not found' } }, 404);
+    }
+    return c.json({ path: canonical });
   });
 
   // POST /api/knowledge/vaults/:id/files/* — write/create a file

--- a/apps/daemon/test/core/knowledge.test.ts
+++ b/apps/daemon/test/core/knowledge.test.ts
@@ -13,6 +13,7 @@ import {
   resolveFilePath,
   scanTree,
   countFiles,
+  resolveCanonicalPath,
 } from '../../src/core/knowledge.js';
 
 describe('knowledge filesystem operations', () => {
@@ -419,6 +420,62 @@ describe('knowledge filesystem operations', () => {
       mkdirSync(join(vaultPath, '.molio', 'assets'), { recursive: true });
       writeFile(vaultPath, '.molio/assets/hidden.md', 'hidden content');
       assert.throws(() => readFile(vaultPath, 'hidden'));
+    });
+  });
+
+  describe('resolveCanonicalPath', () => {
+    it('exact path returns the path unchanged', () => {
+      writeFile(vaultPath, 'exact.md', '# x\n');
+      assert.equal(resolveCanonicalPath(vaultPath, 'exact.md'), 'exact.md');
+    });
+
+    it('appends .md when input has no extension', () => {
+      writeFile(vaultPath, 'bar.md', '# x\n');
+      assert.equal(resolveCanonicalPath(vaultPath, 'bar'), 'bar.md');
+    });
+
+    it('tries the wiki/ prefix when the link drops it', () => {
+      mkdirSync(join(vaultPath, 'wiki', 'entities'), { recursive: true });
+      writeFileSync(join(vaultPath, 'wiki', 'entities', '宇树科技.md'), '# x\n');
+      assert.equal(
+        resolveCanonicalPath(vaultPath, 'entities/宇树科技'),
+        'wiki/entities/宇树科技.md',
+      );
+    });
+
+    it('stem-matches a non-md file when the link omits the extension', () => {
+      mkdirSync(join(vaultPath, 'wiki', 'entities'), { recursive: true });
+      writeFileSync(join(vaultPath, 'wiki', 'entities', '季度报告.pdf'), '%PDF-1.4\n');
+      assert.equal(
+        resolveCanonicalPath(vaultPath, 'entities/季度报告'),
+        'wiki/entities/季度报告.pdf',
+      );
+    });
+
+    it('prefers .md over other extensions with the same stem', () => {
+      mkdirSync(join(vaultPath, 'docs'), { recursive: true });
+      writeFileSync(join(vaultPath, 'docs', 'dup.md'), '# md\n');
+      writeFileSync(join(vaultPath, 'docs', 'dup.pdf'), '%PDF\n');
+      assert.equal(resolveCanonicalPath(vaultPath, 'docs/dup'), 'docs/dup.md');
+    });
+
+    it('bare page name resolves anywhere in the tree', () => {
+      mkdirSync(join(vaultPath, 'wiki', 'deep'), { recursive: true });
+      writeFileSync(join(vaultPath, 'wiki', 'deep', '概念.md'), '# x\n');
+      assert.equal(resolveCanonicalPath(vaultPath, '概念'), 'wiki/deep/概念.md');
+    });
+
+    it('case-insensitive match', () => {
+      writeFileSync(join(vaultPath, 'Case.md'), '# x\n');
+      assert.equal(resolveCanonicalPath(vaultPath, 'case'), 'Case.md');
+    });
+
+    it('returns null when nothing matches', () => {
+      assert.equal(resolveCanonicalPath(vaultPath, 'nope/missing'), null);
+    });
+
+    it('returns null for empty input', () => {
+      assert.equal(resolveCanonicalPath(vaultPath, ''), null);
     });
   });
 });

--- a/apps/daemon/test/routes/knowledge.test.ts
+++ b/apps/daemon/test/routes/knowledge.test.ts
@@ -340,6 +340,7 @@ describe('Knowledge routes — file operations', () => {
 
   describe('GET /vaults/:id/resolve/*', () => {
     it('returns the canonical path for an extension-less link', async () => {
+      mkdirSync(join(vaultDir, 'notes'), { recursive: true });
       writeFileSync(join(vaultDir, 'notes', 'idea.md'), '# idea\n');
       const res = await app.request(
         `/api/knowledge/vaults/${vaultId}/resolve/notes/idea`,

--- a/apps/daemon/test/routes/knowledge.test.ts
+++ b/apps/daemon/test/routes/knowledge.test.ts
@@ -337,4 +337,50 @@ describe('Knowledge routes — file operations', () => {
       assert.ok(typeof entry['createdAt'] === 'number', 'entry should have createdAt');
     });
   });
+
+  describe('GET /vaults/:id/resolve/*', () => {
+    it('returns the canonical path for an extension-less link', async () => {
+      writeFileSync(join(vaultDir, 'notes', 'idea.md'), '# idea\n');
+      const res = await app.request(
+        `/api/knowledge/vaults/${vaultId}/resolve/notes/idea`,
+      );
+      assert.equal(res.status, 200);
+      const body = await json(res);
+      assert.equal(body.path, 'notes/idea.md');
+    });
+
+    it('resolves a wiki-link missing the wiki/ prefix', async () => {
+      mkdirSync(join(vaultDir, 'wiki', 'entities'), { recursive: true });
+      writeFileSync(join(vaultDir, 'wiki', 'entities', '宇树科技.md'), '# x\n');
+      const res = await app.request(
+        `/api/knowledge/vaults/${vaultId}/resolve/entities/${encodeURIComponent('宇树科技')}`,
+      );
+      assert.equal(res.status, 200);
+      const body = await json(res);
+      assert.equal(body.path, `wiki/entities/宇树科技.md`);
+    });
+
+    it('stem-matches a non-md file', async () => {
+      mkdirSync(join(vaultDir, 'wiki', 'entities'), { recursive: true });
+      writeFileSync(join(vaultDir, 'wiki', 'entities', '季度报告.pdf'), '%PDF\n');
+      const res = await app.request(
+        `/api/knowledge/vaults/${vaultId}/resolve/entities/${encodeURIComponent('季度报告')}`,
+      );
+      assert.equal(res.status, 200);
+      const body = await json(res);
+      assert.equal(body.path, `wiki/entities/季度报告.pdf`);
+    });
+
+    it('returns 404 when nothing matches', async () => {
+      const res = await app.request(
+        `/api/knowledge/vaults/${vaultId}/resolve/does/not/exist`,
+      );
+      assert.equal(res.status, 404);
+    });
+
+    it('returns 404 for unknown vault', async () => {
+      const res = await app.request('/api/knowledge/vaults/non-existent/resolve/foo');
+      assert.equal(res.status, 404);
+    });
+  });
 });

--- a/apps/web/e2e/kb-tree-sort-locate.spec.ts
+++ b/apps/web/e2e/kb-tree-sort-locate.spec.ts
@@ -106,4 +106,98 @@ test.describe('KB tree sort + locate', () => {
     await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
     await expect(page.locator('[data-testid="kb-btn-locate"]')).toBeDisabled();
   });
+
+  // Regression: extension-less file links (assistant markdown links and
+  // molio:// URLs routinely omit ".md"). The daemon's readFile tolerates the
+  // missing extension so the file opens, but the frontend must normalize the
+  // path against the tree so the tab title carries the format and the locate
+  // button can match the active tree row. Mirrors the canonical-path case above.
+  test('extension-less link opens with formatted title and is locatable', async ({ page }) => {
+    // Same file as the canonical test above, but the URL omits ".md".
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}&file=dirA/subA/deep`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-group-label').filter({ hasText: 'dirA' })).toBeVisible({ timeout: 10_000 });
+
+    // Tab title must carry the on-disk extension, not the raw link text.
+    await expect(page.locator('.kb-wtab-title').filter({ hasText: 'deep.md' })).toBeVisible({ timeout: 5_000 });
+
+    // deep.md hidden while ancestors are collapsed
+    await expect(page.locator('.kb-tree-item').filter({ hasText: 'deep.md' })).not.toBeVisible();
+
+    const locate = page.locator('[data-testid="kb-btn-locate"]');
+    await expect(locate).not.toBeDisabled();
+    await locate.click();
+
+    // Ancestors expanded → deep.md visible AND marked active (path matched).
+    const deepItem = page.locator('.kb-tree-item').filter({ hasText: 'deep.md' });
+    await expect(deepItem).toBeVisible();
+    await expect(deepItem).toHaveClass(/is-active/);
+  });
+
+  // Regression: bare page-name links (wiki-style "[[deep]]") resolve to the
+  // file anywhere in the tree, not just at the root.
+  test('bare page-name link resolves to nested file and is locatable', async ({ page }) => {
+    // "deep" has no directory component — resolver must walk the tree.
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}&file=deep`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-group-label').filter({ hasText: 'dirA' })).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.locator('.kb-wtab-title').filter({ hasText: 'deep.md' })).toBeVisible({ timeout: 5_000 });
+
+    const locate = page.locator('[data-testid="kb-btn-locate"]');
+    await expect(locate).not.toBeDisabled();
+    await locate.click();
+
+    const deepItem = page.locator('.kb-tree-item').filter({ hasText: 'deep.md' });
+    await expect(deepItem).toBeVisible();
+    await expect(deepItem).toHaveClass(/is-active/);
+  });
+
+  // Regression: wiki-links routinely drop the "wiki/" prefix — e.g.
+  // [[entities/宇树科技]] points at wiki/entities/宇树科技.md. The link carries
+  // a directory component (so the bare-name walker doesn't fire) AND omits both
+  // the prefix and ".md". The resolver must try the wiki/ prefix, mirroring the
+  // daemon's resolveWithFallbacks.
+  test('wiki-link missing the wiki/ prefix resolves to the nested file', async ({ page }) => {
+    fs.mkdirSync(path.join(vault.path, 'wiki', 'entities'), { recursive: true });
+    fs.writeFileSync(path.join(vault.path, 'wiki', 'entities', '宇树科技.md'), '# 宇树\n');
+
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}&file=entities/宇树科技`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-group-label').filter({ hasText: 'wiki' })).toBeVisible({ timeout: 10_000 });
+
+    // Tab title carries the on-disk name (with .md), not the raw link text.
+    await expect(page.locator('.kb-wtab-title').filter({ hasText: '宇树科技.md' })).toBeVisible({ timeout: 5_000 });
+
+    const locate = page.locator('[data-testid="kb-btn-locate"]');
+    await expect(locate).not.toBeDisabled();
+    await locate.click();
+
+    const item = page.locator('.kb-tree-item').filter({ hasText: '宇树科技.md' });
+    await expect(item).toBeVisible();
+    await expect(item).toHaveClass(/is-active/);
+  });
+
+  // Regression: non-md file. A link like [[entities/季度报告]] (dir + no ext)
+  // must resolve to 季度报告.pdf via stem matching, not just .md. Stem MUST
+  // differ from the 宇树科技.md test above, or .md-priority would pick the .md.
+  test('non-md file resolves via stem match when link omits extension', async ({ page }) => {
+    fs.mkdirSync(path.join(vault.path, 'wiki', 'entities'), { recursive: true });
+    fs.writeFileSync(path.join(vault.path, 'wiki', 'entities', '季度报告.pdf'), '%PDF-1.4\n');
+
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}&file=entities/季度报告`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-group-label').filter({ hasText: 'wiki' })).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.locator('.kb-wtab-title').filter({ hasText: '季度报告.pdf' })).toBeVisible({ timeout: 5_000 });
+
+    const locate = page.locator('[data-testid="kb-btn-locate"]');
+    await expect(locate).not.toBeDisabled();
+    await locate.click();
+
+    const item = page.locator('.kb-tree-item').filter({ hasText: '季度报告.pdf' });
+    await expect(item).toBeVisible();
+    await expect(item).toHaveClass(/is-active/);
+  });
+
 });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -384,6 +384,22 @@ export const api = {
     return res.json();
   },
 
+  /**
+   * Resolve a (possibly extension-less / wiki-prefix-less) file path to its
+   * canonical vault-relative path with the real on-disk extension. Returns
+   * null on 404 (no match); throws on other errors. Used when opening files
+   * from assistant links / molio:// / graph so the tab title and tree highlight
+   * match the real file.
+   */
+  async resolveFilePath(vaultId: string, filePath: string): Promise<string | null> {
+    const encoded = encodeURIComponent(filePath).replace(/%2F/g, '/');
+    const res = await fetch(`${BASE}/knowledge/vaults/${vaultId}/resolve/${encoded}`);
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`Failed to resolve file path: ${res.status}`);
+    const data = await res.json();
+    return data.path as string;
+  },
+
   /** Build URL for raw file access (images, PDFs, etc.) */
   rawFileUrl(vaultId: string, filePath: string): string {
     const encoded = encodeURIComponent(filePath).replace(/%2F/g, '/');

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -262,7 +262,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     });
   }, [tabs, kb, runOrConfirmDiscard]);
 
-  // Sync: when URL navigation resolves, open in tab. The path from external
+  // When URL navigation resolves, open in tab. The path from external
   // navigation (assistant links, molio://, graph) may omit the extension and/or
   // wiki/ prefix, so ask the daemon to canonicalize it before opening — this
   // keeps tab title, tree highlighting, and "在目录中定位" consistent with

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -262,15 +262,34 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     });
   }, [tabs, kb, runOrConfirmDiscard]);
 
-  // Sync: when URL navigation resolves, open in tab
+  // Sync: when URL navigation resolves, open in tab. The path from external
+  // navigation (assistant links, molio://, graph) may omit the extension and/or
+  // wiki/ prefix, so ask the daemon to canonicalize it before opening — this
+  // keeps tab title, tree highlighting, and "在目录中定位" consistent with
+  // opening from the directory tree.
   useEffect(() => {
     if (!pendingUrlNav) return;
     if (kb.activeVault?.id !== pendingUrlNav.vaultId) return;
     if (kb.treeVaultId !== pendingUrlNav.vaultId) return;
     if (kb.tree.length === 0) return;
 
-    handleSelectFile(pendingUrlNav.filePath);
-    setPendingUrlNav(null);
+    const controller = new AbortController();
+    const { vaultId, filePath } = pendingUrlNav;
+    api.resolveFilePath(vaultId, filePath)
+      .then((canonical) => {
+        if (controller.signal.aborted) return;
+        handleSelectFile(canonical ?? filePath);
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        // Daemon unreachable / resolve errored — degrade to raw path (pre-fix
+        // behavior for this click; file may still open via readFile fallback).
+        handleSelectFile(filePath);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setPendingUrlNav(null);
+      });
+    return () => controller.abort();
   }, [pendingUrlNav, kb.activeVault?.id, kb.treeVaultId, kb.tree, handleSelectFile]);
 
   // Sync: on mount & vault/tab change, restore active tab's file into selectedFile.


### PR DESCRIPTION
## 背景

从 AI 生成内容（助手消息里的 wiki-link / markdown 链接）、`molio://` 协议、图谱双击等入口打开文档时，链接给出的路径常缺少扩展名或 `wiki/` 前缀（如 `[[entities/宇树科技]]` → 实际文件 `wiki/entities/宇树科技.md`）。

后端 `readFile` 的 `resolveWithFallbacks` 已经能宽容解析这类"简称"，所以文件**能打开**。但前端原样把这个非规范路径当作 `selectedFile`，导致：

1. tab 标题 / 头部显示无扩展名（"文档标题没有带格式"）；
2. `KbFileTree` 的 `isActive = selectedFile === node.path` 严格字符串比较失败，节点不高亮；
3. "在目录中定位"按钮无法定位。

从目录树点击则一切正常（传的是规范 `node.path`）。两条入口表现不一致。

## 改法

让 daemon 成为路径解析的**单一真相源**，前端不再复制解析逻辑，只"问一下"。

### daemon
- `apps/daemon/src/core/knowledge.ts`：新增导出 `resolveCanonicalPath(vaultPath, relPath): string | null`，复用现有 `resolveFilePath` / `resolveWithFallbacks` / `resolveRealWithinVault`，返回 vault 相对规范路径（带真实扩展名）或 null。不读文件内容，只解析路径。
- 扩展 `resolveWithFallbacks`：把"带文件夹 + 无扩展名"那步从"只补 `.md`"升级为"在目标目录按 stem 匹配任意支持格式"（`.md` 优先），覆盖 `.txt/.pdf/.docx/.html` 等非 md 文件。
- `apps/daemon/src/routes/knowledge.ts`：新增 `GET /api/knowledge/vaults/:id/resolve/*`，返回 `{ path }` 或 404。安全复用 `resolveRealWithinVault`，symlink 逃逸防御不变。

### web
- `apps/web/src/api/client.ts`：新增 `resolveFilePath(vaultId, filePath): Promise<string | null>`（404 → null，其他错误 throw）。
- `apps/web/src/components/kb/KnowledgeBasePage.tsx`：`pendingUrlNav` effect 改异步，调 `api.resolveFilePath` 拿规范路径后再 `handleSelectFile`。带 `AbortController` 竞态守卫（点第二个链接时第一个的返回结果被丢弃，不串台）。resolve 404 时回退原始路径走正常读流程。
- **删除** `apps/web/src/utils/resolveFilePathInTree.ts`（前端不再持有解析逻辑）。

### 解析点决策
只在 `pendingUrlNav` effect 解析，不在 `handleSelectFile` 顶部集中解析——外部导航是唯一会收到非规范路径的入口，目录树点击是热路径不该加 fetch。

## 效果

| 之前 | 之后 |
|---|---|
| 从内容点链接，tab 标题 `宇树科技`（无后缀） | `宇树科技.md` ✅ |
| "在目录中定位"按不到文件 | 高亮并滚动到目标文件 ✅ |
| 链接指向 `.pdf` 等非 md 文件时打不开 | 能解析并打开 ✅ |
| 前端复制后端规则，会漂移 | 规则只在 daemon 一处 ✅ |

从内容跳转与从目录树打开表现一致。

## 验证

- daemon 单测：502/502 通过（含 9 个 `resolveCanonicalPath` 用例 + 5 个路由用例）
- 前端 E2E（`kb-tree-sort-locate.spec.ts`）：7/7 通过，含 4 个新增回归用例（无扩展名 / bare 名 / wiki 前缀缺失 / 非 md 文件）
- typecheck：全包通过
- 全分支 code review：可合并，无 Critical/Important
- 真机复测：`[[entities/宇树科技]]` 跳转 + 定位均正常

## 改动文件

```
apps/daemon/src/core/knowledge.ts          +resolveCanonicalPath, 扩展 stem 匹配
apps/daemon/src/routes/knowledge.ts        +GET /resolve/* 路由
apps/daemon/test/core/knowledge.test.ts    +9 单测
apps/daemon/test/routes/knowledge.test.ts  +5 路由测试
apps/web/src/api/client.ts                 +resolveFilePath
apps/web/src/components/kb/KnowledgeBasePage.tsx  effect 异步化
apps/web/e2e/kb-tree-sort-locate.spec.ts   +4 回归 E2E
apps/web/src/utils/resolveFilePathInTree.ts  删除
```
