### PR TITLE
fix(web): chat fallback timer 改 idle 语义，修复长任务误报响应超时

### DIFF
--- a/apps/web/e2e/chat-timeout-idle-reset.spec.ts
+++ b/apps/web/e2e/chat-timeout-idle-reset.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { gotoHome, sendMessage } from './helpers/navigation';
+import { mockChatRun, unmockAll } from './helpers/mock-sse';
+
+/**
+ * @area chat
+ * @priority P1
+ *
+ * Companion to chat-timeout-fallback.spec — guards the IDLE-reset behavior of
+ * the fallback timer. The fallback is armed on run start and reset on EVERY
+ * received AgentEvent, so a long but ACTIVE run (remotion render, multi-turn
+ * chat, periodic tool output) must NOT false-fire "响应超时" while events
+ * are still flowing, even when the run duration exceeds the idle window.
+ *
+ * Regression guard for the bug where a run streaming for >5min got killed
+ * mid-run by an ABSOLUTE timer that ignored activity (the timer only counted
+ * down from run start, never reset on intermediate events).
+ */
+test.describe('Chat — idle reset prevents false timeout', () => {
+  test.beforeEach(async ({ page }) => {
+    // Shrink the 10min idle window to 1s so the test can prove events keep
+    // the run alive PAST the window without sleeping 10min. Production never
+    // sets this.
+    await page.addInitScript(() => {
+      (window as any).__MOLIO_TEST_FALLBACK_TIMEOUT_MS__ = 1000;
+    });
+  });
+
+  test('periodic events keep the composer running past the idle window', async ({ page }) => {
+    // 10 non-terminal events streamed every 300ms = ~3s of activity. The idle
+    // window is 1s. An absolute timer (the old behavior) would fire at 1s and
+    // surface "响应超时"; the idle-reset timer gets re-armed by each event,
+    // so the run stays alive well past 1s with no error.
+    const script = Array.from({ length: 10 }, () => ({ type: 'status', label: 'running' }));
+    await mockChatRun(page, { script, frameDelay: 300 });
+    await gotoHome(page);
+    await sendMessage(page, 'hi');
+
+    const input = page.locator('[data-testid="composer-input"]');
+    // During the run the composer is disabled (isRunning=true).
+    await expect(input).toBeDisabled({ timeout: 5_000 });
+
+    // Wait PAST the 1s idle window. The run is still streaming (events arrive
+    // every 300ms through ~3s), so the timer has been reset repeatedly — no
+    // false timeout. The composer must still be running and no error banner
+    // must have surfaced.
+    await page.waitForTimeout(1_600);
+    await expect(input).toBeDisabled();
+    await expect(page.locator('[data-testid="assistant-error"]')).toHaveCount(0);
+  });
+
+  test.afterEach(async ({ page }) => { await unmockAll(page); });
+});

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -83,6 +83,16 @@ export interface UseChatCoreOptions {
 let msgCounter = 0;
 function nextMsgId() { return `msg-${++msgCounter}-${Date.now()}`; }
 
+/**
+ * Idle window for the fallback unlock timer. Long enough to tolerate a single
+ * silent long-running tool call (e.g. remotion `npm install` of a large dep
+ * tree on a slow network) without a false "响应超时"; short enough that a
+ * genuinely hung run (daemon alive but no events) still surfaces in ~10min.
+ * The timer is idle-based — reset on every received event — so an ACTIVE run
+ * of any length never false-times-out.
+ */
+const FALLBACK_IDLE_MS = 10 * 60 * 1000; // 10 minutes
+
 export function useChatCore(options: UseChatCoreOptions) {
   const { createRun, rewindResend, agentId, initialMessages = [], initialConversationId = null, onComplete } = options;
 
@@ -107,6 +117,33 @@ export function useChatCore(options: UseChatCoreOptions) {
       clearTimeout(fallbackTimerRef.current);
       fallbackTimerRef.current = null;
     }
+  }, []);
+
+  /**
+   * Re-arm the idle fallback timer (clear + schedule). Called on every
+   * received AgentEvent so a long but active run never false-times-out; the
+   * timer only fires when the stream goes truly silent for FALLBACK_IDLE_MS.
+   * Terminal status clears (does not re-arm) via clearFallbackTimer.
+   */
+  const resetFallbackTimer = useCallback(() => {
+    if (fallbackTimerRef.current) {
+      clearTimeout(fallbackTimerRef.current);
+    }
+    const fallbackMs = (typeof window !== 'undefined' &&
+      (window as any).__MOLIO_TEST_FALLBACK_TIMEOUT_MS__) || FALLBACK_IDLE_MS;
+    fallbackTimerRef.current = setTimeout(() => {
+      setState((prev) => {
+        if (!prev.isRunning) return prev;
+        const messages = prev.messages.map((msg) =>
+          msg.id === assistantIdRef.current && msg.streaming
+            ? { ...msg, streaming: false, error: msg.error ?? '响应超时，请重试或检查 daemon 是否运行' }
+            : msg
+        );
+        return { ...prev, messages, isRunning: false, runId: null, runAgentId: null };
+      });
+      esRef.current?.close();
+      esRef.current = null;
+    }, fallbackMs);
   }, []);
 
   const closeEventSource = useCallback(() => {
@@ -157,10 +194,14 @@ export function useChatCore(options: UseChatCoreOptions) {
           window.dispatchEvent(new CustomEvent(ACP_MODELS_UPDATED_EVENT, { detail }));
         }
         setState((prev) => updateWithEvent(prev, currentId, event));
-        // P2-3: terminal status clears the fallback timer — the run ended
-        // cleanly (success/failed/canceled), no need to force-unlock later.
+        // Fallback timer is idle-based: any activity (text/tool/usage/etc.)
+        // resets the window so a long but active run never false-times-out.
+        // Terminal status clears it — the run ended cleanly, no need to
+        // force-unlock later.
         if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed' || event.label === 'canceled')) {
           clearFallbackTimer();
+        } else {
+          resetFallbackTimer();
         }
       },
       () => { /* SSE error — EventSource auto-retries; onDone handles permanent close */ },
@@ -180,30 +221,17 @@ export function useChatCore(options: UseChatCoreOptions) {
     );
     esRef.current = es;
 
-    // P2-3: fallback timer — if no terminal status arrives within 5min,
-    // force-unlock the input. Catches: daemon hang (SSE alive but no events),
-    // daemon crash without a close event, network blackhole. 5min aligns
-    // with daemon's promptIdleTimeoutMs so the frontend unlocks around when
-    // the daemon itself gives up.
+    // Idle fallback timer — armed on run start and reset on every received
+    // event (see resetFallbackTimer). A long but ACTIVE run (remotion render,
+    // multi-turn chat, long tool calls) never false-times-out as long as
+    // events keep flowing; it only fires when the stream goes truly silent
+    // for FALLBACK_IDLE_MS — catching daemon hangs/crashes and network
+    // blackholes. Terminal status clears it.
     //
     // Test hook: `window.__MOLIO_TEST_FALLBACK_TIMEOUT_MS__` shortens the
-    // wait so E2E can exercise this path without sleeping 5min. Production
-    // never sets this.
-    const fallbackMs = (typeof window !== 'undefined' &&
-      (window as any).__MOLIO_TEST_FALLBACK_TIMEOUT_MS__) || 300_000;
-    fallbackTimerRef.current = setTimeout(() => {
-      setState((prev) => {
-        if (!prev.isRunning) return prev;
-        const messages = prev.messages.map((msg) =>
-          msg.id === assistantIdRef.current && msg.streaming
-            ? { ...msg, streaming: false, error: msg.error ?? '响应超时，请重试或检查 daemon 是否运行' }
-            : msg
-        );
-        return { ...prev, messages, isRunning: false, runId: null, runAgentId: null };
-      });
-      esRef.current?.close();
-      esRef.current = null;
-    }, fallbackMs);
+    // wait so E2E can exercise this path without sleeping. Production never
+    // sets this.
+    resetFallbackTimer();
 
     if (onComplete) {
       const origOnEvent = es.onmessage;
@@ -216,7 +244,7 @@ export function useChatCore(options: UseChatCoreOptions) {
         } catch { /* ignore parse errors */ }
       };
     }
-  }, [state.conversationId, agentId, onComplete, clearFallbackTimer]);
+  }, [state.conversationId, agentId, onComplete, clearFallbackTimer, resetFallbackTimer]);
 
   /**
    * Send a message — tries multi-turn on existing run first, falls back to createRun.
@@ -259,6 +287,11 @@ export function useChatCore(options: UseChatCoreOptions) {
     if (existingRunId && !agentChanged) {
       try {
         await api.sendMessage(existingRunId, text.trim());
+        // Multi-turn reuses the existing SSE subscription, which does NOT
+        // re-arm the fallback timer (beginNewRun isn't called). Re-arm here so
+        // a hung follow-up turn still force-unlocks instead of spinning
+        // forever. Events from this turn keep resetting it (idle semantics).
+        resetFallbackTimer();
         return; // SSE is still active, events route via assistantIdRef
       } catch {
         // Multi-turn failed — fall through to new run
@@ -305,7 +338,7 @@ export function useChatCore(options: UseChatCoreOptions) {
         return { ...prev, messages, isRunning: false };
       });
     }
-  }, [state.runId, state.runAgentId, state.conversationId, state.messages, closeEventSource, createRun, agentId, onComplete, beginNewRun]);
+  }, [state.runId, state.runAgentId, state.conversationId, state.messages, closeEventSource, createRun, agentId, onComplete, beginNewRun, resetFallbackTimer]);
 
   const rewindAndResend = useCallback(async (newContent: string) => {
     if (!rewindResend) return;


### PR DESCRIPTION
## 问题

客户机器上跑 remotion skill 生成视频时，5 分钟后前端弹出"响应超时，请重试或检查 daemon 是否运行"，但后台 Claude Code 其实在正常渲染。

## 根因

前端 `useChatCore.ts` 的 fallback 定时器是 **5 分钟绝对定时器**：run 开始时设一次，**只在收到终态 status 时清除**，中间的 `text_delta` / `tool_use` / `tool_result` 等**完全不重置它**。所以任何 run 跑超 5 分钟（remotion 渲染、多轮长任务）即使在持续输出，也会在第 5 分钟误报"响应超时"。注释自称 aligns with daemon 的 `promptIdleTimeoutMs`，但后者是 idle（活动重置）语义，前端却是绝对语义——错配即 bug。

remotion skill 跑在 Claude Code（stdio-jsonl）下，该路径 daemon 无任何超时，会一直等子进程退出；所以"超时"纯前端误报。

## 修复

`apps/web/src/hooks/useChatCore.ts`：

1. 新增 `FALLBACK_IDLE_MS = 10min` 模块常量（原内联 5min）。
2. 新增 `resetFallbackTimer()`（清 + 重新计时）。
3. `onEvent` 回调：**非终态事件 → 重置定时器；终态 → 清除**（原只在终态清除）。这是核心修复——绝对改 idle，活跃 run 永不误报。
4. `beginNewRun`：用 `resetFallbackTimer()` 替换内联绝对定时器。
5. **多轮 `send()` 路径**：发第二条消息后重新计时（原多轮不重建定时器，第二轮无 fallback 会无限转）。

窗口从 5min 提到 10min，容忍单次长静默工具调用（如 remotion `npm install`）；只有真正长时间无事件（daemon 挂/网络黑洞）才触发解锁。

## 测试

- `pnpm typecheck`：通过
- 新增 `apps/web/e2e/chat-timeout-idle-reset.spec.ts`（`@area chat @priority P1`）：周期性事件不会误报超时（验证 idle 重置）。
- 原 `chat-timeout-fallback.spec.ts`（真静默→触发）：仍绿。
- 全量 E2E：162 passed / 8 skipped / 1 failed；唯一失败的 `kb-tab-stale` 与本改动无关（KB tab 同名消歧），单独重跑通过，属预先存在的 flaky。

## 不在范围

- 单次工具调用静默超过 10 分钟（极慢网络下 Chrome/依赖下载）：需要 daemon 心跳才能完全解决，未做。
- 多轮"第二轮完全无事件"的根因（Claude Code 是否响应第二条 stdin）：本 PR 让其 10 分钟后报错而非永远卡，但根因仍待现场日志确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)