### PR TITLE
fix(web): 从 Excel 粘贴文字时不再变成图片附件

### DIFF
--- a/apps/web/e2e/image-paste.spec.ts
+++ b/apps/web/e2e/image-paste.spec.ts
@@ -115,6 +115,152 @@ test.describe('Composer image paste', () => {
     await expect(composer).toHaveValue('Hello, world!');
   });
 
+  test('pasting Excel-style clipboard (text + html + bitmap) inserts text, no attachment', async ({
+    page,
+  }) => {
+    // Excel puts text/plain + text/html AND a rendered bitmap on the clipboard
+    // at once. The handler must prefer the text payload: no preventDefault (so
+    // the browser inserts the text) and no upload request.
+    await page.route('**/api/knowledge/vaults', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          json: {
+            vaults: [
+              {
+                id: TEST_VAULT_ID,
+                name: 'E2E Image Paste Vault',
+                path: '/tmp/e2e-image-paste-vault',
+                fileCount: 0,
+                createdAt: Date.now(),
+              },
+            ],
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    let uploadCalls = 0;
+    await page.route(
+      `**/api/knowledge/vaults/${TEST_VAULT_ID}/assets/upload`,
+      async (route) => {
+        uploadCalls++;
+        await route.fulfill({ json: { filePath: UPLOADED_FILE_PATH, url: '/unused' } });
+      },
+    );
+
+    await gotoHome(page);
+    await page.reload({ waitUntil: 'networkidle' });
+
+    const composer = page.locator('[data-testid="composer-input"]');
+    await expect(composer).toBeVisible();
+
+    const defaultPrevented = await composer.evaluate((el) => {
+      const pngBytes = new Uint8Array([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+        0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00,
+        0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0x68, 0x00, 0x00, 0x00,
+        0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+      ]);
+      const file = new File([new Blob([pngBytes], { type: 'image/png' })], 'excel-bitmap.png', {
+        type: 'image/png',
+      });
+      const dt = new DataTransfer();
+      dt.setData('text/plain', 'A1\tB1\nA2\tB2');
+      dt.setData('text/html', '<table><tr><td>A1</td><td>B1</td></tr></table>');
+      dt.items.add(file);
+      el.focus();
+      const ev = new ClipboardEvent('paste', {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(ev);
+      return ev.defaultPrevented;
+    });
+
+    // Not prevented → the browser performs the default action (insert text)
+    expect(defaultPrevented).toBe(false);
+
+    // No thumbnail, no upload request
+    await expect(page.locator('[data-testid="composer-image-thumb"]')).toHaveCount(0);
+    expect(uploadCalls).toBe(0);
+  });
+
+  test('pasting an image file path from Explorer still attaches the image', async ({ page }) => {
+    // Copying a file in Explorer puts the file path in text/plain alongside
+    // the file itself — that case must still attach, not insert the path.
+    await page.route('**/api/knowledge/vaults', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          json: {
+            vaults: [
+              {
+                id: TEST_VAULT_ID,
+                name: 'E2E Image Paste Vault',
+                path: '/tmp/e2e-image-paste-vault',
+                fileCount: 0,
+                createdAt: Date.now(),
+              },
+            ],
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route(
+      `**/api/knowledge/vaults/${TEST_VAULT_ID}/assets/upload`,
+      async (route) => {
+        await route.fulfill({
+          json: {
+            filePath: UPLOADED_FILE_PATH,
+            url: `/api/knowledge/vaults/${TEST_VAULT_ID}/raw/.molio/assets/e2e-test-1.png`,
+          },
+        });
+      },
+    );
+
+    await gotoHome(page);
+    await page.reload({ waitUntil: 'networkidle' });
+
+    const composer = page.locator('[data-testid="composer-input"]');
+    await expect(composer).toBeVisible();
+
+    await composer.evaluate((el) => {
+      const pngBytes = new Uint8Array([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+        0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00,
+        0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0x68, 0x00, 0x00, 0x00,
+        0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+      ]);
+      const file = new File([new Blob([pngBytes], { type: 'image/png' })], 'shot.png', {
+        type: 'image/png',
+      });
+      const dt = new DataTransfer();
+      dt.setData('text/plain', 'C:\\Users\\test\\Pictures\\shot.png');
+      dt.items.add(file);
+      el.focus();
+      el.dispatchEvent(
+        new ClipboardEvent('paste', {
+          clipboardData: dt,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    await expect(page.locator('[data-testid="composer-image-thumb"]')).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
   test('upload button opens file picker', async ({ page }) => {
     await gotoHome(page);
     await page.reload({ waitUntil: 'networkidle' });

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -260,19 +260,37 @@ export function ChatComposer({
   // Handle image paste (Ctrl+V / Cmd+V)
   const handlePaste = useCallback(
     async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      const items = e.clipboardData?.items;
-      if (!items) return;
+      const dt = e.clipboardData;
+      if (!dt?.items) return;
 
+      const items = dt.items;
+
+      // Collect image payloads first — a paste without any image item is a
+      // plain text paste and needs no special handling.
+      const imageFiles: File[] = [];
       for (let i = 0; i < items.length; i++) {
         const item = items[i];
         if (!item || !item.type.startsWith('image/')) continue;
-
-        e.preventDefault();
         const file = item.getAsFile();
-        if (!file) continue;
-
-        uploadImage(file);
+        if (file) imageFiles.push(file);
       }
+      if (imageFiles.length === 0) return;
+
+      // Office apps (Excel / Word / PPT) put the text/HTML payload AND a
+      // rendered bitmap of the selection on the clipboard at the same time.
+      // Prefer the text payload so pasting cells inserts text instead of
+      // attaching a screenshot of them. Only treat the paste as an image
+      // when there is no usable text (e.g. a screenshot tool), or when the
+      // "text" is merely the path of an image file (copying a file in
+      // Explorer still attaches it).
+      const plain = dt.getData('text/plain').trim();
+      const hasHtml = dt.getData('text/html').trim().length > 0;
+      const looksLikeImagePath =
+        plain.length > 0 && !plain.includes('\n') && /\.(png|jpe?g|gif|webp)$/i.test(plain);
+      if ((plain.length > 0 || hasHtml) && !looksLikeImagePath) return;
+
+      e.preventDefault();
+      for (const file of imageFiles) uploadImage(file);
     },
     [uploadImage],
   );


### PR DESCRIPTION
## 问题

从 Excel 复制单元格文字（Ctrl+C），粘贴到 Molio 输入框（Ctrl+V）时，文字变成一张图片附件。

**原因**：Excel 复制时剪贴板同时携带三种载荷——`text/plain`（TSV 文本）、`text/html`（表格 HTML）、`image/png`（选区渲染位图）。旧的 `handlePaste` 遍历 clipboard items，命中 `image/*` 即无条件 `preventDefault()` 并上传附件，文本载荷被丢弃。

## 修复

`apps/web/src/components/ChatComposer.tsx` 的 `handlePaste` 改为**文本优先**：

- 剪贴板有可用文本载荷（`text/plain` 或 `text/html` 非空）→ 不拦截，浏览器执行默认文本插入（Excel / Word / PPT 场景恢复正常）
- 无文本的纯图片粘贴 → 仍作为图片附件（截图工具行为不变）
- 例外保留：资源管理器复制图片文件时 `text/plain` 是单行图片路径（`.png/.jpg/.gif/.webp`），仍走附件，避免行为退化

## 测试

`apps/web/e2e/image-paste.spec.ts` 新增 2 个回归用例（错误驱动测试）：

- Excel 式粘贴（text + html + bitmap 共存）→ 断言 `defaultPrevented === false`、无缩略图、upload API 零调用
- Explorer 文件路径粘贴（text/plain = 路径 + 图片文件）→ 仍出现图片缩略图

验证结果：

| 检查项 | 结果 |
|---|---|
| `pnpm typecheck` | ✅ 全绿 |
| `image-paste.spec.ts` | ✅ 5/5 |
| 全量 E2E | ✅ 186 passed / 8 skipped；`kb-doc-context-menu.spec.ts` 3 个失败为存量问题（在干净 main 上 stash 验证同样失败，与本 PR 无关） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)