### PR TITLE
feat(kb): 直接拖拽文件进入知识库 + CSV/TSV 支持 + 导入后定位

### DIFF
--- a/apps/daemon/src/core/knowledge.ts
+++ b/apps/daemon/src/core/knowledge.ts
@@ -440,7 +440,7 @@ function isSupportedFile(name: string): boolean {
 }
 
 /** Text file extensions — content read as UTF-8 */
-export const TEXT_EXTS = ['.md', '.txt', '.html', '.htm', '.json', '.yaml', '.yml'];
+export const TEXT_EXTS = ['.md', '.txt', '.html', '.htm', '.json', '.yaml', '.yml', '.csv', '.tsv'];
 
 /** Image file extensions — displayed inline via <img> */
 export const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico'];
@@ -606,6 +606,8 @@ const MIME_TYPES: Record<string, string> = {
   '.json': 'application/json',
   '.yaml': 'text/yaml',
   '.yml': 'text/yaml',
+  '.csv': 'text/csv',
+  '.tsv': 'text/tab-separated-values',
   // Images
   '.png': 'image/png',
   '.jpg': 'image/jpeg',

--- a/apps/daemon/test/core/knowledge.test.ts
+++ b/apps/daemon/test/core/knowledge.test.ts
@@ -286,6 +286,21 @@ describe('knowledge filesystem operations', () => {
       }
     });
 
+    it('should include CSV and TSV files (tabular text data)', () => {
+      const cleanVault = mkdtempSync(join(tmpdir(), 'molio-csv-'));
+      try {
+        writeFileSync(join(cleanVault, 'data.csv'), 'a,b,c\n1,2,3');
+        writeFileSync(join(cleanVault, 'data.tsv'), 'a\tb\tc\n1\t2\t3');
+        writeFileSync(join(cleanVault, 'notes.md'), 'ok');
+
+        const tree = scanTree(cleanVault);
+        const names = tree.map((n) => n.name).sort();
+        assert.deepEqual(names, ['data.csv', 'data.tsv', 'notes.md']);
+      } finally {
+        rmSync(cleanVault, { recursive: true, force: true });
+      }
+    });
+
     it('should return empty array for empty vault', () => {
       const cleanVault = mkdtempSync(join(tmpdir(), 'molio-empty-'));
       try {
@@ -332,6 +347,18 @@ describe('knowledge filesystem operations', () => {
       writeFile(vaultPath, 'config.yaml', 'key: val');
       const file = readFile(vaultPath, 'config.yaml');
       assert.equal(file.mimeType, 'text/yaml');
+    });
+
+    it('should detect CSV MIME type', () => {
+      writeFile(vaultPath, 'table.csv', 'a,b,c\n1,2,3');
+      const file = readFile(vaultPath, 'table.csv');
+      assert.equal(file.mimeType, 'text/csv');
+    });
+
+    it('should detect TSV MIME type', () => {
+      writeFile(vaultPath, 'table.tsv', 'a\tb\tc\n1\t2\t3');
+      const file = readFile(vaultPath, 'table.tsv');
+      assert.equal(file.mimeType, 'text/tab-separated-values');
     });
   });
 

--- a/apps/daemon/test/routes/knowledge-import.test.ts
+++ b/apps/daemon/test/routes/knowledge-import.test.ts
@@ -144,6 +144,26 @@ describe('Knowledge routes — file import', () => {
     assert.equal(errors[0]!.reason, 'unsupported_format');
   });
 
+  it('accepts CSV and TSV as text imports', async () => {
+    const fd = makeFormData({
+      files: [
+        makeFile('table.csv', 'a,b,c\n1,2,3'),
+        makeFile('data.tsv', 'a\tb\tc\n1\t2\t3'),
+      ],
+    });
+    const req = new Request(`http://localhost/api/knowledge/vaults/${vaultId}/import`, {
+      method: 'POST',
+      body: fd,
+    });
+    const res = await app.request(req);
+    assert.equal(res.status, 200);
+    const data = await json(res);
+    const imported = (data['imported'] as string[]).sort();
+    assert.deepEqual(imported, ['data.tsv', 'table.csv']);
+    const errors = data['errors'] as Array<{ file: string; reason: string }>;
+    assert.equal(errors.length, 0);
+  });
+
   // ─── size guard ───
 
   it('returns 413 when Content-Length exceeds 50MB', async () => {

--- a/apps/web/src/components/kb/KbFilePanel.tsx
+++ b/apps/web/src/components/kb/KbFilePanel.tsx
@@ -38,6 +38,13 @@ interface KbFilePanelProps {
   onImportFiles?: (files: File[], targetDir: string) => void;
   /** Called when a file is dragged from one directory to another within the tree. */
   onMoveFile?: (srcPath: string, destDir: string) => void;
+  /**
+   * Parent-triggered locate request — expand the file's ancestor directories
+   * and scroll it into view. Bumping `token` re-triggers even for the same
+   * path (e.g. a second import of the same filename after rename). Used by
+   * the import flow to scroll the just-imported file into view.
+   */
+  locateRequest?: { path: string; token: number } | null;
   children?: ReactNode;
 }
 
@@ -59,6 +66,7 @@ export function KbFilePanel({
   onRenameCancel,
   onImportFiles,
   onMoveFile,
+  locateRequest,
   children,
 }: KbFilePanelProps) {
   const { t } = useI18n();
@@ -75,6 +83,10 @@ export function KbFilePanel({
   // Bumped each time the user hits "locate" — KbFileTree scrolls the active
   // file into view when this token changes (see TreeNodeItem effect).
   const [revealToken, setRevealToken] = useState(0);
+  // Path of the file the parent asked to scroll into view without selecting
+  // (e.g. just-imported file). Paired with revealToken — KbFileTree scrolls
+  // the matching item whenever the token bumps.
+  const [revealPath, setRevealPath] = useState<string | null>(null);
 
   // Drag-over state for external file import
   const [dragOver, setDragOver] = useState<{
@@ -100,21 +112,35 @@ export function KbFilePanel({
     [sortedTree],
   );
 
-  // Locate the currently selected file in the tree: expand every ancestor
-  // directory so the file item is rendered, then bump the reveal token so the
-  // item scrolls itself into view.
-  const locateFile = useCallback(() => {
-    if (!selectedFile) return;
+  // Expand every ancestor directory of `path` so the file item is rendered,
+  // then bump the reveal token + set revealPath so TreeNodeItem scrolls it
+  // into view. Called by the "locate" toolbar button (uses `selectedFile`)
+  // and by the `locateRequest` effect (uses an explicit path, e.g. a
+  // just-imported file that isn't selected yet).
+  const locateFile = useCallback((path?: string) => {
+    const target = path ?? selectedFile;
+    if (!target) return;
     setExpandedPaths((prev) => {
       const next = new Set(prev);
-      const parts = selectedFile.split('/');
+      const parts = target.split('/');
       for (let i = 1; i < parts.length; i++) {
         next.add(parts.slice(0, i).join('/'));
       }
       return next;
     });
+    setRevealPath(target);
     setRevealToken((n) => n + 1);
   }, [selectedFile]);
+
+  // Handle parent-triggered locate requests (e.g. after import). Dedup by
+  // token so the same request doesn't fire twice in StrictMode.
+  const lastLocateTokenRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!locateRequest) return;
+    if (locateRequest.token === lastLocateTokenRef.current) return;
+    lastLocateTokenRef.current = locateRequest.token;
+    locateFile(locateRequest.path);
+  }, [locateRequest, locateFile]);
 
   // ── External drag-and-drop handlers ──
 
@@ -162,30 +188,16 @@ export function KbFilePanel({
       el.classList.remove('drag-target');
     });
 
-    // Check for folders — if any item in the file list is a directory, reject
     const { files } = e.dataTransfer;
     if (files.length === 0) return;
 
-    // Determine target directory from drop position
-    // The KbFileTree directory nodes set a data attribute during dragOver
-    // We extract it from the event target
+    // Directory nodes annotate themselves with `data-drop-dir` so the drop
+    // handler can read the target directory from the closest ancestor.
     let targetDir = '';
     const target = e.target as HTMLElement;
     const dirEl = target.closest('[data-drop-dir]');
     if (dirEl) {
       targetDir = dirEl.getAttribute('data-drop-dir') ?? '';
-    }
-
-    // Reject folders (browser can't distinguish — check for empty type)
-    for (let i = 0; i < files.length; i++) {
-      if (files[i].type === '' && files[i].name.indexOf('.') === -1) {
-        // Likely a folder or file without extension — use size as heuristic:
-        // folders dragged in have size 0 or very small
-        // Actually, the browser gives us File objects for files only.
-        // Folders from the OS are NOT included in dataTransfer.files.
-        // So this check is moot — the browser already filters. Keep as safety.
-        break;
-      }
     }
 
     onImportFiles?.(Array.from(files), targetDir);
@@ -267,7 +279,7 @@ export function KbFilePanel({
         <button
           type="button"
           title={selectedFile ? t('kb.locateFile') : t('kb.locateFileNeedFile')}
-          onClick={locateFile}
+          onClick={() => locateFile()}
           disabled={!selectedFile}
           data-testid="kb-btn-locate"
         >
@@ -372,6 +384,7 @@ export function KbFilePanel({
           searchQuery={searchQuery}
           expandedPaths={expandedPaths}
           revealToken={revealToken}
+          revealPath={revealPath}
           onTogglePath={togglePath}
           onSelectFile={onSelectFile}
           onAddToWiki={onAddToWiki}

--- a/apps/web/src/components/kb/KbFileTree.tsx
+++ b/apps/web/src/components/kb/KbFileTree.tsx
@@ -29,6 +29,14 @@ interface KbFileTreeProps {
    * active.
    */
   revealToken?: number;
+  /**
+   * Path of a file the parent wants to scroll into view WITHOUT selecting it
+   * (e.g. a just-imported file). Paired with `revealToken` — when the token
+   * bumps and this matches a tree item's path, that item scrolls into view
+   * even if it isn't the active file. Lets the import flow reveal the new
+   * file without forcing a tab switch or discard-prompt on the user.
+   */
+  revealPath?: string | null;
   onTogglePath: (path: string) => void;
   onSelectFile: (path: string) => void;
   onAddToWiki?: (path: string, isDirectory: boolean) => void;
@@ -53,6 +61,7 @@ export function KbFileTree({
   searchQuery,
   expandedPaths,
   revealToken,
+  revealPath,
   onTogglePath,
   onSelectFile,
   onAddToWiki,
@@ -86,6 +95,7 @@ export function KbFileTree({
           searchQuery={searchQuery}
           expandedPaths={expandedPaths}
           revealToken={revealToken}
+          revealPath={revealPath}
           onTogglePath={onTogglePath}
           onSelectFile={onSelectFile}
           onAddToWiki={onAddToWiki}
@@ -110,6 +120,7 @@ interface TreeNodeItemProps {
   searchQuery: string;
   expandedPaths: Set<string>;
   revealToken?: number;
+  revealPath?: string | null;
   onTogglePath: (path: string) => void;
   onSelectFile: (path: string) => void;
   onAddToWiki?: (path: string, isDirectory: boolean) => void;
@@ -128,6 +139,7 @@ function TreeNodeItem({
   searchQuery,
   expandedPaths,
   revealToken,
+  revealPath,
   onTogglePath,
   onSelectFile,
   onAddToWiki,
@@ -271,6 +283,7 @@ function TreeNodeItem({
               searchQuery={searchQuery}
               expandedPaths={expandedPaths}
               revealToken={revealToken}
+              revealPath={revealPath}
               onTogglePath={onTogglePath}
               onSelectFile={onSelectFile}
               onAddToWiki={onAddToWiki}
@@ -323,6 +336,15 @@ function TreeNodeItem({
     if (!isActive) return;
     itemRef.current?.scrollIntoView({ block: 'nearest' });
   }, [isActive, revealToken]);
+
+  // Parent-triggered reveal for a non-active file (e.g. just-imported file
+  // that isn't selected yet — we don't want to force a tab switch / discard
+  // prompt, just visually scroll it into view). Fires when revealToken bumps
+  // AND this item's path matches `revealPath`.
+  useEffect(() => {
+    if (!revealPath || revealPath !== node.path) return;
+    itemRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [revealPath, revealToken, node.path]);
 
   const handleFileContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -159,6 +159,11 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
   // Pending import files for conflict retry (replaces fragile `as any` function-property hack)
   const pendingImportRef = useRef<{ files: File[]; targetDir: string; oversizedCount: number } | null>(null);
 
+  // Locate-request signal to KbFilePanel: after a successful import, set this
+  // to expand the imported file's ancestors and scroll it into view. Token
+  // dedup is handled inside KbFilePanel.
+  const [importedLocateRequest, setImportedLocateRequest] = useState<{ path: string; token: number } | null>(null);
+
   const handleOpenQa = useCallback(() => {
     if (!kb.selectedFile) return;
     setQaSelectedText(null);
@@ -821,6 +826,15 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
       // Refresh tree
       await kb.refreshTree();
 
+      // Reveal the first imported file in the tree (expand ancestors + scroll
+      // into view) so the user sees the result of the drop without having to
+      // manually hunt for it. Renamed-takes-precedence: if every file was
+      // renamed due to conflicts, scroll to the renamed path instead.
+      const firstImported = result.imported[0] ?? result.renamed[0]?.to;
+      if (firstImported) {
+        setImportedLocateRequest({ path: firstImported, token: Date.now() });
+      }
+
       // Show result toast
       const imported = result.imported.length;
       const renamed = result.renamed.length;
@@ -850,6 +864,12 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
     try {
       const result = await api.importFiles(kb.activeVault.id, Array.from(files), targetDir ?? '', strategy);
       await kb.refreshTree();
+
+      // Reveal the first imported/renamed file in the tree.
+      const firstImported = result.imported[0] ?? result.renamed[0]?.to;
+      if (firstImported) {
+        setImportedLocateRequest({ path: firstImported, token: Date.now() });
+      }
 
       const imported = result.imported.length;
       const renamed = result.renamed.length;
@@ -909,6 +929,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
         onRenameCancel={handleRenameCancel}
         onImportFiles={handleImportFiles}
         onMoveFile={handleMoveFile}
+        locateRequest={importedLocateRequest}
       >
         <div className="kb-resize-handle" onMouseDown={handleResizeStart} />
       </KbFilePanel>

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2409,14 +2409,15 @@
 
 .kb-save-toast {
   position: fixed;
-  bottom: 24px;
-  right: 24px;
-  padding: 8px 16px;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 12px 24px;
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  font-size: 13px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  font-size: 14px;
   color: var(--text);
   z-index: 400;
   animation: kb-toast-in 200ms ease;

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2424,8 +2424,8 @@
 }
 
 @keyframes kb-toast-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
 
 /* ── Drag-and-drop import ── */


### PR DESCRIPTION
## Summary

- 修复 Electron 客户端无法从资源管理器拖拽文件进知识库的问题。诊断发现 Electron 在 `http://` origin 下 `dataTransfer.files` 的 `File.path` 被剥离但字节可读，原 multipart 导入路径在桌面端能直接工作，无需 `will-navigate` / IPC 绕路
- 导入成功后自动展开祖先目录并滚动到新文件（不强制开 tab、不弹 discard 框，避免多文件导入刷 tab 和打断编辑流）
- daemon `TEXT_EXTS` 增加 `.csv` / `.tsv`，补齐 `MIME_TYPES` 对应条目
- `.kb-save-toast` 从右下角移到底部居中、加大 padding/字号/阴影，让提示更显眼
- 清理 `KbFilePanel.handleDrop` 里一段自承认 moot 的 "Reject folders" 死循环

## Changes

- `apps/web/src/components/kb/KnowledgeBasePage.tsx` — 导入成功后 set `importedLocateRequest`，传给 `KbFilePanel`
- `apps/web/src/components/kb/KbFilePanel.tsx` — `locateFile` 支持可选 path，新增 `locateRequest` prop + token 去重 effect，删除死代码
- `apps/web/src/components/kb/KbFileTree.tsx` — `TreeNodeItem` 接收 `revealPath`，`scrollIntoView({ block: 'nearest' })`
- `apps/daemon/src/core/knowledge.ts` — `TEXT_EXTS` / `MIME_TYPES` 增加 CSV/TSV
- `apps/web/src/styles/knowledge.css` — toast 样式调整
- `apps/desktop/src/main.js`, `apps/desktop/src/preload.cjs` — 清理前几轮 will-navigate/IPC 诊断残留（无功能影响）
- `apps/web/src/main.tsx`, `apps/web/src/api/client.ts` — 配合类型调整

## Test Plan

- [ ] daemon 测试：`pnpm --filter @molio/daemon test`，新增 CSV/TSV 扫描、MIME 检测、CSV/TSV 导入三个用例
- [ ] 桌面端：从 Windows 资源管理器拖 `.md` / `.csv` / `.tsv` / `.pdf` / `.docx` 进 KB，确认导入成功
- [ ] 导入后自动定位：展开目录 + 滚动到第一个导入文件，不强制开 tab
- [ ] toast 显眼性：导入成功后底部居中弹出
- [ ] 浏览器端拖拽回归不受影响