### PR TITLE
fix(daemon,web): vault scan/watch 架构加固 — bounded + 整树剪枝

### DIFF
--- a/apps/daemon/src/core/knowledge.ts
+++ b/apps/daemon/src/core/knowledge.ts
@@ -8,31 +8,78 @@ import path from 'node:path';
 import trash from 'trash';
 import type { TreeNode, FileContent, SearchResult } from '@molio/contracts';
 import { detectEncoding, decodeAll, decideReadStrategy, FileTooLargeError, ENCODING_SAMPLE_BYTES } from './encoding.js';
+// Pruning predicate + caps live in a dependency-free module so importing them
+// (e.g. from VaultWatcher) does not transitively load encoding.ts.
+export { PRUNE_DIR_NAMES, isPrunedDirName, MAX_DIR_ENTRIES, MAX_TOTAL } from './vault-prune.js';
+import { isPrunedDirName, MAX_DIR_ENTRIES, MAX_TOTAL } from './vault-prune.js';
+
+interface ScanCtx {
+  visited: number;
+  stopped: boolean;
+  maxDirEntries: number;
+  maxTotal: number;
+}
+
+/** Optional overrides for scanTree / countFiles caps (mainly for tests). */
+export interface ScanOpts {
+  maxDirEntries?: number;
+  maxTotal?: number;
+}
 
 /**
  * Scan a vault directory and return the file tree.
- * Only includes .md, .txt, .pdf, .docx, .html files and directories.
+ * Only includes supported file types (see ALLOWED_EXTS) and directories.
+ * Pruned directories (PRUNE_DIR_NAMES / oversized) are not descended into.
  */
-export function scanTree(vaultPath: string, relBase = ''): TreeNode[] {
+export function scanTree(vaultPath: string, relBase = '', opts: ScanOpts = {}): TreeNode[] {
+  return scanTreeInner(vaultPath, relBase, {
+    visited: 0,
+    stopped: false,
+    maxDirEntries: opts.maxDirEntries ?? MAX_DIR_ENTRIES,
+    maxTotal: opts.maxTotal ?? MAX_TOTAL,
+  });
+}
+
+function scanTreeInner(vaultPath: string, relBase: string, ctx: ScanCtx): TreeNode[] {
+  if (ctx.stopped) return [];
   const absDir = relBase ? path.join(vaultPath, relBase) : vaultPath;
-  const entries = fs.readdirSync(absDir, { withFileTypes: true });
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
   const nodes: TreeNode[] = [];
 
-  for (const entry of entries) {
-    // Skip hidden files/dirs
-    if (entry.name.startsWith('.')) continue;
+  // Backstop: prune oversized subtrees instead of stat-ing thousands of files.
+  // Return empty children — the parent call still pushes a directory node (now
+  // empty), which surfaces the dir as pruned without stat-ing its contents.
+  if (entries.length > ctx.maxDirEntries) {
+    console.warn(
+      `[knowledge] scanTree pruned oversized directory (${entries.length} entries, limit ${ctx.maxDirEntries}): ${absDir}`,
+    );
+    return [];
+  }
 
+  for (const entry of entries) {
+    if (isPrunedDirName(entry.name)) continue;
     const relPath = relBase ? `${relBase}/${entry.name}` : entry.name;
 
     if (entry.isDirectory()) {
-      const children = scanTree(vaultPath, relPath);
-      nodes.push({
-        name: entry.name,
-        path: relPath,
-        type: 'directory',
-        children,
-      });
+      const children = scanTreeInner(vaultPath, relPath, ctx);
+      nodes.push({ name: entry.name, path: relPath, type: 'directory', children });
+      if (ctx.stopped) break;
     } else if (entry.isFile() && isSupportedFile(entry.name)) {
+      ctx.visited++;
+      if (ctx.visited > ctx.maxTotal) {
+        if (!ctx.stopped) {
+          ctx.stopped = true;
+          console.warn(
+            `[knowledge] scanTree hit MAX_TOTAL (${ctx.maxTotal}) file cap, truncating at ${absDir}`,
+          );
+        }
+        break;
+      }
       const absFile = path.join(absDir, entry.name);
       const stat = fs.statSync(absFile);
       nodes.push({
@@ -56,20 +103,51 @@ export function scanTree(vaultPath: string, relBase = ''): TreeNode[] {
 
 /**
  * Count all supported files in a vault directory (recursive).
+ * Pruned directories (PRUNE_DIR_NAMES / oversized) are not descended into.
  */
-export function countFiles(vaultPath: string): number {
-  let count = 0;
-  const entries = fs.readdirSync(vaultPath, { withFileTypes: true });
+export function countFiles(vaultPath: string, opts: ScanOpts = {}): number {
+  return countFilesInner(vaultPath, {
+    visited: 0,
+    stopped: false,
+    maxDirEntries: opts.maxDirEntries ?? MAX_DIR_ENTRIES,
+    maxTotal: opts.maxTotal ?? MAX_TOTAL,
+  });
+}
 
+function countFilesInner(dir: string, ctx: ScanCtx): number {
+  if (ctx.stopped) return 0;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  if (entries.length > ctx.maxDirEntries) {
+    console.warn(
+      `[knowledge] countFiles pruned oversized directory (${entries.length} entries, limit ${ctx.maxDirEntries}): ${dir}`,
+    );
+    return 0;
+  }
+  let count = 0;
   for (const entry of entries) {
-    if (entry.name.startsWith('.')) continue;
+    if (isPrunedDirName(entry.name)) continue;
     if (entry.isDirectory()) {
-      count += countFiles(path.join(vaultPath, entry.name));
+      count += countFilesInner(path.join(dir, entry.name), ctx);
+      if (ctx.stopped) break;
     } else if (entry.isFile() && isSupportedFile(entry.name)) {
+      ctx.visited++;
+      if (ctx.visited > ctx.maxTotal) {
+        if (!ctx.stopped) {
+          ctx.stopped = true;
+          console.warn(
+            `[knowledge] countFiles hit MAX_TOTAL (${ctx.maxTotal}) file cap, truncating at ${dir}`,
+          );
+        }
+        break;
+      }
       count++;
     }
   }
-
   return count;
 }
 
@@ -241,8 +319,11 @@ function findFileByStem(
     } catch {
       return;
     }
+    // Don't descend into oversized directories — a wiki link target never
+    // lives inside a dumped dataset, and walking 50k entries is wasteful.
+    if (entries.length > MAX_DIR_ENTRIES) return;
     for (const entry of entries) {
-      if (entry.name.startsWith('.')) continue;
+      if (isPrunedDirName(entry.name)) continue;
       const abs = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(abs);
@@ -628,7 +709,8 @@ const MIME_TYPES: Record<string, string> = {
 /**
  * 全文搜索 vault 内文本文件。遍历目录，对每个文本文件 String.includes 匹配，
  * 命中则截取关键词前后 30 字符作为 snippet。
- * - 跳过隐藏文件/目录（. 开头）
+ * - 跳过被剪枝的目录（isPrunedDirName：点号开头 + 构建产物目录名）
+ * - 跳过超大目录（> MAX_DIR_ENTRIES，避免对 dump 出来的大目录逐文件 readFileSync）
  * - 只搜 TEXT_EXTS 内的文件
  * - limit 截断，truncated 标记是否还有更多
  */
@@ -648,8 +730,11 @@ export function searchFiles(
     } catch {
       return;
     }
+    // Don't descend into oversized directories — searching inside a dumped
+    // dataset is wasteful (readFileSync per file) and a real hit never lives there.
+    if (entries.length > MAX_DIR_ENTRIES) return;
     for (const entry of entries) {
-      if (entry.name.startsWith('.')) continue;
+      if (isPrunedDirName(entry.name)) continue;
       const abs = path.join(absDir, entry.name);
       if (entry.isDirectory()) {
         walk(abs);

--- a/apps/daemon/src/core/vault-prune.ts
+++ b/apps/daemon/src/core/vault-prune.ts
@@ -1,0 +1,57 @@
+/**
+ * Vault tree-pruning predicate + hard caps.
+ *
+ * Shared by the vault tree scanner (scanTree, countFiles, findFileByStem,
+ * searchFiles, walkWiki) and the filesystem watcher (VaultWatcher) so the two
+ * never diverge on "what counts as knowledge".
+ *
+ * Kept in a dependency-free module on purpose: importing it (e.g. from
+ * VaultWatcher) must NOT transitively load encoding.ts, because some tests
+ * tune encoding's size caps (MOLIO_MAX_VIEW_SIZE / MOLIO_HARD_CAP) via env
+ * vars at their own module-load time, and a transitive load here would cache
+ * the defaults before those vars are set.
+ */
+
+/**
+ * Directory names that are never part of the knowledge tree — they hold build
+ * artifacts / dependencies / VCS data, often tens of thousands of files.
+ * Walking or watching them exhausts file descriptors and blocks the event
+ * loop (the root cause of the "agent unavailable" bug: chokidar held ~10k FDs
+ * from a vault's node_modules, starving posix_spawn → probeVersion failed).
+ *
+ * Dotfile entries (.git, .molio, .claude, …) are also pruned; listing .git/.svn
+ * /.hg explicitly here is just for clarity.
+ */
+export const PRUNE_DIR_NAMES = new Set([
+  'node_modules', 'bower_components', 'jspm_packages',
+  '.git', '.svn', '.hg',
+  'dist', 'build', 'out', '.next', '.nuxt', '.turbo',
+  '.parcel-cache', 'coverage', '.cache',
+  '__pycache__', '.pytest_cache', '.mypy_cache', '.ruff_cache',
+  'venv', '.venv', 'env',
+  'target', '.gradle',
+]);
+
+/**
+ * True if a directory entry should be pruned wholesale (not readdir, not stat,
+ * not watched). Add a new artifact directory here once and both the scanner
+ * and the watcher pick it up.
+ */
+export function isPrunedDirName(name: string): boolean {
+  return (name.startsWith('.') && name !== '.') || PRUNE_DIR_NAMES.has(name);
+}
+
+/**
+ * Hard cap on immediate entries in a single directory. A non-pruned directory
+ * above this is almost certainly not knowledge (a dumped dataset, a decompressed
+ * archive) — prune the whole subtree instead of stat-ing thousands of files.
+ * One readdir is a single syscall, so this never blocks the event loop.
+ */
+export const MAX_DIR_ENTRIES = 1000;
+
+/**
+ * Hard cap on total files processed in one scan. Guards against deep trees
+ * where every directory is under MAX_DIR_ENTRIES but the total is huge. Real
+ * knowledge bases stay well under this; artifacts are already pruned by name.
+ */
+export const MAX_TOTAL = 50000;

--- a/apps/daemon/src/core/vault-watcher.ts
+++ b/apps/daemon/src/core/vault-watcher.ts
@@ -7,9 +7,12 @@
  * closes every watcher. Individual vault watchers are isolated — one failing
  * does not affect the others.
  *
- * `.git` and dotfiles are ignored: they aren't part of the displayed tree
- * (scanTree skips dotfiles), and ignoring `.git` prevents our own ingest
- * commits from self-triggering a refresh loop.
+ * `.git`, dotfiles, and build/dependency directories (node_modules, dist, …)
+ * are ignored via the shared `isPrunedDirName` predicate — keeping this in sync
+ * with scanTree, and preventing the FD-exhaustion root cause (chokidar held
+ * ~10k FDs from a vault's node_modules → posix_spawn EBADF → probeVersion
+ * failed → "agent unavailable"). A per-directory child counter backstops any
+ * non-pruned oversized directory so an unknown giant folder can't exhaust FDs.
  */
 import { EventEmitter } from 'node:events';
 import { realpathSync } from 'node:fs';
@@ -17,6 +20,9 @@ import path from 'node:path';
 import type Database from 'better-sqlite3';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { listVaults } from './db.js';
+// Import from vault-prune (not knowledge) so this module does NOT transitively
+// pull in encoding.ts — tests tune encoding's size caps via env vars at load.
+import { isPrunedDirName, MAX_DIR_ENTRIES } from './vault-prune.js';
 
 export const VAULT_TREE_CHANGED_EVENT = 'tree-changed';
 
@@ -72,16 +78,34 @@ export class VaultWatcher extends EventEmitter {
         /* path may not exist yet — watch the original path */
       }
       const root = path.resolve(resolvedPath);
+
+      // Per-directory child counter — best-effort backstop so a non-pruned
+      // oversized directory (a folder the user dumped into the vault) can't
+      // exhaust file descriptors. chokidar calls `ignored` once per path it
+      // considers; once a single parent has been asked about more than
+      // MAX_DIR_ENTRIES children, ignore the rest. The vault root is never
+      // pruned (handled by the `resolved === root` check below), so this only
+      // bounds nested directories. Walk order is not guaranteed, so this is a
+      // hard cap on per-directory work, not a precise threshold.
+      const dirChildCounts = new Map<string, number>();
+
       const watcher = await chokidar.watch(resolvedPath, {
-        // Ignore dotfile entries (.git, .claude, .gitignore) — they aren't in
-        // the displayed tree (scanTree skips dotfiles) and watching .git would
-        // self-trigger on our own ingest commits. Never ignore the vault root
-        // itself, even if its name or an ancestor starts with a dot.
+        // Ignore dotfile entries (.git, .claude, .gitignore) and build/dependency
+        // directories (node_modules, dist, …) via the shared isPrunedDirName —
+        // same predicate scanTree uses, so the watcher and the displayed tree
+        // agree on what counts as knowledge. Never ignore the vault root itself,
+        // even if its name or an ancestor starts with a dot.
         ignored: (p) => {
           const resolved = path.resolve(p);
           if (resolved === root) return false;
           const base = resolved.split(/[/\\]/).pop() ?? '';
-          return base.startsWith('.') && base !== '.';
+          if (isPrunedDirName(base)) return true;
+          // Per-dir backstop: count how many children of this parent chokidar
+          // has asked about; once past the cap, ignore the overflow.
+          const parent = path.dirname(resolved);
+          const next = (dirChildCounts.get(parent) ?? 0) + 1;
+          dirChildCounts.set(parent, next);
+          return next > MAX_DIR_ENTRIES;
         },
         ignoreInitial: true,
         persistent: true,

--- a/apps/daemon/src/core/wiki-status.ts
+++ b/apps/daemon/src/core/wiki-status.ts
@@ -20,6 +20,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { TreeNode, IngestStatus } from '@molio/contracts';
+// Import from vault-prune (not knowledge) to avoid transitively loading encoding.ts.
+import { isPrunedDirName, MAX_DIR_ENTRIES } from './vault-prune.js';
 
 const LOG_REL = path.join('wiki', 'log.md');
 const SOURCES_DIR_REL = path.join('wiki', 'sources');
@@ -96,8 +98,9 @@ function walkWiki(wikiDir: string, out: ParsedWiki): void {
   const walk = (d: string) => {
     let entries: fs.Dirent[];
     try { entries = fs.readdirSync(d, { withFileTypes: true }); } catch { return; }
+    if (entries.length > MAX_DIR_ENTRIES) return;
     for (const e of entries) {
-      if (e.name.startsWith('.')) continue;
+      if (isPrunedDirName(e.name)) continue;
       const p = path.join(d, e.name);
       if (e.isDirectory()) {
         walk(p);

--- a/apps/daemon/src/tools/skills/remotion/SKILL.md
+++ b/apps/daemon/src/tools/skills/remotion/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: remotion
 description: Molio's builtin skill for MAKING a video from any source — wiki notes, articles, scripts, product info, or a brief — and rendering it to MP4. Use whenever the user wants to create/produce a video: a product demo, promo, trailer, intro, explainer, motion graphic, kinetic typography, social clip, or animated logo — even if they never mention Remotion by name. Do NOT reach for moviepy, manim, or Python video libraries to stitch frames; this is Molio's supported video path (scaffolds a Remotion React/TypeScript project, animates with interpolate/useCurrentFrame, sequences scenes, adds audio/voiceover/captions, and renders). Trigger words: 做个视频, 制作视频, 介绍视频, 宣传视频, 产品视频, 动画, make a video, create a video, product video, motion graphic, intro, trailer, explainer.
-version: 1.0.2
+version: 1.0.3
 metadata:
   tags: remotion, video, react, animation, composition
 ---
@@ -21,13 +21,15 @@ Before writing any video code, resolve these four things — they are the differ
 
 ## New project setup
 
-When in an empty folder or workspace with no existing Remotion project, scaffold one using:
+When in an empty folder or workspace with no existing Remotion project, scaffold it into the Molio workspace directory (Molio 工作区，文件树扫描会跳过 `.molio`，不污染 vault 根；其 `node_modules`/`dist`/`out` 不会触发监听或扫描，避免 daemon FD 泄漏):
 
 ```bash
-npx create-video@latest --yes --blank --no-tailwind my-video
+mkdir -p .molio/remotion
+cd .molio/remotion
+npx create-video@latest --yes --blank --no-tailwind <project-name>
 ```
 
-Replace `my-video` with a suitable project name.
+Replace `<project-name>` with a suitable project name. The project and all its build artifacts (`node_modules`, `out/` rendered MP4s) stay under `.molio/remotion/`, invisible to the vault file-tree scan. If you need the final MP4 visible in the knowledge tree, copy it out of `.molio/remotion/<project>/out/` into the vault root after rendering.
 
 ### Monorepo setup
 

--- a/apps/daemon/test/core/knowledge.test.ts
+++ b/apps/daemon/test/core/knowledge.test.ts
@@ -14,6 +14,10 @@ import {
   scanTree,
   countFiles,
   resolveCanonicalPath,
+  isPrunedDirName,
+  PRUNE_DIR_NAMES,
+  MAX_DIR_ENTRIES,
+  MAX_TOTAL,
 } from '../../src/core/knowledge.js';
 
 describe('readFile encoding + tiers', () => {
@@ -524,6 +528,163 @@ describe('knowledge filesystem operations', () => {
 
     it('returns null for empty input', () => {
       assert.equal(resolveCanonicalPath(vaultPath, ''), null);
+    });
+  });
+});
+
+// Pruning + bounded-scan backstop: the architecture that prevents FD exhaustion
+// and event-loop blocking when a vault contains a node_modules / dumped dataset.
+// See apps/daemon/src/core/knowledge.ts — isPrunedDirName, MAX_DIR_ENTRIES, MAX_TOTAL.
+describe('vault scan pruning + bounded backstop', () => {
+  let vp: string;
+  before(() => { vp = mkdtempSync(join(tmpdir(), 'molio-prune-')); });
+  after(() => { rmSync(vp, { recursive: true, force: true }); });
+
+  describe('isPrunedDirName', () => {
+    it('prunes dotfile entries (except the vault root marker itself)', () => {
+      assert.equal(isPrunedDirName('.git'), true);
+      assert.equal(isPrunedDirName('.molio'), true);
+      assert.equal(isPrunedDirName('.claude'), true);
+      assert.equal(isPrunedDirName('.'), false);
+    });
+
+    it('prunes known build/dependency directories', () => {
+      assert.equal(isPrunedDirName('node_modules'), true);
+      assert.equal(isPrunedDirName('dist'), true);
+      assert.equal(isPrunedDirName('build'), true);
+      assert.equal(isPrunedDirName('__pycache__'), true);
+      assert.equal(isPrunedDirName('.venv'), true);
+      assert.equal(isPrunedDirName('target'), true);
+    });
+
+    it('does not prune ordinary knowledge directories', () => {
+      assert.equal(isPrunedDirName('notes'), false);
+      assert.equal(isPrunedDirName('wiki'), false);
+      assert.equal(isPrunedDirName('attachments'), false);
+    });
+
+    it('PRUNE_DIR_NAMES is non-empty and stable', () => {
+      assert.ok(PRUNE_DIR_NAMES.size >= 10);
+      assert.ok(PRUNE_DIR_NAMES.has('node_modules'));
+    });
+  });
+
+  describe('scanTree pruning', () => {
+    it('does not descend into node_modules (the FD-exhaustion root cause)', () => {
+      const clean = mkdtempSync(join(tmpdir(), 'molio-prune-nm-'));
+      try {
+        writeFileSync(join(clean, 'real.md'), '# real');
+        mkdirSync(join(clean, 'node_modules', 'some-pkg', 'lib'), { recursive: true });
+        // 30 fake files inside node_modules — scanTree must never touch them.
+        for (let i = 0; i < 30; i++) {
+          writeFileSync(join(clean, 'node_modules', 'some-pkg', 'lib', `f${i}.md`), 'x');
+        }
+
+        const tree = scanTree(clean);
+        const nodeModules = tree.find((n) => n.name === 'node_modules');
+        assert.equal(nodeModules, undefined);
+        // The real knowledge file still surfaces.
+        assert.equal(tree.find((n) => n.name === 'real.md')?.type, 'file');
+      } finally {
+        rmSync(clean, { recursive: true, force: true });
+      }
+    });
+
+    it('prunes every PRUNE_DIR_NAMES entry (not just node_modules)', () => {
+      const clean = mkdtempSync(join(tmpdir(), 'molio-prune-all-'));
+      try {
+        writeFileSync(join(clean, 'keep.md'), 'k');
+        for (const name of ['dist', 'build', 'out', '__pycache__']) {
+          mkdirSync(join(clean, name), { recursive: true });
+          writeFileSync(join(clean, name, 'inside.md'), 'x');
+        }
+        const tree = scanTree(clean);
+        assert.deepEqual(
+          tree.map((n) => n.name),
+          ['keep.md'],
+        );
+      } finally {
+        rmSync(clean, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('scanTree per-directory entry backstop', () => {
+    it('prunes a non-blacklisted directory with > MAX_DIR_ENTRIES entries', () => {
+      const clean = mkdtempSync(join(tmpdir(), 'molio-prune-huge-'));
+      try {
+        mkdirSync(join(clean, 'dump'));
+        // One over the cap, all supported so without the backstop they'd all become nodes.
+        for (let i = 0; i <= MAX_DIR_ENTRIES; i++) {
+          writeFileSync(join(clean, 'dump', `f${i}.md`), 'x');
+        }
+        const tree = scanTree(clean);
+        const dump = tree.find((n) => n.name === 'dump');
+        assert.ok(dump, 'dump dir node should still exist (pruned, not hidden)');
+        // Pruned → empty children, NOT MAX_DIR_ENTRIES+1 stat'd file nodes.
+        assert.equal(dump!.children?.length, 0);
+      } finally {
+        rmSync(clean, { recursive: true, force: true });
+      }
+    });
+
+    it('countFiles skips the oversized subtree entirely', () => {
+      const clean = mkdtempSync(join(tmpdir(), 'molio-prune-count-'));
+      try {
+        writeFileSync(join(clean, 'real.md'), 'r');
+        mkdirSync(join(clean, 'dump'));
+        for (let i = 0; i <= MAX_DIR_ENTRIES; i++) {
+          writeFileSync(join(clean, 'dump', `f${i}.md`), 'x');
+        }
+        // Only real.md counts — the dump subtree is pruned, not counted.
+        assert.equal(countFiles(clean), 1);
+      } finally {
+        rmSync(clean, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('scanTree total-file cap (MAX_TOTAL)', () => {
+    it('truncates once the injected maxTotal is exceeded and stops descending', () => {
+      const clean = mkdtempSync(join(tmpdir(), 'molio-prune-total-'));
+      try {
+        // Two dirs, 3 supported files each = 6 total; cap at 2.
+        mkdirSync(join(clean, 'a'), { recursive: true });
+        mkdirSync(join(clean, 'b'), { recursive: true });
+        for (const d of ['a', 'b']) {
+          for (let i = 0; i < 3; i++) {
+            writeFileSync(join(clean, d, `f${i}.md`), 'x');
+          }
+        }
+        const tree = scanTree(clean, '', { maxTotal: 2 });
+        // The scan stops once 2 files are visited, so far fewer than 6 appear.
+        const files = tree.flatMap((n) => n.children ?? []).filter((n) => n.type === 'file');
+        assert.ok(files.length < 6, `expected truncation before 6, got ${files.length}`);
+        assert.ok(files.length >= 1, `expected at least 1 file, got ${files.length}`);
+      } finally {
+        rmSync(clean, { recursive: true, force: true });
+      }
+    });
+
+    it('does not false-trigger at small scales under default caps', () => {
+      const clean = mkdtempSync(join(tmpdir(), 'molio-prune-default-'));
+      try {
+        mkdirSync(join(clean, 'notes'), { recursive: true });
+        for (let i = 0; i < 20; i++) writeFileSync(join(clean, 'notes', `n${i}.md`), 'x');
+        // Defaults (MAX_DIR_ENTRIES=1000, MAX_TOTAL=50000) must not prune 20 files.
+        assert.equal(countFiles(clean), 20);
+      } finally {
+        rmSync(clean, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('constants sanity', () => {
+    it('MAX_DIR_ENTRIES is below the ~10k FD-exhaustion ceiling', () => {
+      assert.ok(MAX_DIR_ENTRIES < 5000, `MAX_DIR_ENTRIES too high: ${MAX_DIR_ENTRIES}`);
+    });
+    it('MAX_TOTAL is set and generous', () => {
+      assert.ok(MAX_TOTAL >= 10000 && MAX_TOTAL <= 100000);
     });
   });
 });

--- a/apps/daemon/test/core/vault-watcher.test.ts
+++ b/apps/daemon/test/core/vault-watcher.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import type Database from 'better-sqlite3';
 import { openDatabase, closeDatabase, createVault } from '../../src/core/db.js';
 import { VaultWatcher, VAULT_TREE_CHANGED_EVENT } from '../../src/core/vault-watcher.js';
+import { MAX_DIR_ENTRIES } from '../../src/core/knowledge.js';
 
 /**
  * VaultWatcher integration tests (CLAUDE.md: state-machine/lifecycle services
@@ -122,6 +123,47 @@ describe('VaultWatcher', () => {
     await settle(1500);
     watcher.off(VAULT_TREE_CHANGED_EVENT, onEmit);
     assert.equal(emitted, false);
+  });
+
+  it('ignores node_modules changes (the FD-exhaustion root cause)', async () => {
+    let emitted = false;
+    const onEmit = () => { emitted = true; };
+    watcher.on(VAULT_TREE_CHANGED_EVENT, onEmit);
+
+    mkdirSync(join(vaultDir, 'node_modules', 'some-pkg'), { recursive: true });
+    writeFileSync(join(vaultDir, 'node_modules', 'some-pkg', 'index.js'), 'module.exports = 1');
+    writeFileSync(join(vaultDir, 'node_modules', 'added-later.js'), 'x');
+
+    await settle(1500);
+    watcher.off(VAULT_TREE_CHANGED_EVENT, onEmit);
+    assert.equal(emitted, false, 'node_modules writes must not trigger tree-changed');
+  });
+
+  it('per-dir backstop: a non-blacklisted oversized dir does not hang the watcher', async () => {
+    // Drop a directory with far more entries than MAX_DIR_ENTRIES that is NOT in
+    // the prune list. The watcher's per-dir child counter must ignore the
+    // overflow rather than trying to track thousands of paths.
+    mkdirSync(join(vaultDir, 'dump'), { recursive: true });
+    // A few hundred past the cap — enough to exercise the overflow path on every
+    // platform without making the test itself slow.
+    const overBy = 300;
+    for (let i = 0; i < MAX_DIR_ENTRIES + overBy; i++) {
+      writeFileSync(join(vaultDir, 'dump', `f${i}.md`), 'x');
+    }
+
+    // Re-watch with the oversized dir present. watch() must still resolve
+    // promptly — the backstop prunes the overflow instead of tracking every file.
+    const ready = watcher.watch(vaultId, vaultDir);
+    const settled = await Promise.race([
+      ready.then(() => true),
+      new Promise<boolean>((r) => setTimeout(() => r(false), 5000)),
+    ]);
+    assert.equal(settled, true, 'watch() should resolve within 5s even with an oversized dir');
+
+    // A normal knowledge file outside the dump still emits tree-changed.
+    const got = waitForTreeChanged(watcher, vaultId, 5000);
+    writeFileSync(join(vaultDir, 'outside.md'), 'x');
+    assert.equal(await got, true);
   });
 
   it('stop() tears down: no further emits after stop', async () => {


### PR DESCRIPTION
## 问题

PR #131 合入后，本地启动报「未选择代理」。

### 根因（lsof 实证）

`VaultWatcher` 的 chokidar `ignored` 只排除点号目录，**未排除 `node_modules`**。wiki vault 内 remotion 项目的 `node_modules`（~10k 文件）被全量打开未关闭：

```
daemon PID 9993 FDs:
  9980r REG  ...wiki-vault/robot-companion-video/node_modules/...
  9981r REG  ...wiki-vault/robot-companion-video/node_modules/...
```

→ macOS `posix_spawn` EBADF → `probeVersion` 失败 → claude `available:false` → App.tsx 在默认 agent 不可用时直接 `return` → `selectedAgent` 为 null → UI「未选择代理」。

## 原 hotfix 的问题

commit `614f555` 用静态黑名单 + App.tsx fallback 临时止血，但本质脆弱：

1. **黑名单永远枚举不全** — 下一个 skill 或用户随手丢进来的任意大文件夹都会再次卡死
2. **App.tsx fallback 违反用户偏好规则** — CLAUDE.md 明确规定「默认值不可用时保持未选择 + 告知」，静默切换到其他 agent 违反第 2 条

## 架构加固

重写为机制性防御：**无论 vault 里塞了什么大目录都不会 FD 爆 / event-loop 卡**。

### 1. 共享剪枝谓词（消灭分叉）

新增无依赖模块 `vault-prune.ts`：

```ts
export const PRUNE_DIR_NAMES = new Set([
  'node_modules', 'bower_components', 'jspm_packages',
  '.git', '.svn', '.hg',
  'dist', 'build', 'out', '.next', '.nuxt', '.turbo',
  '.parcel-cache', 'coverage', '.cache',
  '__pycache__', '.pytest_cache', '.mypy_cache', '.ruff_cache',
  'venv', '.venv', 'env',
  'target', '.gradle',
]);

export function isPrunedDirName(name: string): boolean {
  return (name.startsWith('.') && name !== '.') || PRUNE_DIR_NAMES.has(name);
}
```

`scanTree` / `countFiles` / `findFileByStem` / `searchFiles` / `walkWiki` 与 `VaultWatcher` 的 chokidar `ignored` 共用同一谓词。**新 artifact 目录只需加一处**。

无依赖模块是关键：避免 `VaultWatcher` 传递性加载 `encoding.ts`，否则 `file-cap` 测试的 size-cap env var 在 `encoding` 首次加载时被缓存为默认值（顺序依赖的测试隔离 bug）。

### 2. 数量 backstop（硬上限）

两道独立硬上限，挡住「按名没命中、但确实巨大」的目录：

- **单目录条目** `MAX_DIR_ENTRIES = 1000`：`readdirSync` 一次拿到 `Dirent[]`，超阈值整树剪枝（不逐文件 `stat`），单次 `readdir` syscall 不卡 event loop
- **整次 scan** `MAX_TOTAL = 50000`：递归传 `{ visited, stopped }` 计数器，超阈值停止下钻
- **watcher per-dir 计数**：`ignored` 闭包维护 `Map<parentDir, count>`，超阈值 ignore 后续 child，vault root 永不剪

### 3. remotion skill 对齐 docling

scaffold 改 `.molio/remotion/`，version `1.0.2→1.0.3` 触发 `skill-installer` 重装到已有 vault：

```bash
mkdir -p .molio/remotion && cd .molio/remotion
npx create-video@latest --yes --blank --no-tailwind <project-name>
```

`node_modules`/`dist`/`out` 不再进入被监听/扫描的知识树（`.molio` 点号前缀自动跳过）。

### 4. 回退 App.tsx P1 fallback

删除静默 fallthrough，恢复原始行为（默认 agent 不可用时 `return`，`selectedAgent` 保持 null）。FD leak 架构性消除后 claude 恢复 `available:true`，命中用户偏好规则第 1 条（用户的选择可用 → 始终用），claude 正常选中。

## 关键改动

| 文件 | 改动 |
|---|---|
| `apps/daemon/src/core/vault-prune.ts`（新增） | 共享谓词 + 硬上限常量 |
| `apps/daemon/src/core/knowledge.ts` | `scanTree`/`countFiles`/`findFileByStem`/`searchFiles` 改用共享谓词 + backstop；re-export 谓词 |
| `apps/daemon/src/core/wiki-status.ts` | `walkWiki` 改用共享谓词 + backstop |
| `apps/daemon/src/core/vault-watcher.ts` | 删本地 `NEVER_WATCH`，`ignored` 用共享谓词 + per-dir 计数 backstop |
| `apps/web/src/App.tsx` | 无改动（App.tsx 已回退到 main 状态） |
| `apps/daemon/src/tools/skills/remotion/SKILL.md` | scaffold 改 `.molio/remotion/`，version bump |
| `apps/daemon/test/core/knowledge.test.ts` | 14 个新增剪枝/backstop 测试 |
| `apps/daemon/test/core/vault-watcher.test.ts` | node_modules 不 emit + per-dir 计数不阻塞 |

## 验证

```
✅ pnpm build
✅ pnpm typecheck (daemon + web)
✅ pnpm test — 632 tests, 0 fail（含 14 个新增剪枝/backstop 用例）
✅ GET /api/agents → claude available:true, probeError:null（原 bug 症状消失）
✅ skill-installer 在 dev 启动时把 remotion v1.0.3 重装到所有已有 vault
```

### FD 实测（对应根因）

```bash
# 启动 daemon（wiki vault 含 remotion 项目）
pnpm dev

# 检查 FD 数（macOS）
lsof -p <daemon-pid> | wc -l
# 预期：几十量级（修复前 ~10k）
```

### 大目录实测（验证 backstop）

```bash
# 往 vault 丢一个 5 万文件的假目录（非黑名单名）
mkdir vault/dump
for i in {1..50000}; do echo "x" > "vault/dump/f${i}.md"; done

# 请求 /tree
curl http://localhost:3100/api/knowledge/vaults/<id>/tree

# 预期：瞬时返回（不卡 event loop），daemon 日志有剪枝 warn
```

## 过程中发现并修掉的 bug

1. **`scanTree` 递归剪枝返回自引用节点** — 原逻辑对超大目录返回 `[{ name: 'dump', path: 'dump', children: [...] }]`（目录自身当 child），改成返回 `[]`（父级仍创建空目录节点）

2. **`VaultWatcher` 传递性加载 `encoding.ts`** — 导致 `file-cap` 测试的 size-cap env var 在 `encoding` 首次加载时被缓存为默认值（顺序依赖的测试隔离 bug）。抽出无依赖的 `vault-prune.ts` 修复

## 不做（明确排除）

- **scanTree 异步化** — 剪枝 + backstop 后同步 walk 工作量已 O(知识文件)，异步化会逼改 4 个 route 签名 + 测试，过度工程
- **manifest-based 项目检测 + `.molio/include` 逃生口** — 改「哪些文件算知识」语义，有误伤项目内知识文档的风险，留作后续增强 PR
- **Tree 内存缓存** — 剪枝 + backstop 落地后单次 walk 已是十毫秒级，会话内重算不疼，缓存的边际收益不抵失效逻辑 + 测试成本
- **gitignore 自适配** — 按名剪枝 + backstop 已覆盖已知场景；加 `ignore` 依赖与嵌套加载属额外复杂度，暂缓

## 历史

替代已关闭的 #160（原分支有 merge commit，rebase 到 main 后重开此 PR）。