### PR TITLE
docs(landing): 下载页/FAQ 改为麒麟/NAS/Linux Docker 自建部署口径

### DIFF
--- a/apps/landing-page/download.html
+++ b/apps/landing-page/download.html
@@ -7,7 +7,7 @@
 
 <!-- SEO -->
 <title>Molio 下载 — 桌面客户端与浏览器扩展</title>
-<meta name="description" content="下载 Molio 桌面客户端（Windows / macOS）及 COSE、Molio Connect Chrome 扩展离线安装包。国内用户可直接下载离线包。">
+<meta name="description" content="下载 Molio 桌面客户端（Windows / macOS）及 COSE、Molio Connect Chrome 扩展离线安装包；麒麟、统信 UOS、NAS、Linux 等系统可通过 Docker 一键自建部署。国内用户可直接下载离线包。">
 <meta name="keywords" content="Molio 下载,Claude Code GUI,本地知识库,Web Clipper,Obsidian 替代">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://molio.cn/download.html">
@@ -43,7 +43,7 @@
   "@type": "SoftwareApplication",
   "name": "Molio 墨流",
   "applicationCategory": "KnowledgeManagementApplication",
-  "operatingSystem": "Windows, macOS",
+  "operatingSystem": "Windows, macOS, Linux (Docker)",
   "description": "兼容 Obsidian Vault 的本地知识库，内置 Claude Code 图形界面、微信 AI 助手和 Chrome Web Clipper。",
   "url": "https://molio.cn/download.html",
   "offers": {
@@ -95,15 +95,33 @@
         <a id="mac-download" href="https://molio-releases.oss-cn-guangzhou.aliyuncs.com/releases/v0.3.29/Molio-0.3.29-mac-arm64.dmg" class="download-btn primary">下载 macOS 版</a>
       </div>
     </div>
-    <div class="download-card reveal" style="opacity:0.6;">
-      
-      <div class="name">Linux 版</div>
-      <div class="desc">暂不支持</div>
-      <div class="meta">—</div>
+    <div class="download-card reveal">
+
+      <div class="name">麒麟 / NAS / Linux</div>
+      <div class="desc">Docker 自建 Web 服务，一条命令安装</div>
+      <div class="meta">install.sh · amd64 + arm64</div>
       <div class="btn-group">
-        <span class="download-btn" style="background:#B0A090;cursor:default;pointer-events:none;">暂不支持</span>
+        <a href="https://github.com/zhuzhaoyun/Molio#readme" target="_blank" rel="noopener noreferrer" class="download-btn primary">安装指南</a>
+        <a href="https://molio-releases.oss-cn-guangzhou.aliyuncs.com/script/install.sh" target="_blank" rel="noopener noreferrer" class="download-btn secondary">安装脚本</a>
       </div>
     </div>
+  </div>
+
+  <div class="step-card reveal">
+    <h3 style="font-family:var(--font-display); font-size:18px; margin-bottom:14px;">🐳 麒麟 / NAS / Linux — Docker 一键安装</h3>
+    <p style="margin-bottom:14px;">群晖、威联通、绿联、铁威马、TrueNAS、Unraid 等 NAS，以及麒麟、统信 UOS、Debian、Ubuntu、CentOS 等服务器系统，都可以把 Molio 作为自建 Web 服务运行：单容器内置 daemon、Web 界面和 Claude Code CLI，同时支持 amd64 / arm64。</p>
+    <ol>
+      <li>准备一台装好 Docker + Docker Compose v2 的机器（脚本会自动补装缺失的依赖）</li>
+      <li>执行一键安装命令，脚本会交互式引导你填写知识库目录和端口，然后自动拉取镜像并启动服务：
+<pre class="cmd-block"><span class="c"># 国内（推荐）</span>
+curl -fsSL https://molio-releases.oss-cn-guangzhou.aliyuncs.com/script/install.sh | bash
+
+<span class="c"># 海外</span>
+curl -fsSL https://raw.githubusercontent.com/zhuzhaoyun/Molio/main/install.sh | bash</pre>
+      </li>
+      <li>完成后浏览器打开 <code>http://&lt;服务器 IP&gt;:3100</code>，到「设置 → 运行时」配置 AI 模型和 API Key 即可</li>
+    </ol>
+    <p style="font-size:13.5px; color:var(--ink-40); margin-top:14px;">注意：自建版只能通过浏览器访问（没有桌面客户端），知识库目录需挂载到容器内 <code>/vaults</code> 下。手动安装、更新与常用命令见 <a href="https://github.com/zhuzhaoyun/Molio#readme" target="_blank" rel="noopener noreferrer">README「Docker / NAS 部署」章节</a>。</p>
   </div>
 
   <h2 class="download-section-title"> Chrome 浏览器扩展</h2>

--- a/apps/landing-page/faq.html
+++ b/apps/landing-page/faq.html
@@ -45,7 +45,7 @@
     { "@type": "Question", "name": "Molio 和 Obsidian 有什么区别？", "acceptedAnswer": { "@type": "Answer", "text": "Molio 完全兼容 Obsidian Vault，可以直接打开你的 Obsidian 文件夹。区别在于 Molio 内置了 Claude Code 图形界面、微信 AI 助手、Web Clipper 和多平台发布功能，是一体化的知识管理工作台。" } },
     { "@type": "Question", "name": "Molio 是免费的吗？", "acceptedAnswer": { "@type": "Answer", "text": "Molio 是开源软件，可以免费使用。你需要自行配置 AI 助手（如 Claude Code）的 API Key，AI 使用的费用取决于你选择的模型提供商。" } },
     { "@type": "Question", "name": "如何安装 Molio？", "acceptedAnswer": { "@type": "Answer", "text": "访问 molio.cn/download.html 下载对应系统的安装包。Windows 用户下载 .exe 文件，macOS 用户下载 .dmg 文件。安装完成后，还需要安装并配置 AI 助手（如 Claude Code）才能使用 AI 功能。" } },
-    { "@type": "Question", "name": "Molio 支持哪些平台？", "acceptedAnswer": { "@type": "Answer", "text": "目前支持 Windows 和 macOS（Apple Silicon）。Linux 版本正在开发中。浏览器扩展支持 Chrome，可在 Chrome 网上应用店或本网站下载离线安装包。" } },
+    { "@type": "Question", "name": "Molio 支持哪些平台？", "acceptedAnswer": { "@type": "Answer", "text": "桌面客户端支持 Windows 和 macOS（Apple Silicon）；Linux、麒麟、统信 UOS、各类 NAS 可通过 Docker 一键自建部署，运行 Molio Web 服务（详见下载页）。浏览器扩展支持 Chrome，可在 Chrome 网上应用店或本网站下载离线安装包。" } },
     { "@type": "Question", "name": "如何使用 Claude Code？", "acceptedAnswer": { "@type": "Answer", "text": "在 Molio 中，进入「设置」→「运行时」，点击 Claude Code 旁的「一键安装」按钮。安装完成后配置 API Key，双击设置为默认助手即可使用。详细步骤请参考使用指南。" } },
     { "@type": "Question", "name": "Web Clipper 怎么用？", "acceptedAnswer": { "@type": "Answer", "text": "安装 Molio Connect Chrome 扩展后，在浏览网页时点击扩展图标，即可一键保存网页内容到你的 Molio 知识库。支持公众号文章、PDF、Markdown 等多种格式。" } },
     { "@type": "Question", "name": "如何排版微信公众号文章？", "acceptedAnswer": { "@type": "Answer", "text": "在 Molio 中打开 Markdown 文件，点击「排版」按钮进入三栏模式。在右侧样式面板调整主题、字体、颜色等，完成后点击「复制」按钮，直接粘贴到微信公众号编辑器即可。" } },
@@ -162,8 +162,13 @@
         <ul>
           <li>Windows（64 位）</li>
           <li>macOS（Apple Silicon M1/M2/M3）</li>
-          <li>Linux（开发中）</li>
         </ul>
+        <p><strong>Docker 自建部署（Linux / NAS）：</strong></p>
+        <ul>
+          <li>麒麟、统信 UOS、Debian、Ubuntu、CentOS 等服务器系统</li>
+          <li>群晖、威联通、绿联、铁威马、TrueNAS、Unraid 等 NAS（amd64 / arm64）</li>
+        </ul>
+        <p>一条命令即可通过 Docker 自建 Molio Web 服务，详见 <a href="download.html">下载页的 Docker 安装说明</a>。</p>
         <p><strong>浏览器扩展：</strong></p>
         <ul>
           <li>Chrome（COSE 多平台发布扩展）</li>

--- a/apps/landing-page/shared.js
+++ b/apps/landing-page/shared.js
@@ -27,7 +27,7 @@
     const customQr = document.body.dataset.floatQr;
     const customCaption = document.body.dataset.floatCaption;
     const qrSrc = customQr ? (qrPrefix + customQr) : (qrPrefix + 'images/qrcode.png');
-    const caption = customCaption || '加好友交流';
+    const caption = customCaption || '加入用户群';
     const altText = customCaption ? (customCaption + '二维码') : 'Molio 墨流用户交流群二维码';
 
     const wrap = document.createElement('div');

--- a/apps/landing-page/styles.css
+++ b/apps/landing-page/styles.css
@@ -1120,6 +1120,22 @@ p { margin-bottom: 0; }
   font-weight: 700;
 }
 
+.cmd-block {
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.8;
+  padding: 16px 20px;
+  border-radius: 3px;
+  overflow-x: auto;
+  margin: 12px 0;
+  white-space: pre;
+  text-align: left;
+}
+
+.cmd-block .c { color: var(--ink-20); }
+
 /* FAQ */
 .faq-content { max-width: 800px; }
 


### PR DESCRIPTION
## 背景

下载页 Linux 卡片长期显示「暂不支持」，但项目已有成熟的 Docker / NAS 一键部署（`install.sh`），麒麟、统信 UOS、各类 NAS 均可自建运行。官网口径与实际能力脱节。

## 改动

| 文件 | 内容 |
|---|---|
| `download.html` | Linux「暂不支持」卡片 → 「麒麟 / NAS / Linux」Docker 部署卡片（安装指南 + 安装脚本按钮）；新增 Docker 一键安装说明卡（国内/海外 curl 命令、`http://<IP>:3100` 访问方式、浏览器访问与 `/vaults` 挂载注意事项）；meta description 与 JSON-LD `operatingSystem` 同步 |
| `faq.html` | 「Linux 版本正在开发中」→ Docker 自建部署说明（正文 q5 + JSON-LD），列出支持的服务器系统与 NAS 型号 |
| `shared.js` | 悬浮二维码默认文案「加好友交流」→「加入用户群」（该二维码实际是群聊，与 alt 文案及 FAQ 口径对齐） |
| `styles.css` | 新增 `.cmd-block` 深色命令块样式（墨底纸字、注释灰显、横向滚动便于整行复制） |

命令与文案均与 `README_zh.md`、`install.sh` 注释保持一致。

## 验证

本地静态服务器冒烟：
- 「暂不支持」「开发中」均已清零，新内容正常输出
- HTML 标签配平检查通过，CSS 正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)