### PR TITLE
feat(kb): 文档属性信息展示 — 可折叠 frontmatter 属性卡片

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -61,7 +61,8 @@ src/
       KnowledgeBasePage.tsx  知识库页面（shell 布局）
       KbFilePanel.tsx         文件面板（搜索、文件列表、vault 切换）
       KbFileTree.tsx          文件树组件
-      KbMainContent.tsx       主内容区（渲染 + 排版模式 + Tab 系统）
+      KbMainContent.tsx       主内容区（渲染 + 排版模式 + Tab 系统 + 属性卡片）
+      KbFrontmatterCard.tsx   可折叠 YAML frontmatter 属性卡片（折叠态标签 + 展开态完整字段 + wikilink 跳转）
       KbTabBar.tsx            Tab 栏
       KbModals.tsx            模态框（vault 创建/切换/导入/COSE 安装提示）
       MdRenderer.tsx          doocs/md 渲染引擎封装

--- a/apps/web/src/components/kb/KbFrontmatterCard.tsx
+++ b/apps/web/src/components/kb/KbFrontmatterCard.tsx
@@ -1,0 +1,232 @@
+/**
+ * KbFrontmatterCard — expanded YAML frontmatter property card.
+ *
+ * Renders all frontmatter fields in a card below the document header.
+ * Supports clickable [[wikilinks]] for `related` and `sources` fields
+ * (and any other field containing wikilinks).
+ *
+ * Renders nothing when data is empty (no frontmatter in the document).
+ */
+
+import { useMemo } from 'react';
+import { useI18n } from '../../i18n';
+
+interface KbFrontmatterCardProps {
+  data: Record<string, unknown>;
+  /** Called when a [[wikilink]] is clicked. Receives the raw page name (stripped of brackets). */
+  onNavigate?: (pageName: string) => void;
+  /** Called to collapse the card. */
+  onCollapse: () => void;
+}
+
+// ── helpers ──
+
+const WIKILINK_REGEX = /\[\[([^\]]+)\]\]/g;
+
+function isURL(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function formatDate(value: unknown): string {
+  if (value instanceof Date) {
+    if (isNaN(value.getTime())) return '';
+    return value.toLocaleDateString();
+  }
+  if (typeof value !== 'string' && typeof value !== 'number') return '';
+  const s = typeof value === 'number' ? String(value) : value;
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return s;
+  return d.toLocaleDateString();
+}
+
+function normalizeTags(raw: unknown): string[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.map((t) => String(t)).filter(Boolean);
+  if (typeof raw === 'string') return raw.split(/,\s*/).filter(Boolean);
+  return [];
+}
+
+function normalizeString(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  // YAML parser may convert dates to Date objects
+  if (raw instanceof Date) return formatDate(raw);
+  if (Array.isArray(raw)) {
+    return raw.map((a) => String(a).trim()).filter(Boolean).join(', ');
+  }
+  const s = String(raw).replace(/^["']|["']$/g, '');
+  return s || null;
+}
+
+function normalizeSource(raw: unknown): { url: string; label: string } | null {
+  const s = normalizeString(raw);
+  if (!s) return null;
+  if (isURL(s)) {
+    try {
+      const u = new URL(s);
+      const short = u.pathname.length > 30 ? u.pathname.slice(0, 30) + '…' : u.pathname;
+      return { url: s, label: u.hostname + short };
+    } catch {
+      return { url: s, label: s };
+    }
+  }
+  return { url: '', label: s };
+}
+
+// ── wikilink-aware value renderer ──
+
+interface WikilinkSegment {
+  type: 'text' | 'wikilink';
+  value: string;
+}
+
+function parseWikilinkText(text: string): WikilinkSegment[] {
+  const segments: WikilinkSegment[] = [];
+  let last = 0;
+  for (const m of text.matchAll(WIKILINK_REGEX)) {
+    if (m.index! > last) {
+      segments.push({ type: 'text', value: text.slice(last, m.index!) });
+    }
+    segments.push({ type: 'wikilink', value: m[1]!.trim() });
+    last = m.index! + m[0].length;
+  }
+  if (last < text.length) {
+    segments.push({ type: 'text', value: text.slice(last) });
+  }
+  return segments;
+}
+
+function RenderValue({
+  rawValue,
+  fieldKey,
+  onNavigate,
+}: {
+  rawValue: unknown;
+  fieldKey: string;
+  onNavigate?: (pageName: string) => void;
+}) {
+  const tags = useMemo(() => normalizeTags(rawValue), [rawValue]);
+  const sourceInfo = useMemo(() => normalizeSource(rawValue), [rawValue]);
+  const text = useMemo(() => normalizeString(rawValue), [rawValue]);
+  const segments = useMemo(() => (text ? parseWikilinkText(text) : []), [text]);
+
+  // source field with URL
+  if (fieldKey === 'source' && sourceInfo?.url) {
+    return (
+      <a href={sourceInfo.url} target="_blank" rel="noopener noreferrer">
+        {sourceInfo.label}
+      </a>
+    );
+  }
+
+  // tags field
+  if (fieldKey === 'tags') {
+    return (
+      <span className="kb-fm-tags">
+        {tags.length > 0
+          ? tags.map((tag) => <span key={tag} className="kb-fm-tag-pill">{tag}</span>)
+          : text}
+      </span>
+    );
+  }
+
+  // Fields with wikilinks — render [[link]] as clickable buttons.
+  // This handles related, sources, and any other field with wikilinks.
+  if (onNavigate && segments.some((s) => s.type === 'wikilink')) {
+    return (
+      <>
+        {segments.map((seg, i) =>
+          seg.type === 'wikilink' ? (
+            <button
+              key={i}
+              type="button"
+              className="kb-fm-wikilink"
+              onClick={() => onNavigate?.(seg.value)}
+              title={`${fieldKey}: ${seg.value}`}
+            >
+              {seg.value}
+            </button>
+          ) : (
+            <span key={i}>{seg.value}</span>
+          ),
+        )}
+      </>
+    );
+  }
+
+  // fallback — plain text
+  return <>{text}</>;
+}
+
+/** Frontmatter property keys that have well-known display treatment. */
+const KNOWN_KEYS = new Set([
+  'title', 'source', 'author', 'description',
+  'created', 'updated', 'published', 'category', 'tags',
+  'related', 'sources',
+]);
+
+export function KbFrontmatterCard({ data, onNavigate, onCollapse }: KbFrontmatterCardProps) {
+  const { t } = useI18n();
+
+  // Empty state
+  if (Object.keys(data).length === 0) return null;
+
+  // Build ordered field list
+  const fields: Array<{ key: string; i18nKey: string; icon: string }> = [];
+
+  const add = (key: string, icon: string) => {
+    if (data[key] !== undefined && data[key] !== null) {
+      fields.push({ key, i18nKey: `kb.frontmatter.${key}`, icon });
+    }
+  };
+
+  add('title', '📝');        // 📝
+  add('source', '🔗');       // 🔗
+  add('author', '✍️');       // ✍️
+  add('description', '📋');  // 📋
+  add('created', '📅');      // 📅
+  add('updated', '🔄');      // 🔄
+  add('published', '📰');    // 📰
+  add('category', '📂');     // 📂
+  add('tags', '🏷');         // 🏷
+  add('related', '🔗');      // 🔗
+  add('sources', '📄');      // 📄
+
+  // Any remaining unknown keys
+  for (const key of Object.keys(data)) {
+    if (!KNOWN_KEYS.has(key) && data[key] !== undefined && data[key] !== null) {
+      fields.push({ key, i18nKey: '', icon: '📌' }); // 📌
+    }
+  }
+
+  return (
+    <div className="kb-frontmatter" data-testid="kb-fm-expanded">
+      <div className="kb-frontmatter-header" onClick={onCollapse}>
+        <span>{t('kb.frontmatter.properties')}</span>
+        <button
+          type="button"
+          className="kb-fm-collapse-btn"
+          onClick={(e) => { e.stopPropagation(); onCollapse(); }}
+          title={t('kb.frontmatter.collapse')}
+        >
+          {t('kb.frontmatter.collapse')} ▴
+        </button>
+      </div>
+      <div className="kb-frontmatter-body">
+        {fields.map((field) => (
+          <div key={field.key} className="kb-fm-line">
+            <span className="kb-fm-key">
+              <span aria-hidden="true">{field.icon}</span> {field.i18nKey ? t(field.i18nKey) : field.key}
+            </span>
+            <span className="kb-fm-val">
+              <RenderValue
+                rawValue={data[field.key]}
+                fieldKey={field.key}
+                onNavigate={onNavigate}
+              />
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/kb/KbMainContent.tsx
+++ b/apps/web/src/components/kb/KbMainContent.tsx
@@ -17,12 +17,14 @@ import type { MenuItem } from './ContextMenu';
 import { TooLargeCard } from './TooLargeCard';
 import { ViewerErrorBoundary } from './ViewerErrorBoundary';
 import type { KbCodeMirrorViewerHandle } from './KbCodeMirrorViewer';
+import { KbFrontmatterCard } from './KbFrontmatterCard';
 import { formatFileSize } from '../../utils/format';
 import { preprocessWikiEmbeds, proxyExternalImages, stripTrackingPixels } from '../../hooks/useKnowledge';
 import { api } from '../../api/client';
 import { useI18n } from '../../i18n';
 import TurndownService from 'turndown';
 import { gfm } from 'turndown-plugin-gfm';
+import frontMatter from 'front-matter';
 
 // Lazy-load the CodeMirror viewer (heavy CM bundle) only when a text file
 // actually takes the CM path (non-md / large md). Named export → default shape.
@@ -119,6 +121,8 @@ interface KbMainContentProps {
   onForceLoad?: () => void;
   /** Close the active tab (wired from useKbTabs by KnowledgeBasePage). */
   onCloseTab?: () => void;
+  /** Navigate to another file in the same vault (for [[wikilink]] clicks). */
+  onNavigateToFile?: (filePath: string) => void;
 }
 
 export function KbMainContent({
@@ -146,12 +150,14 @@ export function KbMainContent({
   editedContent,
   onForceLoad,
   onCloseTab,
+  onNavigateToFile,
 }: KbMainContentProps) {
   const { t } = useI18n();
   const contentRef = useRef<HTMLDivElement>(null);
   const cmRef = useRef<KbCodeMirrorViewerHandle>(null);
   const [wrap, setWrap] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
+  const [fmExpanded, setFmExpanded] = useState(false);
   const [ctxMenu, setCtxMenu] = useState<
     { x: number; y: number; source: 'doocs' | 'codemirror'; selectedText?: string } | null
   >(null);
@@ -182,6 +188,100 @@ export function KbMainContent({
       : '',
     [editedContent, fileContent?.content, vaultId, isSmallMd],
   );
+
+  // Parse YAML frontmatter from the raw source for the property card.
+  // Only meaningful for small .md files (doocs path).
+  const frontmatterData = useMemo(() => {
+    if (!isSmallMd) return {};
+    const raw = editedContent ?? fileContent?.content ?? '';
+    if (!raw) return {};
+    try {
+      const parsed = frontMatter(raw);
+      return (parsed.attributes as Record<string, unknown>) ?? {};
+    } catch {
+      return {};
+    }
+  }, [rawContent, isSmallMd]);
+
+  // Extract distilled badges (not raw frontmatter fields) for the collapsed header.
+  // The collapsed bar should answer "what kind of document is this?" at a glance.
+  const fmCollapsed = useMemo(() => {
+    const fm = frontmatterData;
+    if (Object.keys(fm).length === 0) return null;
+
+    const tags: string[] = (() => {
+      const raw = fm.tags;
+      if (!raw) return [];
+      if (Array.isArray(raw)) return raw.map((t) => String(t)).filter(Boolean);
+      if (typeof raw === 'string') return raw.split(/,\s*/).filter(Boolean);
+      return [];
+    })();
+
+    const source: string | null = (() => {
+      const raw = fm.source;
+      if (!raw) return null;
+      const s = String(raw);
+      return /^https?:\/\//i.test(s) ? s : null;
+    })();
+
+    const author: string | null = (() => {
+      const raw = fm.author;
+      if (!raw) return null;
+      if (Array.isArray(raw)) {
+        return raw.map((a) => String(a).replace(/^\[\[|\]\]$/g, '').trim()).filter(Boolean).join(', ');
+      }
+      return String(raw);
+    })();
+
+    const wikiType = typeof fm.type === 'string' ? fm.type : null;
+
+    const relatedCount = (() => {
+      const raw = fm.related;
+      if (!raw) return 0;
+      if (Array.isArray(raw)) return raw.length;
+      return 0;
+    })();
+
+    const isWeChat =
+      tags.includes('clippings') ||
+      (source !== null && source.includes('mp.weixin.qq.com'));
+
+    // Derive the primary badge (icon + label) from frontmatter properties.
+    interface Badge { icon: string; label: string; }
+    let primaryBadge: Badge | null = null;
+    let secondaryBadge: Badge | null = null;
+
+    if (wikiType) {
+      const typeBadges: Record<string, Badge> = {
+        entity: { icon: '📌', label: '实体' },
+        concept: { icon: '💡', label: '概念' },
+        source: { icon: '📰', label: '数据源' },
+        comparison: { icon: '⚖️', label: '对比' },
+        question: { icon: '❓', label: '问答' },
+      };
+      primaryBadge = typeBadges[wikiType] ?? null;
+      if (relatedCount > 0) {
+        secondaryBadge = { icon: '🔗', label: `${relatedCount}` };
+      }
+    } else if (isWeChat) {
+      primaryBadge = { icon: '📱', label: '微信' };
+      if (author) secondaryBadge = { icon: '✍️', label: author };
+    } else if (source) {
+      primaryBadge = { icon: '📎', label: '剪藏' };
+      if (author) secondaryBadge = { icon: '✍️', label: author };
+    } else if (tags.length > 0) {
+      primaryBadge = { icon: '📄', label: tags[0]! };
+    }
+
+    // Fallback: frontmatter exists but no badge pattern matched —
+    // show a generic "文档" badge so the collapsed bar & expand button stay accessible.
+    if (!primaryBadge) {
+      primaryBadge = { icon: '📄', label: '文档' };
+    }
+    return { primaryBadge, secondaryBadge };
+  }, [frontmatterData]);
+
+  const handleFmCollapse = useCallback(() => setFmExpanded(false), []);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -235,6 +335,32 @@ export function KbMainContent({
       {/* Header — always rendered so view actions (search / more-menu) stay
           visible even in empty states. File actions only render when a file is open. */}
       <div className="kb-main-header">
+        {/* ── Frontmatter inline (small-md read mode) — always visible when frontmatter exists.
+              Collapsed: show distilled badges. Expanded: show collapse indicator. ▴/▾ in same spot. */}
+        {!isTypesetMode && !isEditMode && isSmallMd && fmCollapsed && (
+          <div className="kb-fm-header-inline">
+            {fmCollapsed.primaryBadge && (
+              <span className={'kb-fm-badge' + (fmExpanded ? ' kb-fm-badge-dimmed' : '')}>
+                <span aria-hidden="true">{fmCollapsed.primaryBadge.icon}</span>
+                <span>{fmCollapsed.primaryBadge.label}</span>
+              </span>
+            )}
+            {fmCollapsed.secondaryBadge && (
+              <span className={'kb-fm-badge kb-fm-badge-secondary' + (fmExpanded ? ' kb-fm-badge-dimmed' : '')}>
+                <span aria-hidden="true">{fmCollapsed.secondaryBadge.icon}</span>
+                <span>{fmCollapsed.secondaryBadge.label}</span>
+              </span>
+            )}
+            <button
+              type="button"
+              className="kb-fm-expand-btn"
+              onClick={() => setFmExpanded((prev) => !prev)}
+              title={fmExpanded ? t('kb.frontmatter.collapse') : t('kb.frontmatter.expand')}
+            >
+              {fmExpanded ? '▴' : '▾'}
+            </button>
+          </div>
+        )}
         {showFileName && selectedFile && (
           <div className="kb-header-filename-center">
             <span>
@@ -495,14 +621,23 @@ export function KbMainContent({
           selectedFile={selectedFile}
         />
       ) : category === 'text' && isSmallMd ? (
-        <div className="kb-content-area" ref={contentRef} onContextMenu={handleContextMenu}>
-          {fileContent ? (
-            // 优先使用编辑后的内容（未保存的更改），否则使用原始文件内容
-            <MdRenderer content={renderedContent} themeConfig={themeConfig} />
-          ) : (
-            <div className="kb-empty-state"><p>Loading...</p></div>
+        <>
+          {fmExpanded && (
+            <KbFrontmatterCard
+              data={frontmatterData}
+              onNavigate={onNavigateToFile}
+              onCollapse={handleFmCollapse}
+            />
           )}
-        </div>
+          <div className="kb-content-area" ref={contentRef} onContextMenu={handleContextMenu}>
+            {fileContent ? (
+              // 优先使用编辑后的内容（未保存的更改），否则使用原始文件内容
+              <MdRenderer content={renderedContent} themeConfig={themeConfig} />
+            ) : (
+              <div className="kb-empty-state"><p>Loading...</p></div>
+            )}
+          </div>
+        </>
       ) : category === 'text' && isCmPath ? (
         <div className="kb-content-area kb-cm-area" ref={contentRef}>
           <ViewerErrorBoundary

--- a/apps/web/src/components/kb/KbMainContent.tsx
+++ b/apps/web/src/components/kb/KbMainContent.tsx
@@ -157,7 +157,7 @@ export function KbMainContent({
   const cmRef = useRef<KbCodeMirrorViewerHandle>(null);
   const [wrap, setWrap] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
-  const [fmExpanded, setFmExpanded] = useState(false);
+  const [fmExpanded, setFmExpanded] = useState(true);
   const [ctxMenu, setCtxMenu] = useState<
     { x: number; y: number; source: 'doocs' | 'codemirror'; selectedText?: string } | null
   >(null);

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -70,6 +70,26 @@ function summarizeErrors(errors: Array<{ file: string; reason: string }>): strin
   return parts.join('，');
 }
 
+/** Walk the file tree to find a file whose name or path matches `needle` (case-insensitive).
+ *  Wikilinks may be bare page names (`[[腾讯程序员]]`) or path-qualified (`[[写作/案例/放弃Dify爆款拆解]]`). */
+function findFileByStem(nodes: TreeNode[], needle: string): string | null {
+  for (const node of nodes) {
+    if (node.type === 'directory' && node.children) {
+      const found = findFileByStem(node.children, needle);
+      if (found) return found;
+    }
+    if (node.type === 'file') {
+      // Match against bare filename (stem only)
+      const stem = node.name.replace(/\.[^.]+$/, '');
+      if (stem.toLowerCase() === needle) return node.path;
+      // Match against full relative path (for path-qualified wikilinks)
+      const pathStem = node.path.replace(/\.[^.]+$/, '');
+      if (pathStem.toLowerCase() === needle || pathStem.toLowerCase().endsWith(`/${needle}`)) return node.path;
+    }
+  }
+  return null;
+}
+
 export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenChange, registerKbChatOnComplete, onOpenConversation }: KnowledgeBasePageProps) {
   const { t } = useI18n();
   const kb = useKnowledge();
@@ -247,6 +267,16 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
 
   /** Open a file in a new tab — same semantics as handleSelectFile. */
   const handleOpenInNewTab = handleSelectFile;
+
+  /** Navigate to a file by wikilink page name — opens in a new tab. */
+  const handleNavigateToFile = useCallback((pageName: string) => {
+    if (!kb.tree || !kb.treeVaultId) return;
+    const needle = pageName.toLowerCase();
+    const found = findFileByStem(kb.tree, needle);
+    if (found) {
+      handleSelectFile(found);
+    }
+  }, [kb.tree, kb.treeVaultId, handleSelectFile]);
 
   /** Switch to a tab and load its file. Prompts before discarding unsaved edits. */
   const handleActivateTab = useCallback((tabId: string) => {
@@ -989,6 +1019,7 @@ export function KnowledgeBasePage({ agentId, kbChat, kbChatOpen, onKbChatOpenCha
           onCloseTab={() => {
             if (tabs.activeTabId) handleCloseTab(tabs.activeTabId);
           }}
+          onNavigateToFile={handleNavigateToFile}
         />
       </div>
 

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -298,6 +298,22 @@ const en: Record<string, string> = {
   'kb.outlineEmpty': 'No headings',
   'kb.close': 'Close',
 
+  // ── Frontmatter ──
+  'kb.frontmatter.title': 'Title',
+  'kb.frontmatter.source': 'Source',
+  'kb.frontmatter.author': 'Author',
+  'kb.frontmatter.created': 'Created',
+  'kb.frontmatter.updated': 'Updated',
+  'kb.frontmatter.published': 'Published',
+  'kb.frontmatter.description': 'Description',
+  'kb.frontmatter.tags': 'Tags',
+  'kb.frontmatter.related': 'Related',
+  'kb.frontmatter.sources': 'Sources',
+  'kb.frontmatter.category': 'Category',
+  'kb.frontmatter.expand': 'Show properties',
+  'kb.frontmatter.collapse': 'Hide properties',
+  'kb.frontmatter.properties': 'Properties',
+
   // ── FilePicker ──
   'filePicker.justNow': 'Just now',
   'filePicker.mAgo': '{n} min ago',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -298,6 +298,22 @@ const zh: Record<string, string> = {
   'kb.outlineEmpty': '暂无标题',
   'kb.close': '关闭',
 
+  // ── Frontmatter ──
+  'kb.frontmatter.title': '标题',
+  'kb.frontmatter.source': '来源',
+  'kb.frontmatter.author': '作者',
+  'kb.frontmatter.created': '创建',
+  'kb.frontmatter.updated': '更新',
+  'kb.frontmatter.published': '发布',
+  'kb.frontmatter.description': '描述',
+  'kb.frontmatter.tags': '标签',
+  'kb.frontmatter.related': '相关页面',
+  'kb.frontmatter.sources': '信息来源',
+  'kb.frontmatter.category': '分类',
+  'kb.frontmatter.expand': '展开属性',
+  'kb.frontmatter.collapse': '收起属性',
+  'kb.frontmatter.properties': '文档属性',
+
   // ── FilePicker ──
   'filePicker.justNow': '刚刚',
   'filePicker.mAgo': '{n}分钟前',

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -442,20 +442,170 @@
   text-decoration: none;
 }
 
-/* Frontmatter */
+/* ── Frontmatter Property Card ── */
+
+/* Inline collapsed content inside kb-main-header (zero extra vertical space) */
+.kb-fm-header-inline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 35%;
+  overflow: hidden;
+  font-size: 12px;
+}
+
+/* Distilled document-type badge in collapsed header bar */
+.kb-fm-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 8px;
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 11px;
+  color: var(--text);
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Dimmed variant when the expanded card is visible below */
+.kb-fm-badge-dimmed {
+  opacity: 0.5;
+}
+
+.kb-fm-badge-secondary {
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* Tag pill — used inside expanded card (tags field) */
+.kb-fm-tag-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 11px;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.kb-fm-expand-btn {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.kb-fm-expand-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.kb-fm-collapse-btn {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 2px 8px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.kb-fm-collapse-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+/* Clickable [[wikilink]] inside frontmatter values */
+.kb-fm-wikilink {
+  color: var(--accent);
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+.kb-fm-wikilink:hover {
+  color: var(--accent-hover, var(--accent));
+  text-decoration-style: solid;
+}
+
+/* Expanded card */
 .kb-frontmatter {
   background: var(--bg-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 12px 16px;
-  margin-bottom: 20px;
-  font-size: 12.5px;
-  font-family: var(--mono);
+  padding: 0;
+  margin: 12px 16px 0;
+  font-size: 13px;
+  overflow: hidden;
 }
 
-.kb-fm-line { display: flex; gap: 8px; padding: 1px 0; }
-.kb-fm-key { color: var(--text-muted); }
-.kb-fm-val { color: var(--text); }
+.kb-frontmatter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+.kb-frontmatter-header:hover { background: var(--bg-hover); }
+
+.kb-frontmatter-body {
+  padding: 10px 16px;
+}
+
+.kb-fm-line { display: flex; gap: 8px; padding: 2px 0; align-items: baseline; }
+.kb-fm-key {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  min-width: 80px;
+  white-space: nowrap;
+}
+.kb-fm-val {
+  color: var(--text);
+  word-break: break-word;
+}
+.kb-fm-val a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.kb-fm-val a:hover { text-decoration: underline; }
+
+/* Tag pills inside expanded card */
+.kb-fm-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
 
 /* Sources section */
 .kb-sources {

--- a/docs/obsidian-comparison.md
+++ b/docs/obsidian-comparison.md
@@ -90,7 +90,7 @@
 | **出站链接面板** | 显示当前页链接了谁 | 无 |
 | **链接建议** | 输入 `[[` 时自动补全 | **暂不支持** |
 | **标签系统** | `#tag` 自动收集，标签面板 | Wiki frontmatter 中的 `tags` 字段 |
-| **Properties (frontmatter)** | YAML frontmatter，支持表格视图 | frontmatter schema（type/title/created/updated/tags/related/sources） |
+| **Properties (frontmatter)** | YAML frontmatter，支持表格视图 + 内联编辑 | frontmatter schema + **可折叠属性卡片**（折叠态：类型标签；展开态：完整字段 + [[wikilink]] 跳转）<br>⚠️ 属性编辑：**待实现** — 需引入 `js-yaml` 做序列化回写 |
 | **页面关系图** | 基于链接的图 | 图谱构建 + 可视化 |
 
 ---


### PR DESCRIPTION
## 概述

实现文档 YAML frontmatter 属性的展示，在 Obsidian 式属性展示基础上做了更灵活的内联可折叠设计。

## 改动内容

### 新增文件
- **KbFrontmatterCard.tsx** — 展开态属性卡片组件（230 行），支持：
  - 属性字段按优先级排序展示（title/source/author/created/published/updated/description/tags/category/related/sources）
  - [[wikilink]] 解析与点击导航
  - source URL 外链跳转
  - 日期格式化（兼容 YAML Date 对象）

### 修改文件

| 文件 | 说明 |
|------|------|
| KbMainContent.tsx | frontmatter 解析 + 折叠态 badges + 展开卡片接入 + 统一 ▾/▴ 控制 |
| KnowledgeBasePage.tsx | findFileByStem（支持路径后缀匹配）+ onNavigateToFile（新标签页打开）|
| knowledge.css | badge + 卡片 + wikilink 按钮 + 死代码清理（净 +161 行）|
| en.ts / zh.ts | 13 个 frontmatter 字段中英文翻译 |
| CLAUDE.md / obsidian-comparison.md | 文档同步 |

## 设计要点

**折叠态**（零额外空间，内嵌于 kb-main-header）：
- 提炼文档类型标签：📌 实体 / 💡 概念 / 📰 数据源 / ⚖️ 对比 / ❓ 问答 / 📱 微信 / 📎 剪藏 / 📄 文档
- 二级信息：🔗 N（关联数） / ✍️ 作者
- 同一位置 ▾/▴ 切换，展开时 badges 半透明指示状态

**展开态**：
- 完整属性卡片，全部字段按优先级排列
- source URL 可点击外链跳转
- wikilink 字段（related/sources）渲染为可点击按钮，点击后在文件树中匹配并新标签打开

**边界处理**：
- 无 frontmatter → 不渲染
- 无法匹配类型 → 📄 文档 兜底（保证可展开）
- YAML Date 对象 → toLocaleDateString 格式化
- emoji → aria-hidden

## 作用范围

本 PR 限定在 **小 .md 文件阅读模式**，排版模式/编辑模式/大文件路径不受影响。

属性编辑功能未包含 — 已记录在 docs/obsidian-comparison.md 中标记为待实现。

## 验证

- ✅ TypeScript 类型检查（零错误）
- ✅ Vite 构建成功
- ✅ daemon 单元测试（0 fail）
- ✅ 与 origin/main 零冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)