### PR TITLE
fix(build): 更新 electron / electron-builder 二进制镜像地址

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 registry=https://registry.npmmirror.com
-electron_mirror=https://npmmirror.com/mirrors/electron/
+# Electron 二进制下载镜像（新地址，旧地址 npmmirror.com/mirrors/electron/ 已不稳定，下载会超时）
+electron_mirror=https://registry.npmmirror.com/-/binary/electron/
+# electron-builder 打包时所需二进制（如 nsis、winCodeSign）的镜像，避免 pnpm package 时下载超时
+electron_builder_binaries_mirror=https://registry.npmmirror.com/-/binary/electron-builder-binaries/


### PR DESCRIPTION
## 背景
旧 `electron_mirror`（`npmmirror.com/mirrors/electron/`）已不稳定，下载 Electron 二进制常超时，影响本地打包 / CI 打包。

## 改动（仅 `.npmrc`）
- `electron_mirror` → `https://registry.npmmirror.com/-/binary/electron/`（新可用地址）
- 新增 `electron_builder_binaries_mirror` → `https://registry.npmmirror.com/-/binary/electron-builder-binaries/`，避免 `pnpm package` 时下载 nsis / winCodeSign 等 electron-builder 二进制超时。

## 影响面
仅打包/安装期镜像配置，不动任何运行时代码；`registry`（npm 包源）不变。

## 验证
- 配置项为 electron / electron-builder 官方认可的镜像变量名。
- 建议合并前在本机或 CI 跑一次 `pnpm package`（或触发 release 流程的下载步骤）确认两个镜像可达、不再超时。

> 与预下载功能（#178）无关，独立提交以便快速合并、不互相阻塞。

🤖 Generated with [Claude Code](https://claude.com/claude-code)