### PR TITLE
fix(web): KB 问答 wiki-query 触发语仅包裹会话首轮

### DIFF
--- a/apps/web/e2e/area-map.json
+++ b/apps/web/e2e/area-map.json
@@ -36,12 +36,13 @@
       "paths": [
         "apps/web/src/components/kb/*",
         "apps/web/src/hooks/useKnowledge*",
+        "apps/web/src/hooks/useKbChat*",
         "apps/web/src/hooks/useKbTabs*",
         "apps/daemon/src/core/knowledge.ts",
         "apps/daemon/src/core/db.ts",
         "apps/daemon/src/routes/knowledge.ts"
       ],
-      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry", "kb-tab-limit", "kb-tab-stale", "kb-large-file", "kb-large-file-gbk", "kb-large-file-15mb", "kb-large-file-too-large"]
+      "specs": ["create-vault-form", "knowledge", "markdown-render", "kb-tree-sort-locate", "kb-chat-entry", "kb-qa-trigger", "kb-tab-limit", "kb-tab-stale", "kb-large-file", "kb-large-file-gbk", "kb-large-file-15mb", "kb-large-file-too-large"]
     },
     "publish": {
       "paths": [
@@ -129,6 +130,7 @@
     "knowledge": { "priority": "P0", "file": "knowledge.spec.ts" },
     "kb-tree-sort-locate": { "priority": "P1", "file": "kb-tree-sort-locate.spec.ts" },
     "kb-chat-entry": { "priority": "P1", "file": "kb-chat-entry.spec.ts" },
+    "kb-qa-trigger": { "priority": "P1", "file": "kb-qa-trigger.spec.ts" },
     "kb-tab-limit": { "priority": "P0", "file": "kb-tab-limit.spec.ts" },
     "kb-tab-stale": { "priority": "P1", "file": "kb-tab-stale.spec.ts" },
     "kb-large-file": { "priority": "P0", "file": "kb-large-file.spec.ts" },

--- a/apps/web/e2e/kb-qa-trigger.spec.ts
+++ b/apps/web/e2e/kb-qa-trigger.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { createTempVault, cleanupTempVault, type TempVault } from './helpers/cleanup';
+import { mockChatRun, unmockAll } from './helpers/mock-sse';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * @area kb
+ * @priority P1
+ *
+ * qa 模式的 wiki-query 确定性触发语（useKbChat WIKI_QUERY_TRIGGER）只应包裹会话首轮：
+ * - 首轮 POST /api/runs 的 message 带「（知识库问答：请用 wiki-query skill…）」前缀
+ * - 多轮 follow-up POST /api/runs/:id/messages 的 message 为用户原文，不再带触发语
+ *
+ * 每轮都带前缀会污染对话历史（用户反馈的 bug）。
+ * Prerequisites: `pnpm dev`.
+ */
+let vault: TempVault;
+
+test.describe('KB qa — wiki-query trigger wraps only the first turn', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-qa-trigger');
+    fs.unlinkSync(path.join(vault.path, 'test.md'));
+    fs.writeFileSync(path.join(vault.path, 'doc.md'), '# Doc\n');
+  });
+  test.afterAll(async () => { if (vault) await cleanupTempVault(vault); });
+
+  test.beforeEach(async ({ page }) => {
+    await mockChatRun(page);
+  });
+  test.afterEach(async ({ page }) => {
+    await unmockAll(page);
+  });
+
+  test('first question carries the trigger; follow-up is sent verbatim', async ({ page }) => {
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}&file=doc.md`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 5_000 });
+
+    // Open qa mode (💬问答).
+    await page.locator('[data-testid="kb-btn-ask"]').click();
+    const panel = page.locator('[data-testid="kb-chat-panel"]');
+    await expect(panel).toBeVisible();
+    const input = panel.locator('[data-testid="composer-input"]');
+
+    // ── Turn 1: create-run request must carry the wiki-query trigger ──
+    const createRunReq = page.waitForRequest(
+      (req) => req.url().includes('/api/runs')
+        && req.method() === 'POST'
+        && !req.url().includes('/messages'),
+      { timeout: 10_000 },
+    );
+    await input.fill('First question');
+    await input.press('Enter');
+
+    const firstBody = (await createRunReq).postDataJSON();
+    expect(firstBody.message).toContain('知识库问答');
+    expect(firstBody.message).toContain('wiki-query');
+    expect(firstBody.message).toContain('First question');
+    // Trigger phrase is a prefix — agent sees the directive before the question.
+    expect(firstBody.message.indexOf('知识库问答')).toBeLessThan(firstBody.message.indexOf('First question'));
+
+    // Wait for turn 1 to finish (mock SSE turn_end → input unlocks).
+    await expect(panel.locator('[data-testid="assistant-prose"]')).toBeVisible({ timeout: 10_000 });
+    await expect(input).toBeEnabled({ timeout: 10_000 });
+
+    // ── Turn 2: multi-turn follow-up must NOT carry the trigger ──
+    const followUpReq = page.waitForRequest(
+      (req) => req.url().includes('/messages') && req.method() === 'POST',
+      { timeout: 10_000 },
+    );
+    await input.fill('Follow-up question');
+    await input.press('Enter');
+
+    const secondBody = (await followUpReq).postDataJSON();
+    expect(secondBody.message).toContain('Follow-up question');
+    expect(secondBody.message).not.toContain('知识库问答');
+    expect(secondBody.message).not.toContain('wiki-query');
+  });
+});

--- a/apps/web/src/hooks/useKbChat.ts
+++ b/apps/web/src/hooks/useKbChat.ts
@@ -18,9 +18,12 @@ function WIKI_INGEST_PROMPT(filePath: string, isDirectory = false): string {
 }
 
 /**
- * qa 模式确定性触发：KB 问答面板里用户输入的每条消息都是知识库问题，包一层显式
- * 触发语，确保 agent 走 wiki-query skill 检索而非凭记忆作答。前缀刻意写短，使其
- * 对首轮提问和多轮 follow-up（「再详细点」「继续」）都自然适用。
+ * qa 模式确定性触发：KB 问答面板里用户输入的问题是知识库问题，包一层显式触发语，
+ * 确保 agent 走 wiki-query skill 检索而非凭记忆作答。
+ *
+ * 只在会话首轮包裹（见 send）：后续多轮 follow-up（「再详细点」「继续」）的上下文
+ * 里已经有首轮触发语 + agent 正在执行的 wiki-query 流程，每轮重复包裹只会让消息都
+ * 顶着「（知识库问答：…）」前缀、污染对话历史。
  *
  * 这是主界面的双保险——vault 的 .claude/CLAUDE.md 还有一条常驻 wiki-query 规则
  * （skill-installer 注入）覆盖通用/微信场景；此处针对专用 KB 问答面板再加确定性触发。
@@ -150,10 +153,13 @@ export function useKbChat(opts: UseKbChatOptions): KbChatState {
   }, [reset]);
 
   // qa 模式：用户自由输入且必为知识库问题 → 包显式 wiki-query 触发语（确定性触发）。
+  // 仅会话首轮包裹：conversationIdRef 在新会话（初始 / reset 后）为 null，首轮
+  // createRun 成功后置位——之后发出的消息都是同一会话的多轮 follow-up，不再包裹。
   // 其它 mode（build/lint/ingest）的自动发送走各自 prompt，用户在这些 mode 手输的
   // 消息按原样发出，不改写。
   const send = useCallback((text: string) => {
-    chat.send(mode === 'qa' ? WIKI_QUERY_TRIGGER(text) : text);
+    const isFirstTurn = conversationIdRef.current == null;
+    chat.send(mode === 'qa' && isFirstTurn ? WIKI_QUERY_TRIGGER(text) : text);
   }, [chat, mode]);
 
   return {


### PR DESCRIPTION
## 问题

知识管理侧边栏问答面板中，每一轮对话都会带上「（知识库问答：请用 wiki-query skill，先读 wiki/INDEX.md 检索相关页面再回答，不要凭训练记忆作答）」前缀。实际上只需首轮带——多轮 follow-up（「再详细点」「继续」）已有首轮上下文，agent 正在 wiki-query 流程中，且 vault `.claude/CLAUDE.md` 有常驻 wiki-query 规则兜底；每轮重复包裹只会污染对话历史。

## 改动

- `apps/web/src/hooks/useKbChat.ts`：`send` 仅在 `mode === 'qa'` 且 `conversationIdRef.current == null`（新会话首轮）时包裹 `WIKI_QUERY_TRIGGER`。`conversationIdRef` 在初始 / `reset()`（关面板、构建、ingest）后为 null，首轮 `createRun` 成功后置位——恰好是会话生命周期边界。
- `apps/web/e2e/kb-qa-trigger.spec.ts`（新，P1）：用 `mockChatRun` 在网络层断言首轮 `POST /api/runs` message 含触发语（且前缀在问题之前）、多轮 `POST /api/runs/:id/messages` 为用户原文不含触发语。
- `apps/web/e2e/area-map.json`：kb 区 paths 补 `useKbChat*`，注册新 spec。

## 验证

- 新 spec 在旧行为下确认失败（第二轮 message 仍带触发语），修复后通过
- `kb-qa-trigger` + `kb-chat-entry` + `chat-multi` 共 11 项 E2E 全绿
- `@molio/web` typecheck 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)