### PR TITLE
fix(web,daemon): SSE watchdog 重连同一 run，修复长空闲后对话无响应

### DIFF
--- a/apps/daemon/src/core/RunManager.ts
+++ b/apps/daemon/src/core/RunManager.ts
@@ -21,6 +21,7 @@ import { loadConfig, getAgentConfig, buildAgentEnv } from './config.js';
 import { buildTranscript, type TranscriptMessage } from './transcript.js';
 import type { RunState, BufferedEvent } from '../types.js';
 import { TurnTextCollector } from './turn-text-collector.js';
+import { dbgLog } from './debug-log.js';
 
 const TERMINAL_STATUSES = new Set<RunStatus>(['succeeded', 'failed', 'canceled']);
 const MAX_EVENTS = 2_000;
@@ -183,7 +184,11 @@ export class RunManager {
     const run = this.runs.get(runId);
     if (!run) return null;
     run.eventListeners.add(callback);
-    return () => { run.eventListeners.delete(callback); };
+    dbgLog(`subscribe runId=${runId} listeners=${run.eventListeners.size}`);
+    return () => {
+      run.eventListeners.delete(callback);
+      dbgLog(`unsubscribe runId=${runId} listeners=${run.eventListeners.size}`);
+    };
   }
 
   /**
@@ -867,6 +872,14 @@ export class RunManager {
     this.ensureLogStream(run)?.write(JSON.stringify(record) + '\n');
 
     // Fan out to listeners
+    const listeners = run.eventListeners.size;
+    if (listeners === 0) {
+      // Diagnostic: an event was emitted but no SSE stream is subscribed. If this
+      // happens mid-run (not terminal cleanup), it's the smoking gun for assumption 3
+      // — the SSE listener was cleaned up (e.g. spurious abort) while the run is still
+      // active, so the frontend never receives this event.
+      dbgLog(`emit listeners=0 (NO SSE SUBSCRIBER) runId=${run.id} type=${event.type} status=${run.status}`);
+    }
     for (const listener of run.eventListeners) {
       try { listener(event); } catch { /* listener error, skip */ }
     }

--- a/apps/daemon/src/core/debug-log.ts
+++ b/apps/daemon/src/core/debug-log.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * Shared diagnostic logger for SSE / RunManager reliability investigation.
+ *
+ * Writes to ~/.molio/debug/sse-debug.log AND stdout. The file is the reliable
+ * channel in packaged desktop mode (daemon stdout may be swallowed by the
+ * Electron parent); stdout is for dev (tsx watch) where it's visible.
+ *
+ * Call only on low-frequency points (stream start/cancel, ping enqueue
+ * failure, subscribe/unsubscribe, listeners=0) — never per-event.
+ */
+const DEBUG_LOG_PATH = path.join(os.homedir(), '.molio', 'debug', 'sse-debug.log');
+
+export function dbgLog(msg: string): void {
+  const line = `${new Date().toISOString()} ${msg}\n`;
+  try {
+    fs.mkdirSync(path.dirname(DEBUG_LOG_PATH), { recursive: true });
+    fs.appendFileSync(DEBUG_LOG_PATH, line, { flag: 'a' });
+  } catch { /* best-effort */ }
+  console.warn('[sse-daemon] ' + msg);
+}

--- a/apps/daemon/src/routes/events.ts
+++ b/apps/daemon/src/routes/events.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { stream } from 'hono/streaming';
 import type { RunManager } from '../core/RunManager.js';
 import { createSSEStream } from '../sse.js';
+import { dbgLog } from '../core/debug-log.js';
 
 export function eventsRoutes(runManager: RunManager): Hono {
   const app = new Hono();
@@ -16,7 +17,7 @@ export function eventsRoutes(runManager: RunManager): Hono {
       }, 404);
     }
 
-    // Get last event ID for replay: query param `after` or Last-Event-ID header
+    // Get last event id for replay: query param `after` or Last-Event-ID header
     const afterParam = c.req.query('after');
     const lastEventIdHeader = c.req.header('Last-Event-ID');
     const afterId = Number(afterParam || lastEventIdHeader || 0);
@@ -25,11 +26,33 @@ export function eventsRoutes(runManager: RunManager): Hono {
     c.header('Cache-Control', 'no-cache');
     c.header('Connection', 'keep-alive');
 
+    // SSE is a long-lived connection. Disable Node's per-socket timeout for this
+    // response so the server never aborts a healthy idle stream. @hono/node-server
+    // exposes the Node IncomingMessage via c.env.incoming. (Node 24 defaults:
+    // server.timeout=0 already, but requestTimeout=300s / headersTimeout=60s could
+    // bite SSE under future configs — set explicitly as a safety net. The real
+    // ~11.5min abort was traced to the client/Chromium side, not here, but this
+    // removes the server as a suspect and is cheap.)
+    const incoming = (c.env as any)?.incoming as import('node:http').IncomingMessage | undefined;
+    const sock = incoming?.socket;
+    // setTimeout(0) disables Node's per-socket idle timeout so the server never
+    // aborts a healthy idle SSE stream. TCP keepalive left at OS defaults — too
+    // slow to matter here; the client-side watchdog is the real recovery mechanism.
+    sock?.setTimeout?.(0);
+
     return stream(c, async (s) => {
       const { stream: sseStream, cleanup } = createSSEStream(runManager, runId, afterId);
 
-      // Cleanup on client disconnect
-      c.req.raw.signal.addEventListener('abort', cleanup);
+      // On client disconnect (or any abort of the request signal), clean up the
+      // SSE subscription so emit events don't fan out to a dead listener. Log the
+      // abort + socket state to help locate which layer kills the long connection.
+      c.req.raw.signal.addEventListener('abort', () => {
+        dbgLog(
+          `abort runId=${runId} socket.destroyed=${sock?.destroyed} ` +
+          `remote=${sock?.remoteAddress}:${sock?.remotePort}`,
+        );
+        cleanup();
+      });
 
       // Pipe the SSE stream to the response
       await s.pipe(sseStream);

--- a/apps/daemon/src/sse.ts
+++ b/apps/daemon/src/sse.ts
@@ -1,6 +1,19 @@
 import type { AgentEvent } from '@molio/contracts';
 import type { RunManager } from './core/RunManager.js';
 import type { BufferedEvent } from './types.js';
+import { dbgLog } from './core/debug-log.js';
+
+/**
+ * Fault-injection switch (env, default off): after N successful enqueues to the
+ * SSE stream, start throwing on every subsequent enqueue. Because the existing
+ * enqueue call sites wrap in try/catch that swallows errors, this reproduces
+ * assumption 2 from the diagnosis ("daemon stream controller fails silently —
+ * ping and events stop reaching the client, but daemon thinks it's still
+ * sending"). Lets us verify in seconds whether this mechanism can produce the
+ * "backend turn_end recorded, frontend got nothing" symptom, without waiting
+ * 3h. Production never sets this.
+ */
+const DEBUG_BREAK_AFTER = Number(process.env.MOLIO_DEBUG_SSE_BREAK_AFTER) || 0;
 
 /**
  * Create a ReadableStream that emits SSE frames for a run's events.
@@ -15,9 +28,25 @@ export function createSSEStream(
   const encoder = new TextEncoder();
   let unsub: (() => void) | null = null;
   let pingInterval: ReturnType<typeof setInterval> | null = null;
+  let enqueueCount = 0;
+
+  // Wrap controller.enqueue so the fault-injection switch can simulate a dead
+  // stream mid-connection. Throwing here is caught by the call-site try/catch,
+  // mirroring how a real controller failure would be silently swallowed.
+  const safeEnqueue = (controller: ReadableStreamDefaultController<Uint8Array>, bytes: Uint8Array): boolean => {
+    enqueueCount++;
+    if (DEBUG_BREAK_AFTER > 0 && enqueueCount > DEBUG_BREAK_AFTER) {
+      // Silent fail — caller's try/catch swallows, exactly like the real bug class.
+      throw new Error(`DEBUG: SSE stream broken after ${DEBUG_BREAK_AFTER} enqueues (MOLIO_DEBUG_SSE_BREAK_AFTER)`);
+    }
+    controller.enqueue(bytes);
+    return true;
+  };
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
+      dbgLog(`stream start runId=${runId} after=${afterId} breakAfter=${DEBUG_BREAK_AFTER}`);
+
       // Phase 1: Replay buffered events with id > afterId
       const buffered = runManager.getBufferedEvents(runId, afterId);
       if (buffered) {
@@ -25,8 +54,9 @@ export function createSSEStream(
           const envelope = { seq: record.id, runId, event: record.data as AgentEvent };
           const frame = `id: ${record.id}\ndata: ${JSON.stringify(envelope)}\n\n`;
           try {
-            controller.enqueue(encoder.encode(frame));
+            safeEnqueue(controller, encoder.encode(frame));
           } catch {
+            dbgLog(`replay enqueue FAILED (broken stream) runId=${runId} seq=${record.id}`);
             return; // Stream closed during replay
           }
         }
@@ -34,6 +64,7 @@ export function createSSEStream(
 
       // Phase 2: If run is already terminal, close the stream
       if (runManager.isTerminal(runId)) {
+        dbgLog(`stream close (terminal) runId=${runId}`);
         try { controller.close(); } catch { /* already closed */ }
         return;
       }
@@ -44,8 +75,11 @@ export function createSSEStream(
         const envelope = { seq: lastId, runId, event };
         const frame = `id: ${lastId}\ndata: ${JSON.stringify(envelope)}\n\n`;
         try {
-          controller.enqueue(encoder.encode(frame));
+          safeEnqueue(controller, encoder.encode(frame));
         } catch {
+          // Diagnostic: emitEvent fan-out reached this listener but enqueue failed —
+          // the stream is dead. This is the smoking gun for assumption 2.
+          dbgLog(`live event enqueue FAILED (broken stream) runId=${runId} seq=${lastId} type=${event.type}`);
           // Stream may be closed
         }
       });
@@ -53,13 +87,16 @@ export function createSSEStream(
       // Keepalive ping every 15 seconds
       pingInterval = setInterval(() => {
         try {
-          controller.enqueue(encoder.encode(':ping\n\n'));
+          safeEnqueue(controller, encoder.encode(':ping\n\n'));
         } catch {
-          // Stream closed, cleanup will handle
+          // Diagnostic: ping can't go out either — confirms the stream is dead from
+          // the daemon side, not just a network issue.
+          dbgLog(`ping enqueue FAILED runId=${runId} enqueueCount=${enqueueCount}`);
         }
       }, 15_000);
     },
     cancel() {
+      dbgLog(`stream cancel runId=${runId}`);
       unsub?.();
       unsub = null;
       if (pingInterval) {
@@ -72,6 +109,7 @@ export function createSSEStream(
   return {
     stream,
     cleanup: () => {
+      dbgLog(`stream cleanup runId=${runId}`);
       unsub?.();
       unsub = null;
       if (pingInterval) {

--- a/apps/daemon/src/sse.ts
+++ b/apps/daemon/src/sse.ts
@@ -84,16 +84,23 @@ export function createSSEStream(
         }
       });
 
-      // Keepalive ping every 15 seconds
+      // Keepalive ping every 15 seconds. Sent as a `data:` frame (NOT an SSE
+      // comment line `:ping`) so the browser's EventSource onmessage fires — the
+      // frontend watchdog relies on receiving ping frames to tell "connection
+      // alive but idle" from "connection dead". No `id:` line → not buffered in
+      // run.events → replay won't flood the client with stale pings on reconnect.
+      // Test hook: MOLIO_TEST_SSE_PING_MS shortens the interval so unit tests can
+      // exercise the ping path without sleeping 15s. Production never sets it.
+      const pingMs = Number(process.env.MOLIO_TEST_SSE_PING_MS) || 15_000;
       pingInterval = setInterval(() => {
         try {
-          safeEnqueue(controller, encoder.encode(':ping\n\n'));
+          safeEnqueue(controller, encoder.encode('data: ping\n\n'));
         } catch {
           // Diagnostic: ping can't go out either — confirms the stream is dead from
           // the daemon side, not just a network issue.
           dbgLog(`ping enqueue FAILED runId=${runId} enqueueCount=${enqueueCount}`);
         }
-      }, 15_000);
+      }, pingMs);
     },
     cancel() {
       dbgLog(`stream cancel runId=${runId}`);

--- a/apps/daemon/test/routes/sse-watchdog.test.ts
+++ b/apps/daemon/test/routes/sse-watchdog.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSSEStream } from '../../src/sse.js';
+import type { RunManager } from '../../src/core/RunManager.js';
+import type { BufferedEvent } from '../../src/types.js';
+
+/**
+ * Tests for the SSE watchdog support layer:
+ *  - ping is emitted as a `data:` frame (NOT a `:ping` comment line) so the
+ *    browser's EventSource onmessage fires and the frontend watchdog can use
+ *    ping as a keepalive heartbeat. A regression to `:ping` would silently break
+ *    the watchdog (comment lines don't trigger onmessage), and the E2E suite
+ *    can't catch this because it mocks SSE with its own server — so this unit
+ *    test is the only guard.
+ *  - replay with ?after= (the watchdog reconnect path) returns only events
+ *    with id > afterId, so reconnecting to a live run recovers the missed tail.
+ */
+
+const PING_ENV = 'MOLIO_TEST_SSE_PING_MS';
+
+function makeMockRunManager(): RunManager {
+  return {
+    getBufferedEvents: (_runId: string, _afterId = 0): BufferedEvent[] | null => [],
+    isTerminal: (_runId: string): boolean => false,
+    onEvent: (_runId: string, _cb: (ev: any) => void): (() => void) | null => () => {},
+    getLastEventId: (_runId: string): number => 0,
+  } as unknown as RunManager;
+}
+
+describe('SSE watchdog support', () => {
+  describe('ping frame', () => {
+    it('emits ping as a `data:` frame, not a `:ping` comment line', async () => {
+      process.env[PING_ENV] = '5'; // 5ms ping so the test doesn't sleep 15s
+      try {
+        const { stream, cleanup } = createSSEStream(makeMockRunManager(), 'ping-run', 0);
+        const reader = stream.getReader();
+        try {
+          const { value } = await reader.read();
+          const frame = new TextDecoder().decode(value);
+          // Must be a `data:` frame so browser onmessage fires — the watchdog's heartbeat.
+          assert.ok(
+            frame.startsWith('data: ping\n'),
+            `expected ping data frame, got: ${JSON.stringify(frame)}`,
+          );
+          assert.ok(!frame.startsWith(':ping'), 'ping must NOT be a comment line (onmessage would not fire)');
+          // No `id:` line → not buffered → replay won't flood stale pings on reconnect.
+          assert.ok(!frame.includes('id:'), 'ping must not carry an id (would buffer it for replay)');
+        } finally {
+          cleanup();
+          await reader.cancel();
+        }
+      } finally {
+        delete process.env[PING_ENV];
+      }
+    });
+  });
+
+  describe('?after= replay (watchdog reconnect path)', () => {
+    it('replays only events with id > afterId so a reconnect recovers the missed tail', async () => {
+      const mock = {
+        ...makeMockRunManager(),
+        getBufferedEvents: (_runId: string, afterId = 0): BufferedEvent[] | null => [
+          { id: 10, event: 'text_delta', data: { type: 'text_delta', delta: 'old' }, timestamp: 1 },
+          { id: 11, event: 'text_delta', data: { type: 'text_delta', delta: 'missed' }, timestamp: 2 },
+        ].filter((e) => e.id > afterId),
+        isTerminal: () => true, // close immediately after replay so the test can drain
+      } as unknown as RunManager;
+
+      const { stream } = createSSEStream(mock, 'replay-run', 10);
+      const reader = stream.getReader();
+      const frames: string[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        frames.push(new TextDecoder().decode(value));
+      }
+      // Only id=11 should be replayed (afterId=10 filtered out id=10).
+      assert.equal(frames.length, 1);
+      assert.ok(frames[0]!.includes('id: 11'));
+      assert.ok(frames[0]!.includes('"delta":"missed"'));
+    });
+  });
+});

--- a/apps/web/e2e/chat-sse-watchdog.spec.ts
+++ b/apps/web/e2e/chat-sse-watchdog.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import { gotoHome, sendMessage } from './helpers/navigation';
+import http from 'node:http';
+
+/**
+ * @area chat
+ * @priority P0
+ *
+ * SSE watchdog reconnect (W3.5): the 11.5-min abort bug leaves EventSource at
+ * readyState=OPEN but silent — onerror/onDone never fire. The watchdog (45s,
+ * shortened via __MOLIO_TEST_WATCHDOG_MS__ here) detects "no frame for N ms"
+ * and reconnects to the SAME run with ?after=<lastSeq> so daemon replays missed
+ * events. This test verifies the recovery path end-to-end: a run whose first
+ * SSE connection goes silent mid-turn must resume rendering once the watchdog
+ * reconnects — without re-POSTing /api/runs (no createRun, no session loss).
+ */
+function sseFrame(seq: number, runId: string, event: object): string {
+  return `id: ${seq}\ndata: ${JSON.stringify({ seq, runId, event })}\n\n`;
+}
+
+test.describe('Chat — SSE watchdog reconnect', () => {
+  test('watchdog reconnects to same run with ?after=, recovering missed events (no createRun)', async ({ page }) => {
+    // Shorten watchdog 45s → 1s so the test doesn't wait.
+    await page.addInitScript(() => {
+      (window as any).__MOLIO_TEST_WATCHDOG_MS__ = 1000;
+    });
+
+    const runId = 'watchdog-run-1';
+    const convId = 'watchdog-conv-1';
+    const eventsRequests: string[] = [];
+    let createRunCount = 0;
+
+    // Streaming SSE mock:
+    //  - 1st request (no ?after): send status + text_delta('Hello') then go SILENT
+    //    (no ping, no end) — simulates the dead-but-OPEN connection that trips
+    //    onerror/onDone's blind spot.
+    //  - 2nd request (?after=2): replay the missed tail — text_delta(', world')
+    //    + turn_end + usage — simulating daemon replaying buffered events after
+    //    the watchdog re-subscribes to the same run.
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url!, 'http://x');
+      eventsRequests.push(url.pathname + url.search);
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'Access-Control-Allow-Origin': '*',
+      });
+      const after = Number(url.searchParams.get('after') || 0);
+      if (after === 0) {
+        res.write(sseFrame(1, runId, { type: 'status', label: 'running' }));
+        setTimeout(() => {
+          res.write(sseFrame(2, runId, { type: 'text_delta', delta: 'Hello' }));
+          // then SILENT — do NOT end, do NOT send ping. Watchdog must fire after 1s.
+        }, 50);
+      } else {
+        // reconnect with ?after=2: replay the missed tail
+        res.write(sseFrame(3, runId, { type: 'text_delta', delta: ', world' }));
+        setTimeout(() => {
+          res.write(sseFrame(4, runId, { type: 'turn_end', stopReason: 'end_turn' }));
+          res.write(sseFrame(5, runId, { type: 'usage', usage: {} }));
+          res.end();
+        }, 50);
+      }
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    const port = (server.address() as any).port;
+
+    try {
+      // POST /api/runs → runId (record count to assert NO createRun on reconnect)
+      await page.route('**/api/runs', async (route) => {
+        if (route.request().method() === 'POST') {
+          createRunCount += 1;
+          await route.fulfill({
+            status: 201, contentType: 'application/json',
+            body: JSON.stringify({ runId, conversationId: convId }),
+          });
+        } else { await route.continue(); }
+      });
+      // GET /api/runs/:id/events → forward to the streaming mock
+      await page.route(`**/api/runs/${runId}/events**`, async (route) => {
+        const url = new URL(route.request().url());
+        await route.continue({ url: `http://127.0.0.1:${port}${url.pathname}${url.search}` });
+      });
+      // Minimal agents/config so the composer is enabled
+      await page.route('**/api/agents', async (route) => {
+        await route.fulfill({
+          status: 200, contentType: 'application/json',
+          body: JSON.stringify({ agents: [{ id: 'claude', name: 'Claude', available: true, binary: '/x', source: 'path', version: '1', models: [], installUrl: 'https://x', installable: false }] }),
+        });
+      });
+      await page.route('**/api/config', async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ defaultAgentId: 'claude', locale: 'zh' }) });
+      });
+
+      await gotoHome(page);
+      await sendMessage(page, 'hi');
+
+      // turn 1 partial renders ('Hello') before the connection goes silent
+      const assistant = page.locator('[data-testid="assistant-message"]');
+      await expect(assistant).toContainText('Hello', { timeout: 5_000 });
+
+      // After watchdog (1s silent) → reconnect with ?after=2 → replay tail.
+      // The same assistant bubble must show the recovered 'Hello, world'.
+      await expect(assistant).toContainText('Hello, world', { timeout: 5_000 });
+
+      // Verify the reconnect actually carried ?after=<lastSeq>
+      expect(eventsRequests.some((r) => r.includes('after=2'))).toBeTruthy();
+
+      // And NO createRun happened during recovery (session preserved, not a new run)
+      expect(createRunCount).toBe(1);
+    } finally {
+      // EventSource keep-alive connections would hang server.close() — force them.
+      server.closeAllConnections?.();
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});

--- a/apps/web/src/api/sse.ts
+++ b/apps/web/src/api/sse.ts
@@ -18,29 +18,45 @@ const DEBUG_OPEN_SILENT = typeof window !== 'undefined'
 
 export function subscribeToRun(
   runId: string,
-  onEvent: (event: AgentEvent) => void,
+  onEvent: (event: AgentEvent, seq?: number) => void,
   onError?: (error: Event) => void,
   onDone?: () => void,
+  afterSeq?: number,
+  onKeepalive?: () => void,
 ): EventSource {
-  const es = new EventSource(`/api/runs/${runId}/events`);
+  // afterSeq > 0 → reconnect: ask daemon to replay buffered events with id > afterSeq
+  // (events.ts:20 supports ?after=). Used by the watchdog to reconnect to the SAME run
+  // after a dead connection, recovering missed events without losing session context.
+  const url = afterSeq && afterSeq > 0
+    ? `/api/runs/${runId}/events?after=${afterSeq}`
+    : `/api/runs/${runId}/events`;
+  const es = new EventSource(url);
   // Snapshot the switch at subscribe time so toggling mid-run doesn't half-apply.
   const openSilent = DEBUG_OPEN_SILENT
     || (typeof window !== 'undefined'
       && (window as any).__MOLIO_DEBUG_SSE_OPEN_SILENT__ === true);
 
   es.onmessage = (msg) => {
-    // Diagnostic: confirm frames are reaching the browser. Pings (`:ping`) are SSE
-    // comment lines and do NOT trigger onmessage, so any log here is a real event frame.
+    // Diagnostic switch: drop every frame to simulate "events never reach the upper
+    // layer" — including ping, so the watchdog eventually fires. Used to verify the
+    // watchdog/reconnect path without waiting for a real 3h hang.
     if (openSilent) {
       console.warn('[sse] recv DROPPED (DEBUG_OPEN_SILENT) readyState=' + es.readyState);
+      return;
+    }
+    // Ping is a `data: ping` frame (daemon sse.ts). Recognize before JSON.parse and
+    // signal keepalive — this is the watchdog's heartbeat during turn gaps where no
+    // real chat events flow but the connection is still alive.
+    if (msg.data === 'ping') {
+      onKeepalive?.();
       return;
     }
     try {
       const envelope: SSEEnvelope = JSON.parse(msg.data);
       console.debug('[sse] recv readyState=' + es.readyState + ' seq=' + envelope.seq + ' type=' + envelope.event.type);
-      onEvent(envelope.event);
+      onEvent(envelope.event, envelope.seq);
     } catch {
-      // Ignore parse errors for keepalive pings
+      // Ignore parse errors for any non-JSON keepalive variant
     }
   };
 

--- a/apps/web/src/api/sse.ts
+++ b/apps/web/src/api/sse.ts
@@ -6,6 +6,16 @@ interface SSEEnvelope {
   event: AgentEvent;
 }
 
+/**
+ * Diagnostic switch (devtools console): `window.__MOLIO_DEBUG_SSE_OPEN_SILENT__ = true`
+ * Keeps the EventSource at readyState=OPEN (connection looks healthy) but drops every
+ * inbound message — simulating "events never reach the upper layer" to verify whether
+ * the idle fallback fires and how long it takes, WITHOUT waiting for a real 3h hang.
+ * Production never sets this.
+ */
+const DEBUG_OPEN_SILENT = typeof window !== 'undefined'
+  && (window as any).__MOLIO_DEBUG_SSE_OPEN_SILENT__ === true;
+
 export function subscribeToRun(
   runId: string,
   onEvent: (event: AgentEvent) => void,
@@ -13,10 +23,21 @@ export function subscribeToRun(
   onDone?: () => void,
 ): EventSource {
   const es = new EventSource(`/api/runs/${runId}/events`);
+  // Snapshot the switch at subscribe time so toggling mid-run doesn't half-apply.
+  const openSilent = DEBUG_OPEN_SILENT
+    || (typeof window !== 'undefined'
+      && (window as any).__MOLIO_DEBUG_SSE_OPEN_SILENT__ === true);
 
   es.onmessage = (msg) => {
+    // Diagnostic: confirm frames are reaching the browser. Pings (`:ping`) are SSE
+    // comment lines and do NOT trigger onmessage, so any log here is a real event frame.
+    if (openSilent) {
+      console.warn('[sse] recv DROPPED (DEBUG_OPEN_SILENT) readyState=' + es.readyState);
+      return;
+    }
     try {
       const envelope: SSEEnvelope = JSON.parse(msg.data);
+      console.debug('[sse] recv readyState=' + es.readyState + ' seq=' + envelope.seq + ' type=' + envelope.event.type);
       onEvent(envelope.event);
     } catch {
       // Ignore parse errors for keepalive pings
@@ -24,6 +45,7 @@ export function subscribeToRun(
   };
 
   es.onerror = (err) => {
+    console.warn('[sse] error readyState=' + es.readyState + ' runId=' + runId);
     onError?.(err);
     // If the daemon process exited (connection closed for good, not a
     // transient network blip), readyState is CLOSED. The browser's default
@@ -32,10 +54,14 @@ export function subscribeToRun(
     // unlock the input. Transient failures (readyState still CONNECTING/
     // OPEN) keep the default reconnect behavior.
     if (es.readyState === EventSource.CLOSED) {
+      console.warn('[sse] done (CLOSED) runId=' + runId);
       es.close();
       onDone?.();
     }
   };
+
+  // Log open lifecycle once so we can see when a subscription is (re)established.
+  console.debug('[sse] subscribe runId=' + runId + ' openSilent=' + openSilent);
 
   return es;
 }

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -132,8 +132,12 @@ export function useChatCore(options: UseChatCoreOptions) {
     const fallbackMs = (typeof window !== 'undefined' &&
       (window as any).__MOLIO_TEST_FALLBACK_TIMEOUT_MS__) || FALLBACK_IDLE_MS;
     fallbackTimerRef.current = setTimeout(() => {
+      console.warn('[chat] idle fallback fired after ' + fallbackMs + 'ms — no SSE events received; force-unlocking. assistantId=' + (assistantIdRef.current ?? '(empty)'));
       setState((prev) => {
-        if (!prev.isRunning) return prev;
+        if (!prev.isRunning) {
+          console.debug('[chat] idle fallback noop — no longer running');
+          return prev;
+        }
         const messages = prev.messages.map((msg) =>
           msg.id === assistantIdRef.current && msg.streaming
             ? { ...msg, streaming: false, error: msg.error ?? '响应超时，请重试或检查 daemon 是否运行' }
@@ -182,7 +186,14 @@ export function useChatCore(options: UseChatCoreOptions) {
       runId,
       (event: AgentEvent) => {
         const currentId = assistantIdRef.current;
-        if (!currentId) return;
+        console.debug('[chat] event type=' + event.type + ' runId=' + runId + ' assistantId=' + (currentId ?? '(empty)'));
+        if (!currentId) {
+          // Diagnostic: event reached the browser but assistantIdRef is empty, so it
+          // can't be routed to any assistant message — surfaces the "event arrived but
+          // UI didn't update" failure mode (assumption 4 in the SSE diagnosis).
+          console.warn('[chat] event DROPPED — assistantIdRef empty, cannot route. type=' + event.type);
+          return;
+        }
         // ACP agents (Hermes) report their real model list via session/new.
         // Fan out to useAgents so the model picker updates dynamically.
         if (event.type === 'models' && agentId) {
@@ -209,6 +220,7 @@ export function useChatCore(options: UseChatCoreOptions) {
         // P2-3: SSE closed for good (daemon exited, readyState === CLOSED).
         // Auto-reconnect would hammer a dead endpoint forever — unlock the
         // input so the user can re-send instead of staring at a locked composer.
+        console.warn('[chat] SSE onDone (CLOSED) — force-unlocking. runId=' + runId);
         setState((prev) => {
           if (!prev.isRunning) return prev;
           const messages = prev.messages.map((msg) =>

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -93,6 +93,20 @@ function nextMsgId() { return `msg-${++msgCounter}-${Date.now()}`; }
  */
 const FALLBACK_IDLE_MS = 10 * 60 * 1000; // 10 minutes
 
+/**
+ * Watchdog: if no SSE frame (event OR ping) arrives for this long, the
+ * connection is presumed dead. The 11.5-min abort bug leaves EventSource at
+ * readyState=OPEN but silent — onerror/onDone never fire. The watchdog then
+ * reconnects to the SAME run with ?after=<lastSeq> so daemon replays missed
+ * events (session/cache preserved, no createRun). 45s = 3× the 15s ping; only
+ * a truly dead connection (3 missed pings) trips it. Backoff per attempt;
+ * MAX_RECONNECT caps it, after which onDone fires (→ createRun next time).
+ *
+ * Test hook: `window.__MOLIO_TEST_WATCHDOG_MS__` shortens the wait for E2E.
+ */
+const WATCHDOG_MS = 45_000;
+const MAX_RECONNECT = 4;
+
 export function useChatCore(options: UseChatCoreOptions) {
   const { createRun, rewindResend, agentId, initialMessages = [], initialConversationId = null, onComplete } = options;
 
@@ -111,6 +125,52 @@ export function useChatCore(options: UseChatCoreOptions) {
   // promptIdleTimeoutMs (5min) — if no terminal status arrives by then, the
   // user gets the input back instead of a permanently locked composer.
   const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Last received SSE seq — used as ?after= when the watchdog reconnects, so
+  // daemon replays only the events missed during the dead connection.
+  const lastSeqRef = useRef<number>(0);
+  // Watchdog timer — fires when no frame (event or ping) arrives for WATCHDOG_MS.
+  const watchdogTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Scheduled reconnect (exponential backoff). Cleared on clean shutdown so a
+  // pending reconnect doesn't fire after cancel/reset.
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Reconnect attempt counter for exponential backoff + cap.
+  const reconnectAttemptRef = useRef<number>(0);
+  // The watchdog invokes this to reconnect; set inside beginNewRun so it
+  // closures the current run's callbacks + runId. Null when no active run.
+  const reconnectRef = useRef<(() => void) | null>(null);
+  // True while doReconnect is swapping the EventSource — onDoneCb from the OLD
+  // es (fired by its close()) must be ignored so it doesn't clear runId/isRunning
+  // mid-swap. Only the NEW es's onDone (or a genuine daemon exit) should unlock.
+  const reconnectingRef = useRef<boolean>(false);
+
+  const clearWatchdog = useCallback(() => {
+    if (watchdogTimerRef.current) {
+      clearTimeout(watchdogTimerRef.current);
+      watchdogTimerRef.current = null;
+    }
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Re-arm the watchdog (clear + schedule). On timeout, invokes reconnectRef
+   * (set by beginNewRun) to re-subscribe to the SAME run with ?after=<lastSeq>.
+   * Called on every received event and every ping frame.
+   */
+  const armWatchdog = useCallback(() => {
+    if (watchdogTimerRef.current) {
+      clearTimeout(watchdogTimerRef.current);
+    }
+    const wdMs = (typeof window !== 'undefined' &&
+      (window as any).__MOLIO_TEST_WATCHDOG_MS__) || WATCHDOG_MS;
+    watchdogTimerRef.current = setTimeout(() => {
+      const cb = reconnectRef.current;
+      if (!cb) return;
+      cb();
+    }, wdMs);
+  }, []);
 
   const clearFallbackTimer = useCallback(() => {
     if (fallbackTimerRef.current) {
@@ -154,7 +214,9 @@ export function useChatCore(options: UseChatCoreOptions) {
     esRef.current?.close();
     esRef.current = null;
     clearFallbackTimer();
-  }, [clearFallbackTimer]);
+    clearWatchdog();
+    reconnectRef.current = null;
+  }, [clearFallbackTimer, clearWatchdog]);
 
   const beginNewRun = useCallback(async (
     result: RunResult,
@@ -172,6 +234,9 @@ export function useChatCore(options: UseChatCoreOptions) {
     // events to a new assistant message without resubscribing.
     assistantIdRef.current = assistantId;
     clearFallbackTimer();
+    clearWatchdog();
+    reconnectAttemptRef.current = 0;
+    lastSeqRef.current = 0;
 
     setState((prev) => ({
       ...prev,
@@ -182,67 +247,64 @@ export function useChatCore(options: UseChatCoreOptions) {
       isRunning: true,
     }));
 
-    const es = subscribeToRun(
-      runId,
-      (event: AgentEvent) => {
-        const currentId = assistantIdRef.current;
-        console.debug('[chat] event type=' + event.type + ' runId=' + runId + ' assistantId=' + (currentId ?? '(empty)'));
-        if (!currentId) {
-          // Diagnostic: event reached the browser but assistantIdRef is empty, so it
-          // can't be routed to any assistant message — surfaces the "event arrived but
-          // UI didn't update" failure mode (assumption 4 in the SSE diagnosis).
-          console.warn('[chat] event DROPPED — assistantIdRef empty, cannot route. type=' + event.type);
-          return;
-        }
-        // ACP agents (Hermes) report their real model list via session/new.
-        // Fan out to useAgents so the model picker updates dynamically.
-        if (event.type === 'models' && agentId) {
-          const detail: AcpModelsUpdatedDetail = {
-            agentId,
-            models: event.models,
-            currentModelId: event.currentModelId,
-          };
-          window.dispatchEvent(new CustomEvent(ACP_MODELS_UPDATED_EVENT, { detail }));
-        }
-        setState((prev) => updateWithEvent(prev, currentId, event));
-        // Fallback timer is idle-based: any activity (text/tool/usage/etc.)
-        // resets the window so a long but active run never false-times-out.
-        // Terminal status clears it — the run ended cleanly, no need to
-        // force-unlock later.
-        if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed' || event.label === 'canceled')) {
-          clearFallbackTimer();
-        } else {
-          resetFallbackTimer();
-        }
-      },
-      () => { /* SSE error — EventSource auto-retries; onDone handles permanent close */ },
-      () => {
-        // P2-3: SSE closed for good (daemon exited, readyState === CLOSED).
-        // Auto-reconnect would hammer a dead endpoint forever — unlock the
-        // input so the user can re-send instead of staring at a locked composer.
-        console.warn('[chat] SSE onDone (CLOSED) — force-unlocking. runId=' + runId);
-        setState((prev) => {
-          if (!prev.isRunning) return prev;
-          const messages = prev.messages.map((msg) =>
-            msg.streaming ? { ...msg, streaming: false } : msg
-          );
-          return { ...prev, messages, isRunning: false, runId: null, runAgentId: null };
-        });
+    // --- SSE callbacks (named so the watchdog can re-subscribe with the same
+    // callbacks + ?after=<lastSeq> on reconnect) ---
+    const onEventCb = (event: AgentEvent, seq?: number) => {
+      const currentId = assistantIdRef.current;
+      console.debug('[chat] event type=' + event.type + ' runId=' + runId + ' assistantId=' + (currentId ?? '(empty)'));
+      if (seq && seq > (lastSeqRef.current || 0)) lastSeqRef.current = seq;
+      // Any frame (event or ping) = connection alive: reset backoff + watchdog.
+      reconnectAttemptRef.current = 0;
+      armWatchdog();
+      if (!currentId) {
+        console.warn('[chat] event DROPPED — assistantIdRef empty, cannot route. type=' + event.type);
+        return;
+      }
+      if (event.type === 'models' && agentId) {
+        const detail: AcpModelsUpdatedDetail = {
+          agentId,
+          models: event.models,
+          currentModelId: event.currentModelId,
+        };
+        window.dispatchEvent(new CustomEvent(ACP_MODELS_UPDATED_EVENT, { detail }));
+      }
+      setState((prev) => updateWithEvent(prev, currentId, event));
+      if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed' || event.label === 'canceled')) {
         clearFallbackTimer();
-      },
-    );
+      } else {
+        resetFallbackTimer();
+      }
+    };
+    const onDoneCb = () => {
+      // During watchdog reconnect, closing the OLD es fires its onDone here —
+      // ignore it so we don't clear runId/isRunning mid-swap. Only the NEW es's
+      // onDone (or a genuine daemon exit) should unlock.
+      if (reconnectingRef.current) return;
+      console.warn('[chat] SSE onDone (CLOSED) — force-unlocking. runId=' + runId);
+      clearWatchdog();
+      reconnectRef.current = null;
+      setState((prev) => {
+        if (!prev.isRunning) return prev;
+        const messages = prev.messages.map((msg) =>
+          msg.streaming ? { ...msg, streaming: false } : msg
+        );
+        return { ...prev, messages, isRunning: false, runId: null, runAgentId: null };
+      });
+      clearFallbackTimer();
+    };
+    const onKeepaliveCb = () => {
+      // ping frame — connection alive. Same reset as a real event.
+      reconnectAttemptRef.current = 0;
+      armWatchdog();
+    };
+
+    const es = subscribeToRun(runId, onEventCb, undefined, onDoneCb, undefined, onKeepaliveCb);
     esRef.current = es;
 
-    // Idle fallback timer — armed on run start and reset on every received
-    // event (see resetFallbackTimer). A long but ACTIVE run (remotion render,
-    // multi-turn chat, long tool calls) never false-times-out as long as
-    // events keep flowing; it only fires when the stream goes truly silent
-    // for FALLBACK_IDLE_MS — catching daemon hangs/crashes and network
-    // blackholes. Terminal status clears it.
-    //
-    // Test hook: `window.__MOLIO_TEST_FALLBACK_TIMEOUT_MS__` shortens the
-    // wait so E2E can exercise this path without sleeping. Production never
-    // sets this.
+    // Idle fallback (10min) + watchdog (45s). The watchdog fires first on a
+    // dead-but-OPEN connection and reconnects to the same run; the idle fallback
+    // is the older safety net for genuinely hung runs. Both re-armed per frame.
+    armWatchdog();
     resetFallbackTimer();
 
     if (onComplete) {
@@ -256,7 +318,54 @@ export function useChatCore(options: UseChatCoreOptions) {
         } catch { /* ignore parse errors */ }
       };
     }
-  }, [state.conversationId, agentId, onComplete, clearFallbackTimer, resetFallbackTimer]);
+
+    // Watchdog reconnect: re-subscribe to the SAME run with ?after=<lastSeq>
+    // so daemon replays missed events (session/cache preserved, no createRun).
+    // Closures the named callbacks above; reassigned every beginNewRun so it
+    // always reflects the current run's wiring. Exponential backoff per attempt;
+    // after MAX_RECONNECT, fall through to onDone (next send → createRun).
+    const doReconnect = (afterSeq: number) => {
+      // Guard: closing the old es fires its onDone — onDoneCb checks this flag
+      // and skips. Reset only after the NEW es is wired.
+      reconnectingRef.current = true;
+      esRef.current?.close();
+      esRef.current = null;
+      clearFallbackTimer();
+      clearWatchdog();
+      const newEs = subscribeToRun(runId, onEventCb, undefined, onDoneCb, afterSeq, onKeepaliveCb);
+      esRef.current = newEs;
+      armWatchdog();
+      resetFallbackTimer();
+      if (onComplete) {
+        const orig = newEs.onmessage;
+        newEs.onmessage = (msg) => {
+          orig?.call(newEs, msg);
+          try {
+            const envelope = JSON.parse(msg.data);
+            const ev = envelope.event;
+            if (ev.type === 'status' && ev.label === 'completed') onComplete();
+          } catch { /* ignore */ }
+        };
+      }
+      console.warn('[sse] watchdog reconnected runId=' + runId + ' afterSeq=' + afterSeq);
+      reconnectingRef.current = false;
+    };
+    reconnectRef.current = () => {
+      reconnectAttemptRef.current += 1;
+      const attempt = reconnectAttemptRef.current;
+      const wdMs = (typeof window !== 'undefined' &&
+        (window as any).__MOLIO_TEST_WATCHDOG_MS__) || WATCHDOG_MS;
+      if (attempt > MAX_RECONNECT) {
+        console.warn('[sse] watchdog gave up after ' + MAX_RECONNECT + ' reconnects — onDone (next send → createRun)');
+        reconnectRef.current = null;
+        onDoneCb();
+        return;
+      }
+      const delay = wdMs * 2 ** (attempt - 1);
+      console.warn('[sse] watchdog no frames for ' + wdMs + 'ms, reconnect attempt ' + attempt + ' in ' + delay + 'ms');
+      reconnectTimerRef.current = setTimeout(() => doReconnect(lastSeqRef.current), delay);
+    };
+  }, [state.conversationId, agentId, onComplete, clearFallbackTimer, clearWatchdog, armWatchdog, resetFallbackTimer]);
 
   /**
    * Send a message — tries multi-turn on existing run first, falls back to createRun.


### PR DESCRIPTION
## 问题

桌面端长时间不连续对话后，用户提新问题对话面板无响应，需手动终止再问一遍才响应。多轮连续对话后也偶发"内容不出现"。

## 根因（dev + 打包两次复现坐实）

daemon SSE 请求在连接建立约 **11.5 分钟**（dev 675s / 打包 691.5s）后被 abort，触发 `events.ts` 的 abort 监听 → `cleanup()` → 取消订阅（`listeners=0`）。此后用户提新消息走 `sendMessage` 复用旧 runId，claude 正常处理、daemon 一路 emit 事件，但**全部发到空订阅**。前端 `EventSource` 的 `readyState` 全程保持 `OPEN`（不 `onerror` / 不 `onDone`——`sse.ts:34` 只认 `CLOSED` 才 onDone），`state.runId` 不清空，新消息继续复用死订阅 → 无响应。idle fallback 因 `isRunning` 在上一 turn 已 false，timer 触发都 `noop`，连兜底都救不了。

**触发者**：Node 24 http server 默认超时（`server.timeout=0` / `requestTimeout=300s` / `headersTimeout=60s`）都不匹配 690s，daemon 端 ping 一直成功（无 `ping enqueue FAILED`），说明断开不在 daemon 侧——最可能是 Electron 内置 Chromium 客户端那层。`events.ts` 加了 abort 诊断日志（socket.destroyed/remote），下次复现可锁死具体来源。

## 修法

**核心：前端 SSE 看门狗 + 重连同一 run（上下文无损）**

- 看门狗（45s = 3× ping 间隔）检测"N 秒无帧"（含 ping），判定连接死 → 主动 `close()` + 重新 `subscribeToRun` **同一 runId** 带 `?after=<lastSeq>`。daemon `events.ts` 对还活着的 run replay 缺失事件 + 重新 subscribe。run/claude 进程没死，session/cache/上下文无损，**不走 createRun**。
- 退避 45/90/180/360s，上限 4 次后 `onDone` 兜底（下次 send → createRun）。
- `reconnectingRef` 防 close 旧 es 误触发 onDone 清 runId。

**配套**：
- daemon ping 从注释行 `:ping` 改 data 帧 `data: ping`（SSE 注释行不触发 `onmessage`，前端收不到 ping，看门狗无法靠 ping 维持 turn 间隙，会误判重连）。
- `events.ts` SSE socket `setTimeout(0)` 双保险 + abort 诊断日志。
- daemon `sse.ts` 加 `MOLIO_DEBUG_SSE_BREAK_AFTER` / `MOLIO_TEST_SSE_PING_MS` 注入/测试 hook。

## 为什么不直接 createRun 兜底

createRun 会 spawn 新 claude 进程，丢进程级 session/cache（慢 + 贵）。重连同一 run 只换 SSE 管道，run 没死，daemon replay 补回缺失事件——11.5 分钟前那条回复能补回来，上下文无损。只有 run 真死了（onDone）才 createRun。

## 测试

- **E2E** `chat-sse-watchdog.spec.ts`（P0 @area chat）：连接静默 → 看门狗重连带 `?after=2` → replay 续接渲染 `Hello, world` → 断言不 createRun。
- **daemon unit** `sse-watchdog.test.ts`：ping 是 `data:` 帧非 `:ping` 注释行（E2E mock 不经过 daemon sse.ts 所以这是唯一 guard）+ `?after` replay 只回 id>afterId。
- typecheck 全绿；daemon 634 tests 0 fail；E2E watchdog 通过。

## 性能

诊断日志开销可忽略：daemon `dbgLog` 只在低频/异常点（每连接几次 + 只在订阅丢失/连接死时），正常对话每事件不打；前端 `console.debug` 在 devtools 关闭时几乎零成本（生产打包关 devtools）。诊断观测点和注入开关保留作回归 hook + 下次定位 abort 触发者。

## 验证

- [x] typecheck 全绿
- [x] daemon `pnpm test` 634/0
- [x] E2E `chat-sse-watchdog` 通过
- [x] 用户实测：打包带新代码后长空闲再发消息不再卡（看门狗自动重连恢复）
- [ ] 真实复现抓 abort 日志锁 690s 触发者（可选，不阻塞）

## 改动文件

- `apps/web/src/hooks/useChatCore.ts` — 看门狗 + establishSSE/doReconnect + reconnectingRef
- `apps/web/src/api/sse.ts` — `subscribeToRun` 加 `afterSeq` + `onKeepalive` + ping 识别
- `apps/daemon/src/sse.ts` — ping 改 data 帧 + 测试 hook
- `apps/daemon/src/routes/events.ts` — SSE socket setTimeout(0) + abort 诊断日志
- `apps/web/e2e/chat-sse-watchdog.spec.ts`（新）
- `apps/daemon/test/routes/sse-watchdog.test.ts`（新）

依赖前序 commit `cbc3b7b`（诊断观测点 + 注入开关），两者同分支。

🤖 Generated with [Claude Code](https://claude.com/claude-code)