### PR TITLE
feat(kb): tab cap + overflow UI + stale cleanup + same-name disambig + polish

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -150,7 +150,7 @@ pnpm test:e2e     # Playwright E2E 测试（需先运行 pnpm dev）
 - **右上角按钮**: 默认模式有「排版」按钮；排版模式有「退出排版」「复制」「发布」「样式」按钮
 - **样式面板**: 右侧悬浮面板，支持主题、字体、字号、主题色、排版选项切换
 - **渲染引擎**: 基于 doocs/md (`marked` v18 + 扩展 + 主题系统)
-- **Tab 系统**: 支持多文件 Tab 切换
+- **Tab 系统**: 多文件 Tab 切换，上限 20（`MAX_TABS`，达上限拦截 + toast，不静默淘汰）；溢出时左右箭头 + `▾` 下拉收纳；active tab 自动滚入可见区；状态持久化到 localStorage
 - **统一聊天面板** (`KbChatPanel` + `useKbChat`)：`💬问答`（文档级，`kb-main-header`）/ `📚构建Wiki`·`🩺健康检查`（vault 级，`KbTabBar` 尾部）。任务运行中再点入口：问答不中断、wiki 类弹「中断/排队/取消」。排队复用 agent stdin 原生队列，详见 [docs/kb-chat-interrupt-queue.md](../../docs/kb-chat-interrupt-queue.md)。
 
 ### 知识图谱 (Graph View)

--- a/apps/web/e2e/area-map.json
+++ b/apps/web/e2e/area-map.json
@@ -30,7 +30,7 @@
         "apps/daemon/src/core/db.ts",
         "apps/daemon/src/routes/knowledge.ts"
       ],
-      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry"]
+      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry", "kb-tab-limit"]
     },
     "publish": {
       "paths": [

--- a/apps/web/e2e/area-map.json
+++ b/apps/web/e2e/area-map.json
@@ -30,7 +30,7 @@
         "apps/daemon/src/core/db.ts",
         "apps/daemon/src/routes/knowledge.ts"
       ],
-      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry", "kb-tab-limit"]
+      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry", "kb-tab-limit", "kb-tab-stale"]
     },
     "publish": {
       "paths": [
@@ -112,6 +112,7 @@
     "kb-tree-sort-locate": { "priority": "P1", "file": "kb-tree-sort-locate.spec.ts" },
     "kb-chat-entry": { "priority": "P1", "file": "kb-chat-entry.spec.ts" },
     "kb-tab-limit": { "priority": "P0", "file": "kb-tab-limit.spec.ts" },
+    "kb-tab-stale": { "priority": "P1", "file": "kb-tab-stale.spec.ts" },
         "markdown-render": { "priority": "P1", "file": "markdown-render.spec.ts" },
     "navigation": { "priority": "P1", "file": "navigation.spec.ts" },
     "publish-flow": { "priority": "P0", "file": "publish-flow.spec.ts" },

--- a/apps/web/e2e/area-map.json
+++ b/apps/web/e2e/area-map.json
@@ -111,6 +111,7 @@
     "knowledge": { "priority": "P0", "file": "knowledge.spec.ts" },
     "kb-tree-sort-locate": { "priority": "P1", "file": "kb-tree-sort-locate.spec.ts" },
     "kb-chat-entry": { "priority": "P1", "file": "kb-chat-entry.spec.ts" },
+    "kb-tab-limit": { "priority": "P0", "file": "kb-tab-limit.spec.ts" },
         "markdown-render": { "priority": "P1", "file": "markdown-render.spec.ts" },
     "navigation": { "priority": "P1", "file": "navigation.spec.ts" },
     "publish-flow": { "priority": "P0", "file": "publish-flow.spec.ts" },

--- a/apps/web/e2e/kb-tab-limit.spec.ts
+++ b/apps/web/e2e/kb-tab-limit.spec.ts
@@ -148,11 +148,9 @@ test.describe('KB tab overflow UI', () => {
     const active = page.locator('.kb-wtab.is-active');
     const sBox = await scroll.boundingBox();
     const aBox = await active.boundingBox();
-    const activeText = await active.textContent();
     const scrollLeft = await scroll.evaluate((el) => (el as HTMLElement).scrollLeft);
     const scrollWidth = await scroll.evaluate((el) => (el as HTMLElement).scrollWidth);
     const clientWidth = await scroll.evaluate((el) => (el as HTMLElement).clientWidth);
-    console.log({ activeText, sBox, aBox, scrollLeft, scrollWidth, clientWidth });
     expect(sBox).not.toBeNull();
     expect(aBox).not.toBeNull();
     // With inline: 'nearest' the active tab is fully within the scroll
@@ -160,5 +158,27 @@ test.describe('KB tab overflow UI', () => {
     // scrolled into view.
     expect(aBox!.x + aBox!.width).toBeLessThanOrEqual(sBox!.x + sBox!.width + 1);
     expect(aBox!.x).toBeGreaterThanOrEqual(sBox!.x - 1);
+  });
+
+  test('arrows appear when tabs overflow and scroll on click', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    for (let i = 1; i <= 8; i++) {
+      const n = String(i).padStart(2, '0');
+      await page.locator('.kb-tree-item').filter({ hasText: `g${n}.md` }).click();
+    }
+    const scroll = page.locator('.kb-wtab-scroll');
+    const before = (await scroll.boundingBox())!;
+
+    // Overflowing → right arrow visible. Because the active (last) tab was
+    // scrolled into view, the container has already shifted right, so the
+    // left arrow is also visible.
+    await expect(page.locator('[data-testid="kb-tab-arrow-right"]')).toBeVisible();
+    await expect(page.locator('[data-testid="kb-tab-arrow-left"]')).toBeVisible();
+
+    await page.locator('[data-testid="kb-tab-arrow-right"]').click();
+    await expect.poll(async () => (await scroll.evaluate((el) => el.scrollLeft)) > 0).toBeTruthy();
+    // After scrolling right, left arrow becomes visible.
+    await expect(page.locator('[data-testid="kb-tab-arrow-left"]')).toBeVisible();
   });
 });

--- a/apps/web/e2e/kb-tab-limit.spec.ts
+++ b/apps/web/e2e/kb-tab-limit.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test';
+import { createTempVault, cleanupTempVault, type TempVault } from './helpers/cleanup';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * @area kb
+ * @priority P0
+ *
+ * Tab cap + overflow UI. Regression for: previously tabs grew unbounded
+ * with no cap, no overflow affordance, and no scroll-into-view on activate.
+ */
+
+let vault: TempVault;
+
+test.describe('KB tab limit', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-kb-tab-limit');
+    fs.unlinkSync(path.join(vault.path, 'test.md'));
+    // 22 files: f01..f22. Limit is 20; 21st/22nd exercise the cap.
+    for (let i = 1; i <= 22; i++) {
+      const n = String(i).padStart(2, '0');
+      fs.writeFileSync(path.join(vault.path, `f${n}.md`), `# F${n}\n`);
+    }
+  });
+  test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
+
+  const openN = async (page: import('@playwright/test').Page, n: number) => {
+    for (let i = 1; i <= n; i++) {
+      const nn = String(i).padStart(2, '0');
+      await page.locator('.kb-tree-item').filter({ hasText: `f${nn}.md` }).click();
+    }
+  };
+
+  test('opening 20 files yields 20 tabs; 21st is blocked with a toast', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-item').filter({ hasText: 'f01.md' })).toBeVisible({ timeout: 10_000 });
+
+    await openN(page, 20);
+    await expect(page.locator('.kb-wtab')).toHaveCount(20, { timeout: 5_000 });
+
+    const activeBefore = await page.locator('.kb-wtab.is-active').textContent();
+    await page.locator('.kb-tree-item').filter({ hasText: 'f21.md' }).click();
+    await expect(page.locator('[data-testid="kb-notice"]')).toBeVisible({ timeout: 3_000 });
+    await expect(page.locator('.kb-wtab')).toHaveCount(20);
+    // active did not switch
+    await expect(page.locator('.kb-wtab.is-active')).toContainText(String(activeBefore));
+  });
+
+  test('at limit, re-opening an already-open file activates without toast', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await openN(page, 20);
+    await expect(page.locator('.kb-wtab')).toHaveCount(20);
+
+    // f01 is already open → click activates it, no toast, no new tab.
+    await page.locator('.kb-tree-item').filter({ hasText: 'f01.md' }).click();
+    await expect(page.locator('.kb-wtab')).toHaveCount(20);
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('f01.md');
+    await expect(page.locator('[data-testid="kb-notice"]')).toHaveCount(0);
+  });
+
+  test('at limit with unsaved edits, opening a new file does NOT prompt to discard', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await openN(page, 20);
+    // Enter typeset mode on the 20th (active) file and make an unsaved edit.
+    await page.locator('[data-testid="kb-btn-typeset"]').click();
+    const textarea = page.locator('.kb-typeset-textarea');
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    await textarea.fill('# F20\n\nUNSAVED MARKER');
+
+    // Click f21 (new file at limit) → must NOT show discard overlay.
+    await page.locator('.kb-tree-item').filter({ hasText: 'f21.md' }).click();
+    await expect(page.locator('.kb-overlay.show')).toHaveCount(0, { timeout: 1_000 });
+    await expect(page.locator('[data-testid="kb-notice"]')).toBeVisible({ timeout: 3_000 });
+    // Edits preserved.
+    await expect(textarea).toHaveValue(/UNSAVED MARKER/);
+  });
+
+  test('closing one tab at limit re-enables opening a new one', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await openN(page, 20);
+    await expect(page.locator('.kb-wtab')).toHaveCount(20);
+
+    // Close the active tab's × (last one, f20).
+    await page.locator('.kb-wtab.is-active .kb-wtab-close').click();
+    await expect(page.locator('.kb-wtab')).toHaveCount(19, { timeout: 5_000 });
+
+    // Now f21 can be opened.
+    await page.locator('.kb-tree-item').filter({ hasText: 'f21.md' }).click();
+    await expect(page.locator('.kb-wtab')).toHaveCount(20, { timeout: 5_000 });
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('f21.md');
+  });
+
+  test('persisted tabs beyond MAX_TABS are not silently closed on load', async ({ page }) => {
+    // Seed 25 persisted tabs pointing at f01..f25 paths (paths need not exist).
+    const seeded = Array.from({ length: 25 }, (_, i) => {
+      const n = String(i + 1).padStart(2, '0');
+      return { id: `file:f${n}.md`, type: 'file', title: `f${n}.md` };
+    });
+    await page.addInitScript((tabs) => {
+      localStorage.setItem('molio.kb.tabs', JSON.stringify(tabs));
+      localStorage.setItem('molio.kb.activeTabId', 'file:f01.md');
+    }, seeded);
+
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-wtab')).toHaveCount(25, { timeout: 5_000 });
+
+    // 26th new file must be blocked (f22..f25 are already persisted, so use f26).
+    fs.writeFileSync(path.join(vault.path, 'f26.md'), '# F26\n');
+    await page.locator('.kb-tree-item').filter({ hasText: 'f26.md' }).click();
+    await expect(page.locator('[data-testid="kb-notice"]')).toBeVisible({ timeout: 3_000 });
+    await expect(page.locator('.kb-wtab')).toHaveCount(25);
+  });
+});

--- a/apps/web/e2e/kb-tab-limit.spec.ts
+++ b/apps/web/e2e/kb-tab-limit.spec.ts
@@ -106,12 +106,13 @@ test.describe('KB tab limit', () => {
       localStorage.setItem('molio.kb.activeTabId', 'file:f01.md');
     }, seeded);
 
+    // 26th new file must be blocked (f22..f25 are already persisted, so use f26).
+    fs.writeFileSync(path.join(vault.path, 'f26.md'), '# F26\n');
+
     await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
     await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
     await expect(page.locator('.kb-wtab')).toHaveCount(25, { timeout: 5_000 });
 
-    // 26th new file must be blocked (f22..f25 are already persisted, so use f26).
-    fs.writeFileSync(path.join(vault.path, 'f26.md'), '# F26\n');
     await page.locator('.kb-tree-item').filter({ hasText: 'f26.md' }).click();
     await expect(page.locator('[data-testid="kb-notice"]')).toBeVisible({ timeout: 3_000 });
     await expect(page.locator('.kb-wtab')).toHaveCount(25);
@@ -137,7 +138,7 @@ test.describe('KB tab overflow UI', () => {
     await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
     await expect(page.locator('.kb-tree-item').filter({ hasText: 'g01.md' })).toBeVisible({ timeout: 10_000 });
 
-    // Open 8 tabs in a 500px viewport → overflow. The last opened is active.
+    // Open 8 tabs in a narrow 800px viewport → overflow. The last opened is active.
     for (let i = 1; i <= 8; i++) {
       const n = String(i).padStart(2, '0');
       await page.locator('.kb-tree-item').filter({ hasText: `g${n}.md` }).click();
@@ -148,9 +149,6 @@ test.describe('KB tab overflow UI', () => {
     const active = page.locator('.kb-wtab.is-active');
     const sBox = await scroll.boundingBox();
     const aBox = await active.boundingBox();
-    const scrollLeft = await scroll.evaluate((el) => (el as HTMLElement).scrollLeft);
-    const scrollWidth = await scroll.evaluate((el) => (el as HTMLElement).scrollWidth);
-    const clientWidth = await scroll.evaluate((el) => (el as HTMLElement).clientWidth);
     expect(sBox).not.toBeNull();
     expect(aBox).not.toBeNull();
     // With inline: 'nearest' the active tab is fully within the scroll
@@ -168,7 +166,6 @@ test.describe('KB tab overflow UI', () => {
       await page.locator('.kb-tree-item').filter({ hasText: `g${n}.md` }).click();
     }
     const scroll = page.locator('.kb-wtab-scroll');
-    const before = (await scroll.boundingBox())!;
 
     // Overflowing → right arrow visible. Because the active (last) tab was
     // scrolled into view, the container has already shifted right, so the
@@ -176,9 +173,13 @@ test.describe('KB tab overflow UI', () => {
     await expect(page.locator('[data-testid="kb-tab-arrow-right"]')).toBeVisible();
     await expect(page.locator('[data-testid="kb-tab-arrow-left"]')).toBeVisible();
 
+    const scrollBeforeLeft = await scroll.evaluate((el) => el.scrollLeft);
+    await page.locator('[data-testid="kb-tab-arrow-left"]').click();
+    await expect.poll(async () => (await scroll.evaluate((el) => el.scrollLeft)) < scrollBeforeLeft - 10).toBeTruthy();
+    const scrollBefore = await scroll.evaluate((el) => el.scrollLeft);
     await page.locator('[data-testid="kb-tab-arrow-right"]').click();
-    await expect.poll(async () => (await scroll.evaluate((el) => el.scrollLeft)) > 0).toBeTruthy();
-    // After scrolling right, left arrow becomes visible.
+    await expect.poll(async () => (await scroll.evaluate((el) => el.scrollLeft)) > scrollBefore + 10).toBeTruthy();
+    // Right-arrow click advanced scrollLeft; left arrow remains visible.
     await expect(page.locator('[data-testid="kb-tab-arrow-left"]')).toBeVisible();
   });
 

--- a/apps/web/e2e/kb-tab-limit.spec.ts
+++ b/apps/web/e2e/kb-tab-limit.spec.ts
@@ -117,3 +117,48 @@ test.describe('KB tab limit', () => {
     await expect(page.locator('.kb-wtab')).toHaveCount(25);
   });
 });
+
+test.describe('KB tab overflow UI', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ viewport: { width: 500, height: 400 } });
+
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-kb-tab-overflow');
+    fs.unlinkSync(path.join(vault.path, 'test.md'));
+    for (let i = 1; i <= 8; i++) {
+      const n = String(i).padStart(2, '0');
+      fs.writeFileSync(path.join(vault.path, `g${n}.md`), `# G${n}\n`);
+    }
+  });
+  test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
+
+  test('active tab scrolls into the visible scroll area on open', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-item').filter({ hasText: 'g01.md' })).toBeVisible({ timeout: 10_000 });
+
+    // Open 8 tabs in a 500px viewport → overflow. The last opened is active.
+    for (let i = 1; i <= 8; i++) {
+      const n = String(i).padStart(2, '0');
+      await page.locator('.kb-tree-item').filter({ hasText: `g${n}.md` }).click();
+    }
+    await expect(page.locator('.kb-wtab')).toHaveCount(8, { timeout: 5_000 });
+
+    const scroll = page.locator('.kb-wtab-scroll');
+    const active = page.locator('.kb-wtab.is-active');
+    const sBox = await scroll.boundingBox();
+    const aBox = await active.boundingBox();
+    const activeText = await active.textContent();
+    const scrollLeft = await scroll.evaluate((el) => (el as HTMLElement).scrollLeft);
+    const scrollWidth = await scroll.evaluate((el) => (el as HTMLElement).scrollWidth);
+    const clientWidth = await scroll.evaluate((el) => (el as HTMLElement).clientWidth);
+    console.log({ activeText, sBox, aBox, scrollLeft, scrollWidth, clientWidth });
+    expect(sBox).not.toBeNull();
+    expect(aBox).not.toBeNull();
+    // With inline: 'end' the active tab's right edge aligns with the scroll
+    // container's right edge (allowing 1px tolerance), proving it was
+    // scrolled into view.
+    expect(aBox!.x + aBox!.width).toBeLessThanOrEqual(sBox!.x + sBox!.width + 1);
+    expect(aBox!.x + aBox!.width).toBeGreaterThanOrEqual(sBox!.x + sBox!.width - 1);
+  });
+});

--- a/apps/web/e2e/kb-tab-limit.spec.ts
+++ b/apps/web/e2e/kb-tab-limit.spec.ts
@@ -120,7 +120,7 @@ test.describe('KB tab limit', () => {
 
 test.describe('KB tab overflow UI', () => {
   test.describe.configure({ mode: 'serial' });
-  test.use({ viewport: { width: 500, height: 400 } });
+  test.use({ viewport: { width: 800, height: 600 } });
 
   test.beforeAll(async () => {
     vault = await createTempVault('e2e-kb-tab-overflow');
@@ -155,10 +155,10 @@ test.describe('KB tab overflow UI', () => {
     console.log({ activeText, sBox, aBox, scrollLeft, scrollWidth, clientWidth });
     expect(sBox).not.toBeNull();
     expect(aBox).not.toBeNull();
-    // With inline: 'end' the active tab's right edge aligns with the scroll
-    // container's right edge (allowing 1px tolerance), proving it was
+    // With inline: 'nearest' the active tab is fully within the scroll
+    // container (allowing 1px tolerance on each edge), proving it was
     // scrolled into view.
     expect(aBox!.x + aBox!.width).toBeLessThanOrEqual(sBox!.x + sBox!.width + 1);
-    expect(aBox!.x + aBox!.width).toBeGreaterThanOrEqual(sBox!.x + sBox!.width - 1);
+    expect(aBox!.x).toBeGreaterThanOrEqual(sBox!.x - 1);
   });
 });

--- a/apps/web/e2e/kb-tab-limit.spec.ts
+++ b/apps/web/e2e/kb-tab-limit.spec.ts
@@ -181,4 +181,45 @@ test.describe('KB tab overflow UI', () => {
     // After scrolling right, left arrow becomes visible.
     await expect(page.locator('[data-testid="kb-tab-arrow-left"]')).toBeVisible();
   });
+
+  test('dropdown lists all tabs; selecting one activates + scrolls it into view', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    for (let i = 1; i <= 8; i++) {
+      const n = String(i).padStart(2, '0');
+      await page.locator('.kb-tree-item').filter({ hasText: `g${n}.md` }).click();
+    }
+    // g01 is the first-opened, off-screen left after scrolling to g08.
+    await page.locator('[data-testid="kb-tab-more"]').click();
+    const dropdown = page.locator('[data-testid="kb-tab-dropdown"]');
+    await expect(dropdown).toBeVisible({ timeout: 3_000 });
+    await expect(dropdown.locator('[data-testid="kb-tab-dropdown-item"]')).toHaveCount(8);
+
+    // Click the item whose title is g01.md → activates g01 and brings it into view.
+    await dropdown.locator('[data-testid="kb-tab-dropdown-item"]').first().click();
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('g01.md');
+    const scroll = page.locator('.kb-wtab-scroll');
+    const sBox = await scroll.boundingBox();
+    const aBox = await page.locator('.kb-wtab.is-active').boundingBox();
+    expect(aBox!.x).toBeGreaterThanOrEqual(sBox!.x - 1);
+  });
+
+  test('dropdown item × closes that tab without activating it', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    for (let i = 1; i <= 8; i++) {
+      const n = String(i).padStart(2, '0');
+      await page.locator('.kb-tree-item').filter({ hasText: `g${n}.md` }).click();
+    }
+    // Active is g08 before opening dropdown.
+    await page.locator('[data-testid="kb-tab-more"]').click();
+    const dropdown = page.locator('[data-testid="kb-tab-dropdown"]');
+    await expect(dropdown).toBeVisible({ timeout: 3_000 });
+
+    // Close the first item (g01) via its ×; active must stay on g08, count 7.
+    await dropdown.locator('[data-testid="kb-tab-dropdown-item"]').first()
+      .locator('.kb-wtab-dropdown-close').click();
+    await expect(page.locator('.kb-wtab')).toHaveCount(7, { timeout: 5_000 });
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('g08.md');
+  });
 });

--- a/apps/web/e2e/kb-tab-stale.spec.ts
+++ b/apps/web/e2e/kb-tab-stale.spec.ts
@@ -156,7 +156,7 @@ test.describe('KB same-name tab disambiguation (#5)', () => {
     await expandFolder(page, 'notes');
     await page.locator('.kb-tree-item:visible').filter({ hasText: 'index.md' }).first().click();
     await expandFolder(page, 'drafts');
-    await page.locator('.kb-tree-item:visible').filter({ hasText: 'index.md' }).first().click();
+    await page.locator('.kb-tree-group').filter({ hasText: 'drafts' }).locator('.kb-tree-item').filter({ hasText: 'index.md' }).click();
     await page.locator('.kb-tree-item').filter({ hasText: 'readme.md' }).click();
     await expect(page.locator('.kb-wtab')).toHaveCount(3, { timeout: 5_000 });
 

--- a/apps/web/e2e/kb-tab-stale.spec.ts
+++ b/apps/web/e2e/kb-tab-stale.spec.ts
@@ -90,3 +90,46 @@ test.describe('KB stale tab cleanup (proactive)', () => {
     await expect(page.locator('.kb-wtab.is-active')).toContainText('b.md');
   });
 });
+
+test.describe('KB stale tab cleanup (reactive)', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-kb-tab-reactive');
+    fs.unlinkSync(path.join(vault.path, 'test.md'));
+    fs.writeFileSync(path.join(vault.path, 'real.md'), '# Real\n');
+  });
+  test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
+
+  test('a tab whose path no longer exists in the tree gets cleaned on load', async ({ page }) => {
+    // seed a stale tab pointing at a non-existent path, but with the correct vaultId
+    await page.addInitScript((vaultId) => {
+      localStorage.setItem('molio.kb.tabs', JSON.stringify([
+        { id: 'file:ghost.md', type: 'file', title: 'ghost.md', vaultId },
+        { id: 'file:real.md', type: 'file', title: 'real.md', vaultId },
+      ]));
+      localStorage.setItem('molio.kb.activeTabId', 'file:ghost.md');
+    }, vault.id);
+
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-item').filter({ hasText: 'real.md' })).toBeVisible({ timeout: 10_000 });
+    // ghost.md doesn't exist in tree → its tab cleaned; real.md stays
+    await expect(page.locator('.kb-wtab')).toHaveCount(1, { timeout: 5_000 });
+    await expect(page.locator('.kb-wtab')).toContainText('real.md');
+  });
+
+  test('tabs belonging to another vault are not cleaned when this vault loads', async ({ page }) => {
+    // seed a tab with a foreign vaultId
+    await page.addInitScript((vaultId) => {
+      localStorage.setItem('molio.kb.tabs', JSON.stringify([
+        { id: 'file:other-vault-file.md', type: 'file', title: 'other-vault-file.md', vaultId: 'vault-foreign' },
+        { id: 'file:real.md', type: 'file', title: 'real.md', vaultId },
+      ]));
+      localStorage.setItem('molio.kb.activeTabId', 'file:real.md');
+    }, vault.id);
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-item').filter({ hasText: 'real.md' })).toBeVisible({ timeout: 10_000 });
+    // foreign-vault tab NOT cleaned (still 2 tabs)
+    await expect(page.locator('.kb-wtab')).toHaveCount(2, { timeout: 5_000 });
+  });
+});

--- a/apps/web/e2e/kb-tab-stale.spec.ts
+++ b/apps/web/e2e/kb-tab-stale.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { createTempVault, cleanupTempVault, type TempVault } from './helpers/cleanup';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * @area kb
+ * @priority P1
+ *
+ * Stale tab cleanup (#4) + same-name disambiguation (#5).
+ */
+
+let vault: TempVault;
+
+test.describe('KB stale tab cleanup (proactive)', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-kb-tab-stale');
+    fs.unlinkSync(path.join(vault.path, 'test.md'));
+    fs.writeFileSync(path.join(vault.path, 'alpha.md'), '# Alpha\n');
+    fs.mkdirSync(path.join(vault.path, 'sub1'));
+    fs.writeFileSync(path.join(vault.path, 'sub1/a.md'), '# A\n');
+    fs.mkdirSync(path.join(vault.path, 'sub2'));
+    fs.writeFileSync(path.join(vault.path, 'sub2/b.md'), '# B\n');
+  });
+  test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
+
+  const openTab = async (page: import('@playwright/test').Page, name: string) => {
+    await page.locator('.kb-tree-item').filter({ hasText: name }).click();
+  };
+  const expandFolder = async (page: import('@playwright/test').Page, name: string) => {
+    await page.locator('.kb-tree-group-label').filter({ hasText: name }).click();
+  };
+  const ctxRename = async (page: import('@playwright/test').Page, name: string, newName: string) => {
+    await page.locator('.kb-tree-item').filter({ hasText: name }).click({ button: 'right' });
+    await page.locator('.ctx-menu-item', { hasText: '重命名' }).click();
+    const input = page.locator('.kb-tree-rename-input');
+    await expect(input).toBeVisible({ timeout: 3_000 });
+    await input.fill(newName);
+    await input.press('Enter');
+  };
+
+  test('renaming an open tab file updates the tab, keeps active', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.kb-tree-item').filter({ hasText: 'alpha.md' })).toBeVisible({ timeout: 10_000 });
+    await openTab(page, 'alpha.md');
+    await expect(page.locator('.kb-wtab')).toHaveCount(1, { timeout: 5_000 });
+
+    await ctxRename(page, 'alpha.md', 'alpha-renamed.md');
+    // tab still 1, title updated, active
+    await expect(page.locator('.kb-wtab')).toHaveCount(1, { timeout: 5_000 });
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('alpha-renamed.md');
+    // tree shows new name
+    await expect(page.locator('.kb-tree-item').filter({ hasText: 'alpha-renamed.md' })).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('deleting an open tab file closes the tab', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await openTab(page, 'alpha-renamed.md');
+    await expect(page.locator('.kb-wtab')).toHaveCount(1, { timeout: 5_000 });
+
+    await page.locator('.kb-tree-item').filter({ hasText: 'alpha-renamed.md' }).click({ button: 'right' });
+    await page.locator('.ctx-menu-item', { hasText: '删除' }).click();
+    const overlay = page.locator('.kb-overlay.show');
+    await expect(overlay).toBeVisible({ timeout: 3_000 });
+    await overlay.locator('button', { hasText: '删除' }).click();
+    await expect(overlay).not.toBeVisible();
+    await expect(page.locator('.kb-wtab')).toHaveCount(0, { timeout: 5_000 });
+  });
+
+  test('deleting a folder closes all tabs under it, leaves others', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expandFolder(page, 'sub1');
+    await openTab(page, 'a.md');
+    await expandFolder(page, 'sub2');
+    await openTab(page, 'b.md');
+    await expect(page.locator('.kb-wtab')).toHaveCount(2, { timeout: 5_000 });
+
+    // delete sub1 folder
+    await page.locator('.kb-tree-group-label').filter({ hasText: 'sub1' }).click({ button: 'right' });
+    await page.locator('.ctx-menu-item', { hasText: '删除文件夹' }).click();
+    const overlay = page.locator('.kb-overlay.show');
+    await expect(overlay).toBeVisible({ timeout: 3_000 });
+    await overlay.locator('button', { hasText: '删除' }).click();
+    await expect(overlay).not.toBeVisible();
+    // sub1/a.md tab gone; sub2/b.md stays
+    await expect(page.locator('.kb-wtab')).toHaveCount(1, { timeout: 5_000 });
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('b.md');
+  });
+});

--- a/apps/web/e2e/kb-tab-stale.spec.ts
+++ b/apps/web/e2e/kb-tab-stale.spec.ts
@@ -12,6 +12,21 @@ import * as path from 'path';
 
 let vault: TempVault;
 
+const openTab = async (page: import('@playwright/test').Page, name: string) => {
+  await page.locator('.kb-tree-item').filter({ hasText: name }).click();
+};
+const expandFolder = async (page: import('@playwright/test').Page, name: string) => {
+  await page.locator('.kb-tree-group-label').filter({ hasText: name }).click();
+};
+const ctxRename = async (page: import('@playwright/test').Page, name: string, newName: string) => {
+  await page.locator('.kb-tree-item').filter({ hasText: name }).click({ button: 'right' });
+  await page.locator('.ctx-menu-item', { hasText: '重命名' }).click();
+  const input = page.locator('.kb-tree-rename-input');
+  await expect(input).toBeVisible({ timeout: 3_000 });
+  await input.fill(newName);
+  await input.press('Enter');
+};
+
 test.describe('KB stale tab cleanup (proactive)', () => {
   test.beforeAll(async () => {
     vault = await createTempVault('e2e-kb-tab-stale');
@@ -23,21 +38,6 @@ test.describe('KB stale tab cleanup (proactive)', () => {
     fs.writeFileSync(path.join(vault.path, 'sub2/b.md'), '# B\n');
   });
   test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
-
-  const openTab = async (page: import('@playwright/test').Page, name: string) => {
-    await page.locator('.kb-tree-item').filter({ hasText: name }).click();
-  };
-  const expandFolder = async (page: import('@playwright/test').Page, name: string) => {
-    await page.locator('.kb-tree-group-label').filter({ hasText: name }).click();
-  };
-  const ctxRename = async (page: import('@playwright/test').Page, name: string, newName: string) => {
-    await page.locator('.kb-tree-item').filter({ hasText: name }).click({ button: 'right' });
-    await page.locator('.ctx-menu-item', { hasText: '重命名' }).click();
-    const input = page.locator('.kb-tree-rename-input');
-    await expect(input).toBeVisible({ timeout: 3_000 });
-    await input.fill(newName);
-    await input.press('Enter');
-  };
 
   test('renaming an open tab file updates the tab, keeps active', async ({ page }) => {
     await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
@@ -131,5 +131,64 @@ test.describe('KB stale tab cleanup (reactive)', () => {
     await expect(page.locator('.kb-tree-item').filter({ hasText: 'real.md' })).toBeVisible({ timeout: 10_000 });
     // foreign-vault tab NOT cleaned (still 2 tabs)
     await expect(page.locator('.kb-wtab')).toHaveCount(2, { timeout: 5_000 });
+  });
+});
+
+test.describe('KB same-name tab disambiguation (#5)', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-kb-samename');
+    fs.unlinkSync(path.join(vault.path, 'test.md'));
+    fs.mkdirSync(path.join(vault.path, 'notes'));
+    fs.mkdirSync(path.join(vault.path, 'drafts'));
+    fs.writeFileSync(path.join(vault.path, 'notes/index.md'), '# Notes\n');
+    fs.writeFileSync(path.join(vault.path, 'drafts/index.md'), '# Drafts\n');
+    fs.writeFileSync(path.join(vault.path, 'readme.md'), '# Readme\n');
+    fs.mkdirSync(path.join(vault.path, 'x/foo'), { recursive: true });
+    fs.mkdirSync(path.join(vault.path, 'y/foo'), { recursive: true });
+    fs.writeFileSync(path.join(vault.path, 'x/foo/index.md'), '# X\n');
+    fs.writeFileSync(path.join(vault.path, 'y/foo/index.md'), '# Y\n');
+  });
+  test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
+
+  test('two same-name files show parent-dir prefix; unique file stays bare', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await expandFolder(page, 'notes');
+    await page.locator('.kb-tree-item:visible').filter({ hasText: 'index.md' }).first().click();
+    await expandFolder(page, 'drafts');
+    await page.locator('.kb-tree-item:visible').filter({ hasText: 'index.md' }).first().click();
+    await page.locator('.kb-tree-item').filter({ hasText: 'readme.md' }).click();
+    await expect(page.locator('.kb-wtab')).toHaveCount(3, { timeout: 5_000 });
+
+    const titles = await page.locator('.kb-wtab .kb-wtab-title').allTextContents();
+    expect(titles).toContain('notes/index.md');
+    expect(titles).toContain('drafts/index.md');
+    expect(titles).toContain('readme.md');
+  });
+
+  test('tab tooltip shows the full relative path', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    await page.locator('.kb-tree-item').filter({ hasText: 'readme.md' }).click();
+    await expect(page.locator('.kb-wtab.is-active')).toHaveAttribute('title', 'readme.md');
+    await expandFolder(page, 'notes');
+    await page.locator('.kb-tree-item:visible').filter({ hasText: 'index.md' }).first().click();
+    await expect(page.locator('.kb-wtab.is-active')).toHaveAttribute('title', 'notes/index.md');
+  });
+
+  test('deeper same-parent-dir collision falls back to full path', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+    // two files both at <dir>/foo/index.md → parent name "foo" collides → full path
+    await expandFolder(page, 'x');
+    await page.locator('.kb-tree-group-label').filter({ hasText: 'foo' }).first().click();
+    await page.locator('.kb-tree-item:visible').filter({ hasText: 'index.md' }).first().click();
+    await expandFolder(page, 'y');
+    await page.locator('.kb-tree-group-label').filter({ hasText: 'foo' }).nth(1).click();
+    await page.locator('.kb-tree-item:visible').filter({ hasText: 'index.md' }).nth(1).click();
+    await expect(page.locator('.kb-wtab')).toHaveCount(2, { timeout: 5_000 });
+    const titles = await page.locator('.kb-wtab .kb-wtab-title').allTextContents();
+    expect(titles).toContain('x/foo/index.md');
+    expect(titles).toContain('y/foo/index.md');
   });
 });

--- a/apps/web/src/components/kb/KbTabBar.tsx
+++ b/apps/web/src/components/kb/KbTabBar.tsx
@@ -5,6 +5,7 @@
  * active tab 变化时自动滚入可见区。箭头与下拉在后续 task 接入逻辑。
  */
 import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { FileDocIcon } from '../FileIcons';
 import type { WorkspaceTab } from '../../hooks/useKbTabs';
 
 interface KbTabBarProps {
@@ -15,12 +16,12 @@ interface KbTabBarProps {
   actions?: ReactNode;
 }
 
-function getTabIcon(type: string): string {
+function getTabIcon(type: string): ReactNode {
   switch (type) {
     case 'file':
-      return '📄';
+      return <FileDocIcon size={12} />;
     default:
-      return '📑';
+      return <span style={{ fontSize: 12 }}>📑</span>;
   }
 }
 
@@ -71,7 +72,13 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
   const scrollBy = (dir: 1 | -1) => {
     const el = scrollRef.current;
     if (!el) return;
-    el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: 'smooth' });
+    const reducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollBy({
+      left: dir * el.clientWidth * 0.8,
+      behavior: reducedMotion ? 'auto' : 'smooth',
+    });
   };
 
   // Scroll the active tab into view whenever it changes or a tab is added.

--- a/apps/web/src/components/kb/KbTabBar.tsx
+++ b/apps/web/src/components/kb/KbTabBar.tsx
@@ -15,6 +15,29 @@ interface KbTabBarProps {
   actions?: ReactNode;
 }
 
+function tabDisplayTitle(tab: WorkspaceTab, allTabs: WorkspaceTab[]): { display: string; tooltip: string } {
+  if (!tab.id.startsWith('file:')) {
+    return { display: tab.title, tooltip: tab.title };
+  }
+  const relPath = tab.id.slice(5);
+  const filename = relPath.split('/').pop() ?? relPath;
+  const tooltip = relPath;
+  const siblings = allTabs.filter(
+    (t) => t.id.startsWith('file:') && (t.id.slice(5).split('/').pop() ?? '') === filename,
+  );
+  if (siblings.length <= 1) return { display: filename, tooltip };
+  const slashIdx = relPath.lastIndexOf('/');
+  const parentName = slashIdx > 0 ? relPath.slice(0, slashIdx).split('/').pop() : null;
+  const candidate = parentName ? `${parentName}/${filename}` : filename;
+  const stillCollide =
+    siblings.filter((t) => {
+      const p = t.id.slice(5);
+      const si = p.lastIndexOf('/');
+      const pn = si > 0 ? p.slice(0, si).split('/').pop() : null;
+      return (pn ? `${pn}/${filename}` : filename) === candidate;
+    }).length > 1;
+  return { display: stillCollide ? relPath : candidate, tooltip };
+}
 
 export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: KbTabBarProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -93,6 +116,7 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
       <div className="kb-wtab-scroll" ref={scrollRef} onScroll={recompute}>
         {tabs.map((tab) => {
           const isActive = tab.id === activeTabId;
+          const { display, tooltip } = tabDisplayTitle(tab, tabs);
           return (
             <div
               key={tab.id}
@@ -105,9 +129,9 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
                   onClose(tab.id);
                 }
               }}
-              title={tab.title}
+              title={tooltip}
             >
-              <span className="kb-wtab-title">{tab.title}</span>
+              <span className="kb-wtab-title">{display}</span>
               <button
                 type="button"
                 className="kb-wtab-close"
@@ -144,15 +168,16 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
         <div className="kb-tab-dropdown" data-testid="kb-tab-dropdown" ref={dropdownRef}>
           {tabs.map((tab) => {
             const isActive = tab.id === activeTabId;
+            const { display, tooltip } = tabDisplayTitle(tab, tabs);
             return (
               <div
                 key={tab.id}
                 className={`kb-wtab-dropdown-item ${isActive ? 'is-active' : ''}`}
                 data-testid="kb-tab-dropdown-item"
                 onClick={() => { onActivate(tab.id); setMenuOpen(false); }}
-                title={tab.title}
+                title={tooltip}
               >
-                <span className="kb-wtab-dropdown-title">{tab.title}</span>
+                <span className="kb-wtab-dropdown-title">{display}</span>
                 <button
                   type="button"
                   className="kb-wtab-dropdown-close"

--- a/apps/web/src/components/kb/KbTabBar.tsx
+++ b/apps/web/src/components/kb/KbTabBar.tsx
@@ -1,11 +1,10 @@
 /**
  * 通用工作区标签栏组件（Obsidian-style）
  *
- * 布局：左侧可横向滚动的 tab 列表 + 右侧固定（不随 tab 溢出滚走）的全局操作区。
- * 当没有 tab 但传入了 actions 时仍渲染操作区，保证全局入口（如全文搜索）常驻可用。
+ * 布局：左箭头 + 可横向滚动的 tab 列表 + 右箭头 + 下拉 ▾ + 右侧固定全局操作区。
+ * active tab 变化时自动滚入可见区。箭头与下拉在后续 task 接入逻辑。
  */
-
-import type { ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, type ReactNode } from 'react';
 import type { WorkspaceTab } from '../../hooks/useKbTabs';
 
 interface KbTabBarProps {
@@ -13,7 +12,6 @@ interface KbTabBarProps {
   activeTabId: string | null;
   onActivate: (id: string) => void;
   onClose: (id: string) => void;
-  /** 右侧尾部全局操作（vault 级，与当前文档解耦）。 */
   actions?: ReactNode;
 }
 
@@ -27,17 +25,34 @@ function getTabIcon(type: string): string {
 }
 
 export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: KbTabBarProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  // Scroll the active tab into view whenever it changes or a tab is added.
+  useLayoutEffect(() => {
+    activeRef.current?.scrollIntoView({ inline: 'end', block: 'nearest' });
+  }, [activeTabId, tabs.length]);
+
   if (tabs.length === 0 && !actions) return null;
 
   return (
     <div className="kb-workspace-tabs">
-      <div className="kb-wtab-list">
+      <button
+        type="button"
+        className="kb-wtab-arrow"
+        data-testid="kb-tab-arrow-left"
+        hidden
+        tabIndex={-1}
+        aria-label="向左滚动"
+      >‹</button>
+      <div className="kb-wtab-scroll" ref={scrollRef}>
         {tabs.map((tab) => {
           const isActive = tab.id === activeTabId;
           return (
             <div
               key={tab.id}
               className={`kb-wtab ${isActive ? 'is-active' : ''}`}
+              ref={isActive ? activeRef : null}
               onClick={() => onActivate(tab.id)}
               onMouseDown={(e) => {
                 if (e.button === 1) {
@@ -57,13 +72,26 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
                   onClose(tab.id);
                 }}
                 title="关闭"
-              >
-                ×
-              </button>
+              >×</button>
             </div>
           );
         })}
       </div>
+      <button
+        type="button"
+        className="kb-wtab-arrow"
+        data-testid="kb-tab-arrow-right"
+        hidden
+        tabIndex={-1}
+        aria-label="向右滚动"
+      >›</button>
+      <button
+        type="button"
+        className="kb-wtab-more"
+        data-testid="kb-tab-more"
+        hidden={tabs.length === 0}
+        aria-label="全部标签"
+      >▾</button>
       {actions && <div className="kb-wtab-actions">{actions}</div>}
     </div>
   );

--- a/apps/web/src/components/kb/KbTabBar.tsx
+++ b/apps/web/src/components/kb/KbTabBar.tsx
@@ -4,7 +4,7 @@
  * 布局：左箭头 + 可横向滚动的 tab 列表 + 右箭头 + 下拉 ▾ + 右侧固定全局操作区。
  * active tab 变化时自动滚入可见区。箭头与下拉在后续 task 接入逻辑。
  */
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { WorkspaceTab } from '../../hooks/useKbTabs';
 
 interface KbTabBarProps {
@@ -27,6 +27,31 @@ function getTabIcon(type: string): string {
 export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: KbTabBarProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const activeRef = useRef<HTMLDivElement>(null);
+  const [canLeft, setCanLeft] = useState(false);
+  const [canRight, setCanRight] = useState(false);
+
+  const recompute = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanLeft(el.scrollLeft > 0);
+    setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  };
+
+  // Recompute overflow on mount, tab changes, and resize.
+  useEffect(() => {
+    recompute();
+    const el = scrollRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => recompute());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [tabs.length]);
+
+  const scrollBy = (dir: 1 | -1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * el.clientWidth * 0.8, behavior: 'smooth' });
+  };
 
   // Scroll the active tab into view whenever it changes or a tab is added.
   useEffect(() => {
@@ -41,11 +66,12 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
         type="button"
         className="kb-wtab-arrow"
         data-testid="kb-tab-arrow-left"
-        hidden
+        hidden={!canLeft}
         tabIndex={-1}
         aria-label="向左滚动"
+        onClick={() => scrollBy(-1)}
       >‹</button>
-      <div className="kb-wtab-scroll" ref={scrollRef}>
+      <div className="kb-wtab-scroll" ref={scrollRef} onScroll={recompute}>
         {tabs.map((tab) => {
           const isActive = tab.id === activeTabId;
           return (
@@ -81,9 +107,10 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
         type="button"
         className="kb-wtab-arrow"
         data-testid="kb-tab-arrow-right"
-        hidden
+        hidden={!canRight}
         tabIndex={-1}
         aria-label="向右滚动"
+        onClick={() => scrollBy(1)}
       >›</button>
       <button
         type="button"

--- a/apps/web/src/components/kb/KbTabBar.tsx
+++ b/apps/web/src/components/kb/KbTabBar.tsx
@@ -5,7 +5,6 @@
  * active tab 变化时自动滚入可见区。箭头与下拉在后续 task 接入逻辑。
  */
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { FileDocIcon } from '../FileIcons';
 import type { WorkspaceTab } from '../../hooks/useKbTabs';
 
 interface KbTabBarProps {
@@ -16,14 +15,6 @@ interface KbTabBarProps {
   actions?: ReactNode;
 }
 
-function getTabIcon(type: string): ReactNode {
-  switch (type) {
-    case 'file':
-      return <FileDocIcon size={12} />;
-    default:
-      return <span style={{ fontSize: 12 }}>📑</span>;
-  }
-}
 
 export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: KbTabBarProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -116,7 +107,6 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
               }}
               title={tab.title}
             >
-              <span className="kb-wtab-icon">{getTabIcon(tab.type)}</span>
               <span className="kb-wtab-title">{tab.title}</span>
               <button
                 type="button"
@@ -162,7 +152,6 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
                 onClick={() => { onActivate(tab.id); setMenuOpen(false); }}
                 title={tab.title}
               >
-                <span className="kb-wtab-icon">{getTabIcon(tab.type)}</span>
                 <span className="kb-wtab-dropdown-title">{tab.title}</span>
                 <button
                   type="button"

--- a/apps/web/src/components/kb/KbTabBar.tsx
+++ b/apps/web/src/components/kb/KbTabBar.tsx
@@ -29,6 +29,27 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
   const activeRef = useRef<HTMLDivElement>(null);
   const [canLeft, setCanLeft] = useState(false);
   const [canRight, setCanRight] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const moreRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on Esc or outside click (button + menu count as one unit).
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setMenuOpen(false); };
+    const onPointer = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const insideMore = moreRef.current?.contains(target) ?? false;
+      const insideDropdown = dropdownRef.current?.contains(target) ?? false;
+      if (!insideMore && !insideDropdown) setMenuOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onPointer);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onPointer);
+    };
+  }, [menuOpen]);
 
   const recompute = () => {
     const el = scrollRef.current;
@@ -114,11 +135,39 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
       >›</button>
       <button
         type="button"
+        ref={moreRef}
         className="kb-wtab-more"
         data-testid="kb-tab-more"
         hidden={tabs.length === 0}
         aria-label="全部标签"
+        aria-expanded={menuOpen}
+        onClick={() => setMenuOpen((v) => !v)}
       >▾</button>
+      {menuOpen && (
+        <div className="kb-tab-dropdown" data-testid="kb-tab-dropdown" ref={dropdownRef}>
+          {tabs.map((tab) => {
+            const isActive = tab.id === activeTabId;
+            return (
+              <div
+                key={tab.id}
+                className={`kb-wtab-dropdown-item ${isActive ? 'is-active' : ''}`}
+                data-testid="kb-tab-dropdown-item"
+                onClick={() => { onActivate(tab.id); setMenuOpen(false); }}
+                title={tab.title}
+              >
+                <span className="kb-wtab-icon">{getTabIcon(tab.type)}</span>
+                <span className="kb-wtab-dropdown-title">{tab.title}</span>
+                <button
+                  type="button"
+                  className="kb-wtab-dropdown-close"
+                  onClick={(e) => { e.stopPropagation(); onClose(tab.id); }}
+                  title="关闭"
+                >×</button>
+              </div>
+            );
+          })}
+        </div>
+      )}
       {actions && <div className="kb-wtab-actions">{actions}</div>}
     </div>
   );

--- a/apps/web/src/components/kb/KbTabBar.tsx
+++ b/apps/web/src/components/kb/KbTabBar.tsx
@@ -4,7 +4,7 @@
  * 布局：左箭头 + 可横向滚动的 tab 列表 + 右箭头 + 下拉 ▾ + 右侧固定全局操作区。
  * active tab 变化时自动滚入可见区。箭头与下拉在后续 task 接入逻辑。
  */
-import { useEffect, useLayoutEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import type { WorkspaceTab } from '../../hooks/useKbTabs';
 
 interface KbTabBarProps {
@@ -29,8 +29,8 @@ export function KbTabBar({ tabs, activeTabId, onActivate, onClose, actions }: Kb
   const activeRef = useRef<HTMLDivElement>(null);
 
   // Scroll the active tab into view whenever it changes or a tab is added.
-  useLayoutEffect(() => {
-    activeRef.current?.scrollIntoView({ inline: 'end', block: 'nearest' });
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ inline: 'nearest', block: 'nearest' });
   }, [activeTabId, tabs.length]);
 
   if (tabs.length === 0 && !actions) return null;

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -744,7 +744,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     } catch (err) {
       showToast(`移动文件失败：${err instanceof Error ? err.message : String(err)}`);
     }
-  }, [kb.activeVault, kb.activeVault?.id, kb.tree, kb.renameFile, tabs, showToast]);
+  }, [kb.activeVault?.id, kb.tree, kb.renameFile, tabs, showToast]);
 
   const handleImportFiles = useCallback(async (files: File[], targetDir: string) => {
     if (!kb.activeVault) return;

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -309,6 +309,29 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kb.activeVault?.id, tabs.activeTabId]);
 
+  // Reactive safety net: close tabs whose file no longer exists in the active vault's tree.
+  // Triggers on tree refresh (external deletes via VaultWatcher) and vault switches.
+  useEffect(() => {
+    const av = kb.activeVault;
+    if (!av || kb.treeVaultId !== av.id || kb.tree.length === 0) return;
+    const paths = new Set<string>();
+    const collect = (nodes: TreeNode[]) => {
+      for (const n of nodes) {
+        if (n.type === 'file') paths.add(n.path);
+        if (n.children) collect(n.children);
+      }
+    };
+    collect(kb.tree);
+    const staleIds = tabs.tabs
+      .filter(t => t.vaultId === av.id && t.id.startsWith('file:') && !paths.has(t.id.slice(5)))
+      .map(t => t.id);
+    if (staleIds.length) {
+      const staleSet = new Set(staleIds);
+      tabs.removeWhere(t => staleSet.has(t.id));
+      if (!tabs.activeTabId) kb.selectFile(null);
+    }
+  }, [kb.tree, kb.treeVaultId, kb.activeVault?.id, tabs.tabs, tabs.removeWhere, kb.selectFile]);
+
   // Panel resize drag handling
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -8,7 +8,7 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import type { TreeNode } from '@molio/contracts';
 import { useKnowledge } from '../../hooks/useKnowledge';
 import type { KbChatState } from '../../hooks/useKbChat';
-import { useKbTabs } from '../../hooks/useKbTabs';
+import { useKbTabs, MAX_TABS } from '../../hooks/useKbTabs';
 import { kbTabsStore } from '../../stores/kbTabsStore';
 import { vaultStore } from '../../stores/vaultStore';
 import { KbFilePanel } from './KbFilePanel';
@@ -173,6 +173,14 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     onKbChatOpenChange(true);
   }, [kb.selectedFile, kbChat]);
 
+  // ─── Save toast helper (used by file selection and other callbacks) ───
+
+  const showToast = useCallback((msg: string) => {
+    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
+    setSaveToast(msg);
+    saveToastTimer.current = setTimeout(() => setSaveToast(null), 2000);
+  }, []);
+
   // ─── Tab-aware file selection ───
 
   /**
@@ -209,21 +217,33 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
       const tabId = `file:${path}`;
       const existingTab = tabs.tabs.find(t => t.id === tabId);
       if (existingTab) {
-        // Already open in a tab — just activate it
         tabs.activateTab(tabId);
       } else {
-        // Open a new tab (openTab appends to the end and activates it)
-        tabs.openTab({ id: tabId, type: 'file', title: fileName });
+        const res = tabs.openTab({ id: tabId, type: 'file', title: fileName });
+        if (!res.opened && res.reason === 'limit') {
+          // Defensive: pre-check below should have caught this; never switch
+          // the viewed file or discard edits when blocked.
+          showToast(`已达 ${MAX_TABS} 个标签上限，请先关闭某个标签`);
+          return;
+        }
       }
       kb.selectFile(path);
     };
-    // Re-selecting the current file is a no-op — don't prompt.
+    // Limit pre-check BEFORE the discard prompt: avoids confirming "discard
+    // edits" only to have the open blocked by the cap. Re-opening an existing
+    // tab is exempt (activate != new open).
+    const tabId = `file:${path}`;
+    const existingTab = tabs.tabs.find(t => t.id === tabId);
+    if (!existingTab && tabs.tabs.length >= MAX_TABS) {
+      showToast(`已达 ${MAX_TABS} 个标签上限，请先关闭某个标签`);
+      return;
+    }
     if (path === kb.selectedFile) {
       action();
       return;
     }
     runOrConfirmDiscard(action);
-  }, [tabs, kb, runOrConfirmDiscard]);
+  }, [tabs, kb, runOrConfirmDiscard, showToast]);
 
   /** Open a file in a new tab — same semantics as handleSelectFile. */
   const handleOpenInNewTab = handleSelectFile;
@@ -446,14 +466,6 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [kb.selectedFile, kbChat]);
-
-  // ─── Save toast helper (defined early — used by callbacks below) ───
-
-  const showToast = useCallback((msg: string) => {
-    if (saveToastTimer.current) clearTimeout(saveToastTimer.current);
-    setSaveToast(msg);
-    saveToastTimer.current = setTimeout(() => setSaveToast(null), 2000);
-  }, []);
 
   // ─── New file / folder flows (React dialogs instead of window.prompt) ───
 
@@ -1021,7 +1033,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
 
       {/* Save toast */}
       {saveToast && (
-        <div className="kb-save-toast">{saveToast}</div>
+        <div className="kb-save-toast" data-testid="kb-notice">{saveToast}</div>
       )}
 
       {/* Input dialog (replaces window.prompt) */}

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -219,7 +219,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
       if (existingTab) {
         tabs.activateTab(tabId);
       } else {
-        const res = tabs.openTab({ id: tabId, type: 'file', title: fileName });
+        const res = tabs.openTab({ id: tabId, type: 'file', title: fileName, vaultId: kb.activeVault?.id });
         if (!res.opened && res.reason === 'limit') {
           // Defensive: pre-check below should have caught this; never switch
           // the viewed file or discard edits when blocked.
@@ -534,6 +534,27 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     setCtxMenu(null);
   }, []);
 
+  const handleDeleteFile = useCallback(async (filePath: string) => {
+    try {
+      await kb.deleteFile(filePath);
+    } catch (err) {
+      showToast(`删除失败：${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    tabs.closeTab(`file:${filePath}`);
+  }, [kb, tabs, showToast]);
+
+  const handleDeleteFolder = useCallback(async (folderPath: string) => {
+    try {
+      await kb.deleteFolder(folderPath);
+    } catch (err) {
+      showToast(`删除失败：${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    const prefix = `file:${folderPath}/`;
+    tabs.removeWhere(t => t.vaultId === kb.activeVault?.id && t.id.startsWith(prefix));
+  }, [kb, tabs, showToast]);
+
   const getContextMenuItems = useCallback((): MenuItem[] => {
     if (!ctxMenu) return [];
     const { node } = ctxMenu;
@@ -618,11 +639,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
             danger: true,
             onConfirm: async () => {
               setConfirmDialog((prev) => ({ ...prev, show: false }));
-              try {
-                await kb.deleteFile(node.path);
-              } catch (err) {
-                showToast(`删除失败：${err instanceof Error ? err.message : String(err)}`);
-              }
+              await handleDeleteFile(node.path);
             },
           });
         },
@@ -640,11 +657,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
             danger: true,
             onConfirm: async () => {
               setConfirmDialog((prev) => ({ ...prev, show: false }));
-              try {
-                await kb.deleteFolder(node.path);
-              } catch (err) {
-                showToast(`删除失败：${err instanceof Error ? err.message : String(err)}`);
-              }
+              await handleDeleteFolder(node.path);
             },
           });
         },
@@ -652,7 +665,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     }
 
     return items;
-  }, [ctxMenu, kb, showToast, handleNewFile, handleNewFolder, handleSelectFile, handleOpenInNewTab, kbChat]);
+  }, [ctxMenu, kb, showToast, handleNewFile, handleNewFolder, handleSelectFile, handleOpenInNewTab, handleDeleteFile, handleDeleteFolder, kbChat]);
 
   // ─── Inline rename ───
 
@@ -664,10 +677,14 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     if (newPath === oldPath) return;
     try {
       await kb.renameFile(oldPath, newPath);
+      const newFileName = newPath.split('/').pop() ?? newPath;
+      const existingTabForNewPath = tabs.tabs.find(t => t.id === `file:${newPath}`);
+      if (existingTabForNewPath) tabs.closeTab(`file:${newPath}`);
+      tabs.updateTab(`file:${oldPath}`, { id: `file:${newPath}`, title: newFileName, vaultId: kb.activeVault?.id });
     } catch (err) {
       showToast(`重命名失败：${err instanceof Error ? err.message : String(err)}`);
     }
-  }, [kb.renameFile, showToast]);
+  }, [kb.renameFile, kb.activeVault?.id, tabs, showToast]);
 
   const handleRenameCancel = useCallback(() => {
     setRenamingPath(null);
@@ -697,10 +714,14 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
 
     try {
       await kb.renameFile(srcPath, newPath);
+      const newFileName = newPath.split('/').pop() ?? newPath;
+      const existingTabForNewPath = tabs.tabs.find(t => t.id === `file:${newPath}`);
+      if (existingTabForNewPath) tabs.closeTab(`file:${newPath}`);
+      tabs.updateTab(`file:${srcPath}`, { id: `file:${newPath}`, title: newFileName, vaultId: kb.activeVault?.id });
     } catch (err) {
       showToast(`移动文件失败：${err instanceof Error ? err.message : String(err)}`);
     }
-  }, [kb.activeVault, kb.tree, kb.renameFile, showToast]);
+  }, [kb.activeVault, kb.activeVault?.id, kb.tree, kb.renameFile, tabs, showToast]);
 
   const handleImportFiles = useCallback(async (files: File[], targetDir: string) => {
     if (!kb.activeVault) return;

--- a/apps/web/src/hooks/useKbTabs.ts
+++ b/apps/web/src/hooks/useKbTabs.ts
@@ -15,11 +15,12 @@ import {
 } from '../stores/kbTabsStore';
 
 export type { TabType, WorkspaceTab } from '../stores/kbTabsStore';
+export { MAX_TABS } from '../stores/kbTabsStore';
 
 export interface UseKbTabsReturn {
   tabs: WorkspaceTab[];
   activeTabId: string | null;
-  openTab: (tab: Omit<WorkspaceTab, 'id'> & { id?: string }) => void;
+  openTab: (tab: Omit<WorkspaceTab, 'id'> & { id?: string }) => { opened: boolean; reason?: 'limit' };
   closeTab: (id: string) => void;
   activateTab: (id: string) => void;
   updateTab: (id: string, patch: Partial<WorkspaceTab>) => void;

--- a/apps/web/src/hooks/useKbTabs.ts
+++ b/apps/web/src/hooks/useKbTabs.ts
@@ -22,6 +22,7 @@ export interface UseKbTabsReturn {
   activeTabId: string | null;
   openTab: (tab: Omit<WorkspaceTab, 'id'> & { id?: string }) => { opened: boolean; reason?: 'limit' };
   closeTab: (id: string) => void;
+  removeWhere: (predicate: (t: WorkspaceTab) => boolean) => string[];
   activateTab: (id: string) => void;
   updateTab: (id: string, patch: Partial<WorkspaceTab>) => void;
   getActiveTab: () => WorkspaceTab | undefined;
@@ -38,6 +39,11 @@ export function useKbTabs(): UseKbTabsReturn {
 
   const closeTab = useCallback(
     (id: string) => kbTabsStore.closeTab(id),
+    [],
+  );
+
+  const removeWhere = useCallback(
+    (predicate: (t: WorkspaceTab) => boolean) => kbTabsStore.removeWhere(predicate),
     [],
   );
 
@@ -58,7 +64,7 @@ export function useKbTabs(): UseKbTabsReturn {
   );
 
   return useMemo(
-    () => ({ tabs, activeTabId, openTab, closeTab, activateTab, updateTab, getActiveTab }),
-    [tabs, activeTabId, openTab, closeTab, activateTab, updateTab, getActiveTab],
+    () => ({ tabs, activeTabId, openTab, closeTab, removeWhere, activateTab, updateTab, getActiveTab }),
+    [tabs, activeTabId, openTab, closeTab, removeWhere, activateTab, updateTab, getActiveTab],
   );
 }

--- a/apps/web/src/stores/kbTabsStore.ts
+++ b/apps/web/src/stores/kbTabsStore.ts
@@ -10,6 +10,9 @@ import { useSyncExternalStore } from 'react';
 const STORAGE_KEY_TABS = 'molio.kb.tabs';
 const STORAGE_KEY_ACTIVE_TAB = 'molio.kb.activeTabId';
 
+/** Maximum number of simultaneously open document tabs. Cap-only, not configurable. */
+export const MAX_TABS = 20;
+
 export type TabType = 'file' | string;
 
 export interface WorkspaceTab {
@@ -75,21 +78,26 @@ export const kbTabsStore = {
     return tabs.find((t) => t.id === activeTabId);
   },
 
-  openTab(tabInput: Omit<WorkspaceTab, 'id'> & { id?: string }) {
+  openTab(tabInput: Omit<WorkspaceTab, 'id'> & { id?: string }): { opened: boolean; reason?: 'limit' } {
     const id = tabInput.id ?? `${tabInput.type}:${Math.random().toString(36).slice(2, 9)}`;
     const existing = tabs.find((t) => t.id === id);
     if (existing) {
-      // Already exists — just activate
+      // Already exists — just activate; not a new open.
       if (activeTabId !== id) {
         activeTabId = id;
         emit();
       }
-      return;
+      return { opened: false };
+    }
+    // Cap: do not mutate state or emit; caller surfaces a notice.
+    if (tabs.length >= MAX_TABS) {
+      return { opened: false, reason: 'limit' };
     }
     const newTab: WorkspaceTab = { ...tabInput, id };
     tabs = [...tabs, newTab];
     activeTabId = id;
     emit();
+    return { opened: true };
   },
 
   closeTab(id: string) {
@@ -105,6 +113,7 @@ export const kbTabsStore = {
   },
 
   activateTab(id: string) {
+    if (!tabs.some((t) => t.id === id)) return;
     if (activeTabId !== id) {
       activeTabId = id;
       emit();

--- a/apps/web/src/stores/kbTabsStore.ts
+++ b/apps/web/src/stores/kbTabsStore.ts
@@ -19,6 +19,7 @@ export interface WorkspaceTab {
   id: string;
   type: TabType;
   title: string;
+  vaultId?: string;
   data?: Record<string, unknown>;
 }
 
@@ -110,6 +111,19 @@ export const kbTabsStore = {
       activeTabId = newActive?.id ?? null;
     }
     emit();
+  },
+
+  removeWhere(predicate: (t: WorkspaceTab) => boolean): string[] {
+    const removed = tabs.filter(predicate);
+    if (removed.length === 0) return [];
+    const removedIds = new Set(removed.map((t) => t.id));
+    const survivors = tabs.filter((t) => !removedIds.has(t.id));
+    tabs = survivors;
+    if (activeTabId && removedIds.has(activeTabId)) {
+      activeTabId = survivors[0]?.id ?? null;
+    }
+    emit();
+    return removed.map((t) => t.id);
   },
 
   activateTab(id: string) {

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2239,17 +2239,7 @@
   background: var(--bg-panel);
   color: var(--text-strong);
   border-color: var(--border);
-  font-weight: 500;
   margin-bottom: -1px;
-}
-
-.kb-wtab-icon {
-  font-size: 12px;
-  flex-shrink: 0;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .kb-wtab-title {

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2123,7 +2123,7 @@
   line-height: 1;
 }
 .kb-wtab-arrow:hover { color: var(--text); background: var(--bg-panel); }
-.kb-wtab-arrow[hidden] { display: none; }
+.kb-wtab-arrow[hidden] { visibility: hidden; }
 
 .kb-wtab-more {
   flex-shrink: 0;
@@ -2136,7 +2136,7 @@
   line-height: 1;
 }
 .kb-wtab-more:hover { color: var(--text); background: var(--bg-panel); }
-.kb-wtab-more[hidden] { display: none; }
+.kb-wtab-more[hidden] { visibility: hidden; }
 
 /* Dropdown menu listing all tabs (overflow affordance). */
 .kb-tab-dropdown {
@@ -2148,7 +2148,7 @@
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   max-height: 320px;
   overflow-y: auto;
   min-width: 180px;
@@ -2224,7 +2224,7 @@
   font-size: 12px;
   cursor: pointer;
   user-select: none;
-  transition: all 100ms ease;
+  transition: background-color 100ms ease, color 100ms ease, border-color 100ms ease;
   position: relative;
   margin-right: 1px;
   flex-shrink: 0;
@@ -2240,12 +2240,16 @@
   color: var(--text-strong);
   border-color: var(--border);
   font-weight: 500;
+  margin-bottom: -1px;
 }
 
 .kb-wtab-icon {
   font-size: 12px;
   flex-shrink: 0;
   line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .kb-wtab-title {
@@ -2282,6 +2286,17 @@
 .kb-wtab-close:hover {
   background: var(--bg-muted);
   color: var(--text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kb-wtab,
+  .kb-wtab-close,
+  .kb-wtab-arrow,
+  .kb-wtab-more,
+  .kb-wtab-dropdown-item,
+  .kb-wtab-dropdown-close {
+    transition: none;
+  }
 }
 
 /* ══════════ Context Menu ══════════ */

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2177,13 +2177,24 @@
 .kb-wtab-dropdown-close {
   width: 16px;
   height: 16px;
+  padding: 0;
   border: none;
   background: transparent;
   border-radius: 4px;
   color: var(--text-faint);
   font-size: 14px;
+  line-height: 1;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 80ms ease;
   flex-shrink: 0;
+}
+.kb-wtab-dropdown-item:hover .kb-wtab-dropdown-close,
+.kb-wtab-dropdown-item.is-active .kb-wtab-dropdown-close {
+  opacity: 1;
 }
 .kb-wtab-dropdown-close:hover { background: var(--bg-muted); color: var(--text); }
 

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2096,7 +2096,7 @@
 }
 
 /* Scrollable tab list — keeps trailing global actions fixed when tabs overflow. */
-.kb-wtab-list {
+.kb-wtab-scroll {
   display: flex;
   align-items: center;
   gap: 0;
@@ -2108,7 +2108,34 @@
   scrollbar-width: none;
 }
 
-.kb-wtab-list::-webkit-scrollbar { display: none; }
+.kb-wtab-scroll::-webkit-scrollbar { display: none; }
+
+/* Overflow arrows + dropdown trigger (functional in later tasks). */
+.kb-wtab-arrow {
+  flex-shrink: 0;
+  width: 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+.kb-wtab-arrow:hover { color: var(--text); background: var(--bg-panel); }
+.kb-wtab-arrow[hidden] { display: none; }
+
+.kb-wtab-more {
+  flex-shrink: 0;
+  width: 22px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+}
+.kb-wtab-more:hover { color: var(--text); background: var(--bg-panel); }
+.kb-wtab-more[hidden] { display: none; }
 
 /* Trailing global actions (vault-level, not tied to the active document). */
 .kb-wtab-actions {

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2093,6 +2093,7 @@
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   height: 36px;
+  position: relative;
 }
 
 /* Scrollable tab list — keeps trailing global actions fixed when tabs overflow. */
@@ -2136,6 +2137,55 @@
 }
 .kb-wtab-more:hover { color: var(--text); background: var(--bg-panel); }
 .kb-wtab-more[hidden] { display: none; }
+
+/* Dropdown menu listing all tabs (overflow affordance). */
+.kb-tab-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 200;
+  margin-top: 2px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-height: 320px;
+  overflow-y: auto;
+  min-width: 180px;
+}
+
+.kb-wtab-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.kb-wtab-dropdown-item:hover { background: var(--bg-subtle); color: var(--text); }
+.kb-wtab-dropdown-item.is-active { color: var(--text-strong); font-weight: 500; }
+
+.kb-wtab-dropdown-title {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.kb-wtab-dropdown-close {
+  width: 16px;
+  height: 16px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  color: var(--text-faint);
+  font-size: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.kb-wtab-dropdown-close:hover { background: var(--bg-muted); color: var(--text); }
 
 /* Trailing global actions (vault-level, not tied to the active document). */
 .kb-wtab-actions {


### PR DESCRIPTION
## What

知识库标签栏（KbTabBar）的体验治理，分三块：
1. **数量上限 + 溢出收纳 + active 滚入**——开多了不再失控。
2. **失效 tab 自动清理 + 同名标题消歧**——文件删/改名后不留死 tab；同名文件可区分。
3. **视觉打磨**——active 连入内容、暗色阴影、reduced-motion 等。

## Why

此前 tab 无上限、无溢出收纳、无 scrollIntoView；文件删/改名后 tab 变死 tab（指向不存在的路径）；同名文件（不同目录的 `index.md`）标题相同难区分；视觉上 active tab 没真正连入内容区、暗色模式下拉阴影消失。

## Changes

### 1. 数量上限 + 溢出收纳
- **`MAX_TABS = 20`**（const，单点读取于 `kbTabsStore.openTab`）。达上限拦截 + toast，**不静默淘汰**（遵守用户偏好规则）。
- **limit 预检在 `runOrConfirmDiscard` 之前**——避免确认放弃草稿后却被挡。
- **`openTab` 返回 `{opened, reason?:'limit'}`**，`activateTab` 加 id 存在性防御。
- **溢出收纳**：左右箭头 `‹ ›`（`onScroll` + `ResizeObserver` 控制显隐，点击滚约一屏）+ `▾` 下拉列出全部 tab。
- **active 自动滚入可见区**：`scrollIntoView({inline:'nearest'})`。
- 状态持久化 localStorage；持久化 tab 数 > MAX 不静默关闭。

### 2. 失效 tab 清理 + 同名消歧
- **`WorkspaceTab.vaultId`**——让 reactive 能区分 tab 所属 vault，不误清别 vault 的 tab。
- **`removeWhere(predicate)`**——store 批量关 tab，active 被关自动激活 survivor。
- **Proactive**（app 内操作）：rename/move → `updateTab` 改 id+title（保留 tab 与 active 状态，含 rename 覆盖防御）；delete → `closeTab` / `removeWhere`（文件夹删除按前缀批量）；抽 `handleDeleteFile`/`handleDeleteFolder` 接右键菜单。
- **Reactive**（app 外安全网）：`tree-changed` SSE 刷新树后，对 `vaultId` 匹配的 tab 检查路径是否还在树中，不在则关；守卫 `treeVaultId === activeVault.id && tree.length > 0` 防 vault 切换/加载中误清；全清时显式 `selectFile(null)`。
- **同名消歧**：`KbTabBar` 渲染层 `tabDisplayTitle` 派生——碰撞显示 `父目录/文件名`，仍碰撞回退完整相对路径；无碰撞只显示文件名；tooltip 用完整路径。不改 store，无循环风险。

### 3. 视觉打磨
- active tab `margin-bottom:-1px`，用不透明背景盖住容器底边框 → 与内容区视觉贯通。
- 箭头/下拉 `[hidden]` 从 `display:none` 改 `visibility:hidden` → 出现/消失不挤压滚动容器、消除抖动。
- 下拉阴影改 `var(--shadow-md)` token → 暗色模式可见。
- `transition: all` 改显式属性 → 剔除 font-weight 跳变；active 不靠加粗区分（避免标题截断跳变）。
- 尊重 `prefers-reduced-motion`（CSS media + `scrollBy` matchMedia）。
- tab 无图标（统一图标不承载信息）；下拉 `×` 默认隐藏、hover/active 显现、flex 居中与标题对齐。

### 测试
- `kb-tab-limit.spec.ts`（P0，11 用例：上限拦截 / discard 顺序 / 持久化 >MAX / 溢出 UI / 箭头滚动 / 下拉 / scrollIntoView）。
- `kb-tab-stale.spec.ts`（P1：proactive rename/delete/folder-delete / reactive stale 清理 / 跨 vault 不误清 / 同名消歧 / tooltip / deeper 碰撞）。
- `kb-tabs.spec.ts` 既有用例回归通过。
- `area-map.json` 注册两个新 spec（含顶层 `specs` 元数据）。

## Verification

- `pnpm typecheck` 全包 clean。
- `cd apps/web && npx playwright test e2e/kb-*.spec.ts` → 40/40 PASS。

## Notes

- 未触及 CLAUDE.md「E2E 核心流程保护」清单内文件（HomePage/ChatComposer/useChat 等），按 area 规则跑 kb spec。
- 失效 tab「外部 rename 续接」（旧 tab 自动接到新路径）不做——外部 rename 关旧 tab，用户重开。
- per-tab 编辑态、拖拽排序、右键菜单、按文件类型分图标等已在 `docs/kb-tab-bar-issues.md` 列为后续独立分支。