### PR TITLE
fix(ci): OCR extra_body 默认空 — 思考模型拒绝强制关思考导致审查全失败

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -14,6 +14,10 @@
 # Optional secrets:
 #   OCR_LLM_MODEL         - Model name (default: gpt-4o)
 #   OCR_LLM_USE_ANTHROPIC - Set to 'true' if using Anthropic Claude models
+#   OCR_LLM_EXTRA_BODY    - JSON extra_body override. Defaults to {} (no override).
+#                           Set e.g. {"thinking":{"type":"disabled"}} only for models
+#                           that need it — thinking models (qwen3 etc.) reject a forced
+#                           disabled-thinking config with HTTP 400.
 #
 # Optional variables (for retry/delay tuning, see retry strategy in the post-comments step):
 #   OCR_RETRY_BASE_DELAY, OCR_RETRY_MAX_DELAY, OCR_MAX_RETRIES,
@@ -100,7 +104,16 @@ jobs:
           if [ -n "${{ secrets.OCR_LLM_USE_ANTHROPIC }}" ]; then
             ocr config set llm.use_anthropic "${{ secrets.OCR_LLM_USE_ANTHROPIC }}"
           fi
-          ocr config set llm.extra_body '{"thinking": {"type": "disabled"}}'
+          # extra_body defaults to empty so models that reject a forced thinking
+          # config (e.g. qwen3 thinking models, which require enable_thinking=True)
+          # work out of the box. Override via OCR_LLM_EXTRA_BODY for models that need
+          # explicit JSON. Previously hardcoded to {"thinking":{"type":"disabled"}},
+          # which returned HTTP 400 on every file for such models.
+          if [ -n "${{ secrets.OCR_LLM_EXTRA_BODY }}" ]; then
+            ocr config set llm.extra_body '${{ secrets.OCR_LLM_EXTRA_BODY }}'
+          else
+            ocr config set llm.extra_body '{}'
+          fi
 
       - name: Run OpenCodeReview
         id: review


### PR DESCRIPTION
## Summary
- OCR 自动审查对所有 PR「all N file review(s) failed」。根因：`ocr-review.yml` 写死 `extra_body '{"thinking":{"type":"disabled"}}'`，而思考模型（如 qwen3.8-max-preview，阿里云 MaaS 的 Anthropic 兼容端点）强制 `enable_thinking=True`，每个文件都被 HTTP 400 打回。
- 改为默认 `{}`（不注入 thinking 配置），并新增可选 secret `OCR_LLM_EXTRA_BODY` 供确需关思考的模型覆盖。
- 配套需设置 `OCR_LLM_USE_ANTHROPIC=true`（该端点是 Anthropic 协议）。

## 验证
- 本地 `ocr llm test` 对 qwen3.8-max-preview 端点连通成功（extra_body={} + use_anthropic=true）。
- 本地完整跑通对本仓库一个 PR 的 review，产出真实审查意见。

## Test plan
- [ ] 合并后在任一 PR 发 `/open-code-review`，确认贴出真实审查意见而非报错