### PR TITLE
feat(daemon): 飞书回复改用 interactive card 渲染 Markdown

### DIFF
--- a/apps/daemon/CLAUDE.md
+++ b/apps/daemon/CLAUDE.md
@@ -57,7 +57,8 @@ src/
       service.ts       微信服务编排（implements ChannelSink）
       types.ts         微信类型定义
     feishu/
-      client.ts        Lark REST API 包装 (tenant_access_token、im/v1 消息收发)
+      client.ts        Lark REST API 包装 (tenant_access_token、im/v1 消息收发：text/interactive card/image/file 共享 postMessage)
+      card.ts          buildMarkdownCard — JSON 2.0 interactive 卡片（markdown 元素），回复包成卡片渲染 Markdown，发送失败降级纯文本
       ws-client.ts     WebSocket 长连接 — 接收 im.message.receive_v1 事件
       message.ts       事件 payload 解析 → ParsedFeishuMessage
       media.ts         图片/文件下载到 raw/feishu/<date>/

--- a/apps/daemon/src/core/feishu/card.ts
+++ b/apps/daemon/src/core/feishu/card.ts
@@ -1,0 +1,35 @@
+/**
+ * Feishu interactive card (JSON 2.0) builder.
+ *
+ * Agent replies are Markdown, but `msg_type: 'text'` messages render none of
+ * it — users see raw `#` / `**` / ``` symbols. Wrapping the text in a card
+ * with a `markdown` body element makes Feishu render headings, lists, code
+ * blocks, links and images (CommonMark 0.31 + GFM subset; no HTML; tables
+ * paginate at 5 rows).
+ * See https://open.feishu.cn/document/feishu-cards/card-json-v2-breaking-changes-release-notes
+ */
+
+/** Card JSON 2.0 with a single markdown body element. `elements` is typed as
+ * a one-element tuple: we always emit exactly one element, and the tuple lets
+ * `elements[0]` stay non-optional under noUncheckedIndexedAccess. */
+export interface FeishuCard {
+  schema: '2.0';
+  body: {
+    elements: [{ tag: 'markdown'; content: string }];
+  };
+}
+
+/**
+ * Wrap Markdown text in a minimal JSON 2.0 card. Deliberately no header —
+ * placeholder texts like "Molio 正在处理..." share this send path, and a
+ * titled header on every message would be noise.
+ *
+ * Card request bodies cap at 30KB (Feishu error 300300); callers chunk the
+ * text before wrapping (see `TEXT_CHUNK_LIMIT` in service.ts).
+ */
+export function buildMarkdownCard(markdown: string): FeishuCard {
+  return {
+    schema: '2.0',
+    body: { elements: [{ tag: 'markdown', content: markdown }] },
+  };
+}

--- a/apps/daemon/src/core/feishu/client.ts
+++ b/apps/daemon/src/core/feishu/client.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import type { FeishuCard } from './card.js';
 import type { FeishuCredentials } from './types.js';
 
 /**
@@ -98,26 +99,17 @@ export class FeishuApi {
    * on success; throws on API error.
    */
   async sendText(tenantAccessToken: string, openId: string, text: string): Promise<string> {
-    const url = `${ensureTrailingSlash(this.baseUrl)}open-apis/im/v1/messages?receive_id_type=open_id`;
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${tenantAccessToken}`,
-      },
-      body: JSON.stringify({
-        receive_id: openId,
-        msg_type: 'text',
-        content: JSON.stringify({ text }),
-      }),
-    });
-    const body = await readJson(res);
-    const code = Number(body.code ?? 0);
-    if (code !== 0) {
-      throw new Error(`Feishu sendText failed: ${feishuErrMessage(body, String(code))}`);
-    }
-    const msgId = (body.data as { message_id?: string } | undefined)?.message_id;
-    return typeof msgId === 'string' ? msgId : '';
+    return this.postMessage(tenantAccessToken, openId, 'text', { text }, 'sendText');
+  }
+
+  /**
+   * Send an interactive card (JSON 2.0) to a user. Feishu renders the card's
+   * markdown element, so agent Markdown output shows up formatted instead of
+   * raw symbols. Same endpoint and permissions as `sendText`; throws on API
+   * error (e.g. 300300 = card request body exceeds 30KB).
+   */
+  async sendCard(tenantAccessToken: string, openId: string, card: FeishuCard): Promise<string> {
+    return this.postMessage(tenantAccessToken, openId, 'interactive', card, 'sendCard');
   }
 
   /** Upload an image file (multipart) and return the `image_key`. */
@@ -188,6 +180,22 @@ export class FeishuApi {
     msgType: 'image' | 'file',
     content: Record<string, string>,
   ): Promise<string> {
+    return this.postMessage(tenantAccessToken, openId, msgType, content, `send${msgType}`);
+  }
+
+  /**
+   * Shared POST to `im/v1/messages` — sendText / sendCard / sendMedia all hit
+   * this endpoint with only `msg_type` and `content` differing. Per Feishu's
+   * double-encoding contract the outer request body is JSON and the `content`
+   * field is itself a JSON string, hence the nested `JSON.stringify`.
+   */
+  private async postMessage(
+    tenantAccessToken: string,
+    openId: string,
+    msgType: 'text' | 'image' | 'file' | 'interactive',
+    content: unknown,
+    opName: string,
+  ): Promise<string> {
     const url = `${ensureTrailingSlash(this.baseUrl)}open-apis/im/v1/messages?receive_id_type=open_id`;
     const res = await fetch(url, {
       method: 'POST',
@@ -204,7 +212,7 @@ export class FeishuApi {
     const body = await readJson(res);
     const code = Number(body.code ?? 0);
     if (code !== 0) {
-      throw new Error(`Feishu send${msgType} failed: ${feishuErrMessage(body, String(code))}`);
+      throw new Error(`Feishu ${opName} failed: ${feishuErrMessage(body, String(code))}`);
     }
     const msgId = (body.data as { message_id?: string } | undefined)?.message_id;
     return typeof msgId === 'string' ? msgId : '';

--- a/apps/daemon/src/core/feishu/service.ts
+++ b/apps/daemon/src/core/feishu/service.ts
@@ -13,6 +13,7 @@ import { MessageDedup } from '../channels/message-dedup.js';
 import { chunkText } from '../channels/text-chunker.js';
 import { getVaultByPath } from '../db.js';
 import { FEISHU_SYS_PROMPT_FILE } from '../wiki-prompts.js';
+import { buildMarkdownCard } from './card.js';
 import { DEFAULT_BASE_URL, FeishuApi } from './client.js';
 import { FeishuWSClient } from './ws-client.js';
 import { FeishuTokenStore } from './token-store.js';
@@ -33,7 +34,10 @@ const DEDUP_TTL_MS = 7 * 60 * 60 * 1000;
 /** Hard cap on the dedup map so a quiet-but-long-lived process can't leak
  * memory indefinitely. 7h TTL means ~10k entries at 1 msg/s sustained. */
 const DEDUP_MAX_ENTRIES = 10_000;
-/** Chunk size for sendText — Feishu's text limit is 4096 bytes; use 3000 chars for safety. */
+/** Chunk size for sendText — Feishu's text limit is 4096 bytes; use 3000
+ * chars for safety. Cards allow ~30KB per request, but replies are chunked at
+ * the text limit anyway: when card sending fails we fall back to plain text,
+ * which must stay within the 4096-byte bound without a separate chunk size. */
 const TEXT_CHUNK_LIMIT = 3000;
 
 const FEISHU_CHANNEL_PREFIX = 'feishu';
@@ -391,10 +395,18 @@ export class FeishuService implements ChannelSink {
     try {
       const token = await this.tokenStore.getToken();
       for (const chunk of chunkText(text, TEXT_CHUNK_LIMIT)) {
-        await this.api.sendText(token, toUserId, chunk);
+        try {
+          // Interactive card: Feishu renders the markdown element, so agent
+          // replies show up formatted instead of raw Markdown symbols.
+          await this.api.sendCard(token, toUserId, buildMarkdownCard(chunk));
+        } catch {
+          // Card rejected (ancient Feishu client / transient card-service
+          // hiccup) — fall back to plain text so the user never loses a reply.
+          await this.api.sendText(token, toUserId, chunk);
+        }
       }
     } catch (err) {
-      this.status.lastError = `发送文本失败：${err instanceof Error ? err.message : String(err)}`;
+      this.status.lastError = `发送消息失败：${err instanceof Error ? err.message : String(err)}`;
     }
   }
 

--- a/apps/daemon/test/core/feishu/card.test.ts
+++ b/apps/daemon/test/core/feishu/card.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildMarkdownCard } from '../../../src/core/feishu/card.js';
+
+describe('buildMarkdownCard', () => {
+  it('produces a JSON 2.0 card with a single markdown body element', () => {
+    const card = buildMarkdownCard('hello **world**');
+    assert.equal(card.schema, '2.0');
+    assert.equal(card.body.elements.length, 1);
+    assert.equal(card.body.elements[0].tag, 'markdown');
+    assert.equal(card.body.elements[0].content, 'hello **world**');
+  });
+
+  it('passes markdown through verbatim (no escaping or trimming)', () => {
+    const md = '# 标题\n\n- 列表项\n\n```js\nconsole.log("hi")\n```\n';
+    const card = buildMarkdownCard(md);
+    assert.equal(card.body.elements[0].content, md);
+  });
+
+  it('serializes to valid JSON that round-trips losslessly', () => {
+    // Quotes, backslashes, newlines, tabs, CJK and emoji are exactly what
+    // agent output contains — JSON.stringify must escape them and parse must
+    // recover the original string byte-for-byte.
+    const md = '引号 " 反斜杠 \\ 换行\n制表\t中文 🚀 `code` [链接](https://x.cn)';
+    const parsed = JSON.parse(JSON.stringify(buildMarkdownCard(md)));
+    assert.equal(parsed.schema, '2.0');
+    assert.equal(parsed.body.elements[0].tag, 'markdown');
+    assert.equal(parsed.body.elements[0].content, md);
+  });
+
+  it('keeps empty markdown empty (placeholder texts stay valid cards)', () => {
+    const card = buildMarkdownCard('');
+    assert.equal(card.body.elements[0].content, '');
+  });
+});

--- a/apps/daemon/test/core/feishu/client.test.ts
+++ b/apps/daemon/test/core/feishu/client.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { buildMarkdownCard } from '../../../src/core/feishu/card.js';
 import { FeishuApi } from '../../../src/core/feishu/client.js';
 
 /**
@@ -95,5 +96,83 @@ describe('FeishuApi upload size guard', () => {
     const fileKey = await api.uploadFile('tok', smallFile, 100); // 50 < 100
     assert.equal(fileKey, 'file_x');
     assert.equal(counter.callCount, 1);
+  });
+});
+
+describe('FeishuApi message sending (postMessage)', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  /** Mock im/v1/messages and capture every request body for assertions. */
+  function mockMessagesEndpoint(
+    response: Record<string, unknown> = { code: 0, data: { message_id: 'om_msg_x' } },
+  ): { bodies: Array<Record<string, unknown>> } {
+    const captured = { bodies: [] as Array<Record<string, unknown>> };
+    globalThis.fetch = (async (_url: URL | string, init?: RequestInit) => {
+      captured.bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    return captured;
+  }
+
+  it('sendText posts msg_type=text and returns message_id (refactor regression)', async () => {
+    const captured = mockMessagesEndpoint();
+    const api = new FeishuApi('https://open.feishu.cn', 'cli_x', 'sec_x');
+    const msgId = await api.sendText('tok', 'ou_user', 'hello');
+    assert.equal(msgId, 'om_msg_x');
+    assert.equal(captured.bodies.length, 1);
+    const body = captured.bodies[0]!;
+    assert.equal(body.receive_id, 'ou_user');
+    assert.equal(body.msg_type, 'text');
+    assert.deepEqual(JSON.parse(String(body.content)), { text: 'hello' });
+  });
+
+  it('sendCard posts msg_type=interactive with the card JSON-stringified into content', async () => {
+    const captured = mockMessagesEndpoint();
+    const api = new FeishuApi('https://open.feishu.cn', 'cli_x', 'sec_x');
+    const msgId = await api.sendCard('tok', 'ou_user', buildMarkdownCard('# T\n**bold**'));
+    assert.equal(msgId, 'om_msg_x');
+    assert.equal(captured.bodies.length, 1);
+    const body = captured.bodies[0]!;
+    assert.equal(body.receive_id, 'ou_user');
+    assert.equal(body.msg_type, 'interactive');
+    assert.deepEqual(JSON.parse(String(body.content)), {
+      schema: '2.0',
+      body: { elements: [{ tag: 'markdown', content: '# T\n**bold**' }] },
+    });
+  });
+
+  it('sendCard sends the Authorization header with the tenant token', async () => {
+    let authHeader = '';
+    globalThis.fetch = (async (_url: URL | string, init?: RequestInit) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      authHeader = headers.Authorization ?? '';
+      return new Response(JSON.stringify({ code: 0, data: { message_id: 'om_x' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    const api = new FeishuApi('https://open.feishu.cn', 'cli_x', 'sec_x');
+    await api.sendCard('tok_abc', 'ou_user', buildMarkdownCard('x'));
+    assert.equal(authHeader, 'Bearer tok_abc');
+  });
+
+  it('sendCard throws a typed error carrying Feishu msg on non-zero code', async () => {
+    mockMessagesEndpoint({ code: 300300, msg: 'card size exceeds 30KB' });
+    const api = new FeishuApi('https://open.feishu.cn', 'cli_x', 'sec_x');
+    await assert.rejects(
+      () => api.sendCard('tok', 'ou_user', buildMarkdownCard('x')),
+      /sendCard failed: card size exceeds 30KB/,
+    );
   });
 });

--- a/apps/daemon/test/core/feishu/service.test.ts
+++ b/apps/daemon/test/core/feishu/service.test.ts
@@ -220,4 +220,89 @@ describe('FeishuService', () => {
         .handleRawMessage(event);
     });
   });
+
+  describe('sendText — interactive card first, plain-text fallback', () => {
+    interface FakeApiRecorder {
+      cardChunks: string[];
+      textChunks: string[];
+    }
+
+    /**
+     * Inject a fake api + tokenStore into the service's private fields (same
+     * cast pattern as the start(force) tests above). `failCard` / `failText`
+     * make the respective send path throw to exercise the fallback chain.
+     */
+    function injectFakeApi(
+      svc: FeishuService,
+      opts: { failCard?: boolean; failText?: boolean } = {},
+    ): FakeApiRecorder {
+      const rec: FakeApiRecorder = { cardChunks: [], textChunks: [] };
+      const s = svc as unknown as {
+        api: unknown;
+        tokenStore: {
+          getToken: () => Promise<string>;
+          startRefresh: () => void;
+          stopRefresh: () => void;
+          invalidate: () => void;
+        };
+      };
+      s.api = {
+        sendCard: async (
+          _tok: string,
+          _openId: string,
+          card: { body: { elements: [{ content: string }] } },
+        ) => {
+          if (opts.failCard) throw new Error('card rejected');
+          rec.cardChunks.push(card.body.elements[0].content);
+          return 'om_card';
+        },
+        sendText: async (_tok: string, _openId: string, text: string) => {
+          if (opts.failText) throw new Error('text rejected');
+          rec.textChunks.push(text);
+          return 'om_text';
+        },
+      };
+      // stop() in the outer afterEach calls tokenStore.stopRefresh() +
+      // invalidate() — the fake must provide the full surface or teardown throws.
+      s.tokenStore = {
+        getToken: async () => 'tok',
+        startRefresh: () => {},
+        stopRefresh: () => {},
+        invalidate: () => {},
+      };
+      return rec;
+    }
+
+    it('sends short markdown text as one card, no plain-text call', async () => {
+      const rec = injectFakeApi(service);
+      await service.sendText('ou_user', '# 标题\n**正文**');
+      assert.deepEqual(rec.cardChunks, ['# 标题\n**正文**']);
+      assert.equal(rec.textChunks.length, 0);
+      assert.equal(service.getStatus().lastError, null);
+    });
+
+    it('falls back to plain text when card sending fails', async () => {
+      const rec = injectFakeApi(service, { failCard: true });
+      await service.sendText('ou_user', 'hello');
+      assert.equal(rec.cardChunks.length, 0, 'failed card is not recorded');
+      assert.deepEqual(rec.textChunks, ['hello'], 'same chunk must go out as plain text');
+      assert.equal(service.getStatus().lastError, null, 'successful fallback is not an error');
+    });
+
+    it('records lastError without throwing when both card and text fail', async () => {
+      injectFakeApi(service, { failCard: true, failText: true });
+      await service.sendText('ou_user', 'hello'); // must not throw
+      assert.match(service.getStatus().lastError ?? '', /发送消息失败/);
+    });
+
+    it('chunks long text into multiple cards (>3000 chars → 2 cards)', async () => {
+      const rec = injectFakeApi(service);
+      const long = 'a'.repeat(5000); // no paragraph/line breaks → hard cut at 3000
+      await service.sendText('ou_user', long);
+      assert.equal(rec.cardChunks.length, 2);
+      assert.equal(rec.cardChunks[0]?.length, 3000);
+      assert.equal(rec.cardChunks[1]?.length, 2000);
+      assert.equal(rec.textChunks.length, 0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- 飞书渠道回复改用 **interactive 消息卡片**（卡片 JSON 2.0 + markdown 元素）。此前用 `msg_type: text` 纯文本发送，飞书不渲染 Markdown，用户收到的 agent 回复全是 `#`、`**`、\`\`\` 等原始符号（用户反馈的 "raw data" 问题）。改为卡片后标题/列表/代码块/链接正常渲染。
- **发送失败自动降级纯文本**（极老客户端/卡片服务异常），逐 chunk 降级，回复不会丢。
- `client.ts` 抽出共享 `postMessage`：sendText / sendCard / sendImage / sendFile 复用同一个 `im/v1/messages` 发送路径；新增 `sendCard(msg_type=interactive)`。**无需新增飞书权限**。
- `ChannelSink` 接口不变，weixin 渠道零感知；dispatcher 的占位文本（"Molio 正在处理..."）与最终回复统一走卡片。
- 切块上限保持 3000 字符：卡片允许 ~30KB，但降级纯文本受 4096 字节限制，统一上限避免二次切分。

## 官方文档依据

- [发送消息内容结构](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json?lang=zh-CN)（msg_type=interactive）
- [卡片 JSON 2.0 富文本（Markdown）组件](https://open.feishu.cn/document/feishu-cards/card-components/content-components/rich-text?lang=zh-CN)：CommonMark 0.31 + GFM 子集；不支持 HTML；表格 5 行分页
- 卡片请求体上限 30KB（错误码 300300）；3000 字符 chunk 包成卡片 ≈10KB，余量充足

## Test plan

- [x] 新增 12 个测试：`card.test.ts`（结构 + JSON 序列化往返 + 空文本）、`client.test.ts`（请求体 msg_type/content 断言、Auth 头、300300 错误码、sendText 回归）、`service.test.ts`（卡片优先、降级纯文本、双失败记 lastError、长文本分块）
- [x] daemon 809 测试：797 pass / 3 skip；fail+cancelled 仅为 `hermes-acp-integration` 的既有本地超时问题（已在干净 main 上复现，与本 PR 无关）
- [x] typecheck 全绿
- [ ] 手动验证：打包启动 → 飞书发一条会产出 markdown 的提问 → 确认"正在处理"占位与最终回复均为渲染卡片

## 后续（不在本 PR）

- 二期可做卡片流式更新：先发占位卡片，`PATCH /im/v1/messages/:id` 边生成边更新（5 QPS 频控），标准 AI bot 体验