### PR TITLE
fix(desktop,daemon,web): 修复长时运行内存泄漏 — 日志轮转/缓冲限容/SSE 背压

### DIFF
--- a/apps/daemon/src/core/debug-log.ts
+++ b/apps/daemon/src/core/debug-log.ts
@@ -11,13 +11,50 @@ import os from 'node:os';
  *
  * Call only on low-frequency points (stream start/cancel, ping enqueue
  * failure, subscribe/unsubscribe, listeners=0) — never per-event.
+ *
+ * Rotation: when the log exceeds MAX_DEBUG_LOG_BYTES it is renamed to
+ * sse-debug.log.old (overwriting any previous rotation) before the write
+ * continues. The previous implementation appended forever — the file grew
+ * without bound across weeks of runtime (1.4MB+ observed and climbing).
+ *
+ * Level gating: dbgLog is a DEBUG-level diagnostic channel. In production
+ * builds it is SILENT by default — no file writes, no console output — so a
+ * long-running daemon doesn't accumulate log state. Set `MOLIO_DEBUG=1` to
+ * enable it when investigating an issue (ask the reporter to reproduce with
+ * the flag set). Read at module load; tests set the env before importing.
+ *
+ * The directory is overridable via MOLIO_DEBUG_LOG_DIR (used by tests to
+ * avoid writing into the real homedir).
  */
-const DEBUG_LOG_PATH = path.join(os.homedir(), '.molio', 'debug', 'sse-debug.log');
+export function isDebugEnabled(): boolean {
+  return process.env['MOLIO_DEBUG'] === '1';
+}
+
+const DEBUG_LOG_DIR = process.env['MOLIO_DEBUG_LOG_DIR']
+  || path.join(os.homedir(), '.molio', 'debug');
+const DEBUG_LOG_PATH = path.join(DEBUG_LOG_DIR, 'sse-debug.log');
+
+/** Rotate past this size. Kept small: this is a diagnostic channel, not an audit trail. */
+export const MAX_DEBUG_LOG_BYTES = 1 * 1024 * 1024; // 1 MB
+
+/** Rename the log to .old if it exceeds the size cap. Best-effort. */
+function rotateIfNeeded(): void {
+  try {
+    const st = fs.statSync(DEBUG_LOG_PATH);
+    if (st.size > MAX_DEBUG_LOG_BYTES) {
+      fs.renameSync(DEBUG_LOG_PATH, DEBUG_LOG_PATH + '.old');
+    }
+  } catch {
+    // ENOENT (no file yet) or a transient FS error — just keep appending.
+  }
+}
 
 export function dbgLog(msg: string): void {
+  if (!isDebugEnabled()) return;
   const line = `${new Date().toISOString()} ${msg}\n`;
   try {
-    fs.mkdirSync(path.dirname(DEBUG_LOG_PATH), { recursive: true });
+    fs.mkdirSync(DEBUG_LOG_DIR, { recursive: true });
+    rotateIfNeeded();
     fs.appendFileSync(DEBUG_LOG_PATH, line, { flag: 'a' });
   } catch { /* best-effort */ }
   console.warn('[sse-daemon] ' + msg);

--- a/apps/daemon/src/core/runs-log-prune.ts
+++ b/apps/daemon/src/core/runs-log-prune.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Pruning for per-run JSONL event logs under ~/.molio/runs/.
+ *
+ * Every run writes its event stream to ~/.molio/runs/<runId>/events.jsonl
+ * (RunManager.ensureLogStream). finishRun closes the stream but nothing ever
+ * deleted the files — ~2000 run directories (72MB) had accumulated on a real
+ * machine after five weeks. Prune once at daemon startup; the window is wide
+ * (7 days) so logs from recent debugging sessions survive.
+ *
+ * Age is judged from the directory's mtime: it updates when entries are
+ * created or removed inside (i.e. while a run is active), so a directory
+ * untouched for maxAgeDays belongs to a long-finished run.
+ */
+
+export const DEFAULT_RUNS_LOG_DIR = path.join(os.homedir(), '.molio', 'runs');
+export const DEFAULT_MAX_AGE_DAYS = 7;
+
+export interface PruneRunLogsOptions {
+  /** Directory to prune. Default: ~/.molio/runs */
+  dir?: string;
+  /** Delete directories whose mtime is older than this. Default: 7 days. */
+  maxAgeDays?: number;
+  /** Reference time (for tests). Default: Date.now(). */
+  now?: number;
+}
+
+export interface PruneRunLogsResult {
+  removed: number;
+  failed: number;
+  kept: number;
+}
+
+export function pruneRunLogs(opts: PruneRunLogsOptions = {}): PruneRunLogsResult {
+  const dir = opts.dir ?? DEFAULT_RUNS_LOG_DIR;
+  const now = opts.now ?? Date.now();
+  const maxAgeMs = (opts.maxAgeDays ?? DEFAULT_MAX_AGE_DAYS) * 24 * 60 * 60 * 1000;
+
+  const result: PruneRunLogsResult = { removed: 0, failed: 0, kept: 0 };
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    // Directory doesn't exist yet (fresh install) — nothing to do.
+    return result;
+  }
+
+  for (const name of entries) {
+    const target = path.join(dir, name);
+    try {
+      const st = fs.statSync(target);
+      if (!st.isDirectory()) {
+        result.kept++;
+        continue;
+      }
+      if (now - st.mtimeMs <= maxAgeMs) {
+        result.kept++;
+        continue;
+      }
+      fs.rmSync(target, { recursive: true, force: true });
+      result.removed++;
+    } catch {
+      // A locked or vanished directory must never abort the sweep.
+      result.failed++;
+    }
+  }
+
+  if (result.removed > 0) {
+    console.log(
+      `[runs-log-prune] removed ${result.removed} expired run log directories ` +
+      `(kept ${result.kept}, failed ${result.failed}) from ${dir}`,
+    );
+  }
+  return result;
+}

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -5,6 +5,7 @@ import { listVaults } from './core/db.js';
 import { installBuiltinSkills } from './core/skill-installer.js';
 import { ensureWikiSysPromptFiles } from './core/wiki-prompts.js';
 import { isKillablePortOccupant } from './core/port-check.js';
+import { pruneRunLogs } from './core/runs-log-prune.js';
 
 const port = Number(process.env['MOLIO_PORT'] ?? 3100);
 
@@ -94,6 +95,11 @@ checkAndKillPortOccupant(port);
 for (const vault of listVaults(db)) {
   installBuiltinSkills(vault.path);
 }
+
+// Delete per-run JSONL logs older than 7 days (nothing cleaned them up
+// before; they accumulate indefinitely under ~/.molio/runs). Best-effort and
+// fast — a readdir + stat sweep over the run-id directories.
+pruneRunLogs();
 
 // Materialize the feishu wiki role frame (the only channel still delivered via
 // --append-system-prompt-file; weixin prepends its frame, see weixin/dispatcher).

--- a/apps/daemon/src/sse.ts
+++ b/apps/daemon/src/sse.ts
@@ -29,6 +29,32 @@ export function createSSEStream(
   let unsub: (() => void) | null = null;
   let pingInterval: ReturnType<typeof setInterval> | null = null;
   let enqueueCount = 0;
+  // Backpressure: counts consecutive ping ticks where the consumer hasn't
+  // drained the stream (desiredSize <= 0 — the client stopped reading, e.g.
+  // a minimized/throttled renderer while a run keeps emitting). Previously
+  // pings and live events were enqueued unconditionally, so a stalled client
+  // made the daemon buffer the entire run's output in memory. After
+  // MAX_STALLED_PINGS (≈60s at the 15s ping interval) we close the stream;
+  // the client's EventSource auto-reconnects / watchdog re-subscribes with
+  // ?after=<lastSeq> and the daemon replays buffered events — no data loss.
+  // Test hook: MOLIO_TEST_SSE_STALL_TICKS lowers the tick count.
+  const maxStalledTicks = Number(process.env.MOLIO_TEST_SSE_STALL_TICKS) || 4;
+  let stalledTicks = 0;
+
+  /** Whether the consumer is keeping up (safe to enqueue). */
+  const consumerReady = (controller: ReadableStreamDefaultController<Uint8Array>): boolean =>
+    controller.desiredSize !== null && controller.desiredSize > 0;
+
+  /** Stop the subscription + ping timer. Idempotent — safe from cancel,
+   * cleanup, AND the stall-close path. */
+  const teardown = (): void => {
+    unsub?.();
+    unsub = null;
+    if (pingInterval) {
+      clearInterval(pingInterval);
+      pingInterval = null;
+    }
+  };
 
   // Wrap controller.enqueue so the fault-injection switch can simulate a dead
   // stream mid-connection. Throwing here is caught by the call-site try/catch,
@@ -71,6 +97,11 @@ export function createSSEStream(
 
       // Phase 3: Subscribe to live events
       unsub = runManager.onEvent(runId, (event: AgentEvent) => {
+        // Backpressure: skip enqueueing while the consumer is stalled. The
+        // event stays in run.events (cap 2000) and is replayed when the
+        // client reconnects — either via its own watchdog or the stall-close
+        // below — so skipping here loses nothing.
+        if (!consumerReady(controller)) return;
         const lastId = runManager.getLastEventId(runId);
         const envelope = { seq: lastId, runId, event };
         const frame = `id: ${lastId}\ndata: ${JSON.stringify(envelope)}\n\n`;
@@ -93,6 +124,21 @@ export function createSSEStream(
       // exercise the ping path without sleeping 15s. Production never sets it.
       const pingMs = Number(process.env.MOLIO_TEST_SSE_PING_MS) || 15_000;
       pingInterval = setInterval(() => {
+        if (!consumerReady(controller)) {
+          stalledTicks++;
+          if (stalledTicks >= maxStalledTicks) {
+            dbgLog(
+              `stream stalled ${stalledTicks} ticks — client not reading, closing ` +
+              `(client reconnect replays buffered events) runId=${runId}`,
+            );
+            teardown();
+            try { controller.close(); } catch { /* already closed */ }
+          }
+          // A keepalive ping is worthless to a consumer that isn't reading —
+          // never buffer it.
+          return;
+        }
+        stalledTicks = 0;
         try {
           safeEnqueue(controller, encoder.encode('data: ping\n\n'));
         } catch {
@@ -104,12 +150,7 @@ export function createSSEStream(
     },
     cancel() {
       dbgLog(`stream cancel runId=${runId}`);
-      unsub?.();
-      unsub = null;
-      if (pingInterval) {
-        clearInterval(pingInterval);
-        pingInterval = null;
-      }
+      teardown();
     },
   });
 
@@ -117,12 +158,7 @@ export function createSSEStream(
     stream,
     cleanup: () => {
       dbgLog(`stream cleanup runId=${runId}`);
-      unsub?.();
-      unsub = null;
-      if (pingInterval) {
-        clearInterval(pingInterval);
-        pingInterval = null;
-      }
+      teardown();
     },
   };
 }

--- a/apps/daemon/test/core/debug-log-gating.test.ts
+++ b/apps/daemon/test/core/debug-log-gating.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * Regression test: dbgLog is a DEBUG-level channel and must be SILENT in
+ * production (no MOLIO_DEBUG=1) — previously it appended to
+ * ~/.molio/debug/sse-debug.log and wrote to the console unconditionally on
+ * every long-running daemon. This file runs in its own process (node --test)
+ * with MOLIO_DEBUG unset so the module-load gate reads the production value.
+ */
+
+const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'molio-debug-gate-test-'));
+process.env['MOLIO_DEBUG_LOG_DIR'] = tmpDir;
+delete process.env['MOLIO_DEBUG'];
+
+const { dbgLog, isDebugEnabled } = await import('../../src/core/debug-log.js');
+
+after(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('dbgLog level gating', () => {
+  it('should report disabled when MOLIO_DEBUG is not set', () => {
+    assert.equal(isDebugEnabled(), false);
+  });
+
+  it('should not write any file or throw when disabled', () => {
+    dbgLog('this must not be persisted');
+    assert.equal(existsSync(path.join(tmpDir, 'sse-debug.log')), false);
+    assert.equal(existsSync(path.join(tmpDir, 'sse-debug.log.old')), false);
+  });
+});

--- a/apps/daemon/test/core/debug-log-rotation.test.ts
+++ b/apps/daemon/test/core/debug-log-rotation.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, statSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * Regression test: sse-debug.log previously appended forever (appendFileSync,
+ * no rotation) — 1.4MB+ and climbing after weeks of runtime. dbgLog must
+ * rotate the file once it exceeds MAX_DEBUG_LOG_BYTES.
+ *
+ * MOLIO_DEBUG and MOLIO_DEBUG_LOG_DIR are set BEFORE the module is imported
+ * (debug-log reads them at module-load time). node --test runs each file in
+ * its own process, so the env overrides are isolated to this suite.
+ */
+
+const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'molio-debug-log-test-'));
+process.env['MOLIO_DEBUG'] = '1';
+process.env['MOLIO_DEBUG_LOG_DIR'] = tmpDir;
+
+const { dbgLog, MAX_DEBUG_LOG_BYTES } = await import('../../src/core/debug-log.js');
+
+const LOG_PATH = path.join(tmpDir, 'sse-debug.log');
+const OLD_PATH = LOG_PATH + '.old';
+
+// Clean up the temp dir once the suite finishes.
+process.on('exit', () => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+/** Pre-grow the live log just past the cap (fast, no 2000-line loop). */
+function seedOversizedLog(marker: string): void {
+  writeFileSync(LOG_PATH, `# ${marker}\n` + 'x'.repeat(MAX_DEBUG_LOG_BYTES + 1024));
+}
+
+describe('dbgLog rotation', () => {
+  it('should write lines to the debug log', () => {
+    dbgLog('hello rotation');
+    assert.ok(existsSync(LOG_PATH));
+    const content = readFileSync(LOG_PATH, 'utf8');
+    assert.ok(content.includes('hello rotation'));
+  });
+
+  it('should rotate to .old when the next write would exceed the size cap', () => {
+    seedOversizedLog('gen-one');
+
+    dbgLog('post-rotation line');
+
+    assert.ok(existsSync(OLD_PATH), '.old rotation file should exist');
+    // The live log restarts with just the new line.
+    const size = statSync(LOG_PATH).size;
+    assert.ok(size < 1024, `post-rotation log size ${size} should be tiny`);
+    assert.ok(readFileSync(LOG_PATH, 'utf8').includes('post-rotation line'));
+    // The rotated file holds the oversized content.
+    assert.ok(readFileSync(OLD_PATH, 'utf8').includes('gen-one'));
+  });
+
+  it('should keep exactly one rotation (overwrite .old on next rotation)', () => {
+    // First rotation.
+    seedOversizedLog('gen-one');
+    dbgLog('line A');
+    assert.ok(existsSync(OLD_PATH));
+
+    // Second rotation — .old must be replaced, not accumulated, so disk
+    // usage stays bounded at ~2x the cap.
+    seedOversizedLog('gen-two');
+    dbgLog('line B');
+
+    const oldContent = readFileSync(OLD_PATH, 'utf8');
+    assert.ok(oldContent.includes('gen-two'), '.old should hold the latest rotation');
+    assert.ok(!oldContent.includes('gen-one'), 'previous .old must be overwritten');
+  });
+});

--- a/apps/daemon/test/core/runs-log-prune.test.ts
+++ b/apps/daemon/test/core/runs-log-prune.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, utimesSync, symlinkSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { pruneRunLogs } from '../../src/core/runs-log-prune.js';
+
+/**
+ * Regression test: per-run JSONL logs (~/.molio/runs/<runId>/) were never
+ * deleted — ~2000 directories / 72MB accumulated on a real machine in five
+ * weeks. pruneRunLogs must remove directories older than the retention
+ * window and leave recent ones alone.
+ */
+
+let tmpDir: string;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'molio-runs-prune-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Create a fake run log dir with a controlled mtime (days ago). */
+function makeRunDir(name: string, ageDays: number, now: number): string {
+  const dir = path.join(tmpDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'events.jsonl'), '{"id":1}\n');
+  const mtime = new Date(now - ageDays * DAY_MS);
+  utimesSync(dir, mtime, mtime);
+  return dir;
+}
+
+describe('pruneRunLogs', () => {
+  it('should remove directories older than the retention window', () => {
+    const now = Date.now();
+    const old = makeRunDir('run-old', 10, now);
+    const recent = makeRunDir('run-recent', 2, now);
+
+    const result = pruneRunLogs({ dir: tmpDir, now });
+
+    assert.equal(result.removed, 1);
+    assert.equal(result.kept, 1);
+    assert.equal(existsSync(old), false, 'old run dir should be deleted');
+    assert.ok(existsSync(recent), 'recent run dir should survive');
+    assert.ok(existsSync(path.join(recent, 'events.jsonl')));
+  });
+
+  it('should delete the whole run directory tree, not just the top level', () => {
+    const now = Date.now();
+    const old = makeRunDir('run-nested', 30, now);
+    mkdirSync(path.join(old, 'sub'));
+    writeFileSync(path.join(old, 'sub', 'extra.jsonl'), '{}\n');
+    // Re-apply the aged mtime after adding children (child creation bumps it).
+    const mtime = new Date(now - 30 * DAY_MS);
+    utimesSync(old, mtime, mtime);
+
+    const result = pruneRunLogs({ dir: tmpDir, now });
+
+    assert.equal(result.removed, 1);
+    assert.equal(existsSync(old), false);
+  });
+
+  it('should keep directories exactly at the age boundary', () => {
+    const now = Date.now();
+    // mtime exactly maxAgeDays ago → age == maxAgeMs → NOT strictly older → kept.
+    const boundary = makeRunDir('run-boundary', 7, now);
+
+    const result = pruneRunLogs({ dir: tmpDir, maxAgeDays: 7, now });
+
+    assert.equal(result.removed, 0);
+    assert.equal(result.kept, 1);
+    assert.ok(existsSync(boundary));
+  });
+
+  it('should respect a custom maxAgeDays', () => {
+    const now = Date.now();
+    const twoDaysOld = makeRunDir('run-2d', 2, now);
+
+    const result = pruneRunLogs({ dir: tmpDir, maxAgeDays: 1, now });
+
+    assert.equal(result.removed, 1);
+    assert.equal(existsSync(twoDaysOld), false);
+  });
+
+  it('should skip loose files and only prune directories', () => {
+    const now = Date.now();
+    const looseFile = path.join(tmpDir, 'stray.jsonl');
+    writeFileSync(looseFile, '{}');
+    const old = new Date(now - 30 * DAY_MS);
+    utimesSync(looseFile, old, old);
+    makeRunDir('run-old', 30, now);
+
+    const result = pruneRunLogs({ dir: tmpDir, now });
+
+    assert.equal(result.removed, 1);
+    assert.ok(existsSync(looseFile), 'loose files must not be touched');
+  });
+
+  it('should tolerate a missing directory (fresh install)', () => {
+    const result = pruneRunLogs({ dir: path.join(tmpDir, 'does-not-exist') });
+    assert.deepEqual(result, { removed: 0, failed: 0, kept: 0 });
+  });
+
+  it('should keep sweeping when one entry fails', () => {
+    const now = Date.now();
+    makeRunDir('run-a', 20, now);
+    // A dangling symlink makes statSync throw — the sweep must count it as
+    // failed and continue to the next entry instead of aborting.
+    const dangling = path.join(tmpDir, 'dangling');
+    try {
+      // Skip gracefully if the platform forbids symlink creation
+      // (unprivileged Windows).
+      symlinkSync(path.join(tmpDir, 'no-such-target'), dangling);
+    } catch {
+      // Symlinks unavailable — the rest of the test still covers the sweep.
+    }
+    makeRunDir('run-b', 20, now);
+
+    const result = pruneRunLogs({ dir: tmpDir, now });
+
+    assert.equal(result.removed, 2, 'both aged run dirs should be removed');
+    assert.ok(existsSync(path.join(tmpDir, 'run-a')) === false);
+    assert.ok(existsSync(path.join(tmpDir, 'run-b')) === false);
+  });
+});

--- a/apps/daemon/test/routes/sse-stall.test.ts
+++ b/apps/daemon/test/routes/sse-stall.test.ts
@@ -1,0 +1,178 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AgentEvent } from '@molio/contracts';
+import type { RunManager } from '../../src/core/RunManager.js';
+import type { BufferedEvent } from '../../src/types.js';
+
+/**
+ * Regression test: the SSE stream used to enqueue pings and live events
+ * unconditionally. A client that stopped reading (minimized/throttled
+ * renderer during a long run) made the daemon buffer the run's entire event
+ * output in memory — part of the day-long 3GB memory-growth report.
+ *
+ * The stream now checks controller.desiredSize: while the consumer is
+ * stalled it stops enqueueing, and after MAX_STALLED_PINGS consecutive
+ * stalled ticks it closes the stream so the client reconnects and replays
+ * buffered events (no data loss).
+ *
+ * Env hooks are set BEFORE importing sse.js (read at module load). node
+ * --test gives each file its own process, so these don't leak to other
+ * suites.
+ */
+process.env['MOLIO_TEST_SSE_PING_MS'] = '20';
+process.env['MOLIO_TEST_SSE_STALL_TICKS'] = '3';
+
+const { createSSEStream } = await import('../../src/sse.js');
+
+class MockRunManager {
+  private bufferedEvents: Map<string, BufferedEvent[]> = new Map();
+  private terminalRuns: Set<string> = new Set();
+  private eventListeners: Map<string, Set<(ev: AgentEvent) => void>> = new Map();
+  private lastEventIds: Map<string, number> = new Map();
+
+  setTerminal(runId: string, isTerminal: boolean): void {
+    if (isTerminal) this.terminalRuns.add(runId);
+    else this.terminalRuns.delete(runId);
+  }
+
+  /** Emit a live event AND buffer it (mirrors RunManager.emitEvent) so a
+   * reconnecting client can replay it. */
+  emitLiveEvent(runId: string, event: AgentEvent): void {
+    const id = (this.lastEventIds.get(runId) ?? 0) + 1;
+    this.lastEventIds.set(runId, id);
+    const list = this.bufferedEvents.get(runId) ?? [];
+    list.push({ id, event: String(event.type), data: event, timestamp: Date.now() });
+    this.bufferedEvents.set(runId, list);
+    const listeners = this.eventListeners.get(runId);
+    if (listeners) for (const l of listeners) l(event);
+  }
+
+  listenerCount(runId: string): number {
+    return this.eventListeners.get(runId)?.size ?? 0;
+  }
+
+  getBufferedEvents(runId: string, afterId: number = 0): BufferedEvent[] | null {
+    const events = this.bufferedEvents.get(runId);
+    if (!events) return null;
+    return events.filter((e) => e.id > afterId);
+  }
+
+  isTerminal(runId: string): boolean {
+    return this.terminalRuns.has(runId);
+  }
+
+  onEvent(runId: string, callback: (event: AgentEvent) => void): (() => void) | null {
+    if (!this.eventListeners.has(runId)) this.eventListeners.set(runId, new Set());
+    this.eventListeners.get(runId)!.add(callback);
+    return () => { this.eventListeners.get(runId)?.delete(callback); };
+  }
+
+  getLastEventId(runId: string): number {
+    return this.lastEventIds.get(runId) ?? 0;
+  }
+}
+
+/** Read until the stream closes; THROWS if it doesn't close in time (a fake
+ * `done` here would mask the exact regression this suite exists to catch). */
+async function drainUntilDone(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 3000,
+): Promise<string[]> {
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  for (;;) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<null>((resolve) => { timer = setTimeout(() => resolve(null), timeoutMs); }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (result === null) {
+      throw new Error('stream did not close before deadline — stall-close did not fire');
+    }
+    if (result.done) return chunks;
+    if (result.value) chunks.push(decoder.decode(result.value));
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('SSE backpressure (stalled consumer)', () => {
+  it('should close the stream after the consumer stalls for MAX_STALLED_PINGS ticks', async () => {
+    const mock = new MockRunManager();
+    mock.setTerminal('stall-1', false);
+
+    const { stream } = createSSEStream(mock as unknown as RunManager, 'stall-1', 0);
+    const reader = stream.getReader();
+
+    // Fill the stream's internal queue so desiredSize drops to 0, then issue
+    // NO read requests — simulating a throttled/hidden renderer. (An
+    // outstanding read() would drain the queue and make the consumer look
+    // healthy, which is exactly the real-world distinction this relies on.)
+    mock.emitLiveEvent('stall-1', { type: 'text_delta', delta: 'x' });
+    mock.emitLiveEvent('stall-1', { type: 'text_delta', delta: 'y' });
+
+    // ping=20ms × 3 stalled ticks → close at ~60ms. Give it 500ms of slack
+    // WITHOUT reading, then drain: a closed stream yields its queued chunks
+    // plus done promptly.
+    await sleep(500);
+    const chunks = await drainUntilDone(reader, 1000);
+    assert.ok(chunks.length >= 1, 'the initially queued event should still be delivered');
+
+    // The close path must have unsubscribed — no leaked listener.
+    assert.equal(mock.listenerCount('stall-1'), 0, 'stall-close must unsubscribe the listener');
+  });
+
+  it('should not close a stream whose consumer keeps reading (healthy path)', async () => {
+    const mock = new MockRunManager();
+    mock.setTerminal('healthy-1', false);
+
+    const { stream, cleanup } = createSSEStream(mock as unknown as RunManager, 'healthy-1', 0);
+    const reader = stream.getReader();
+
+    // Actively consume for ~200ms — many ping intervals. A healthy consumer
+    // resets the stall counter every tick, so no close must happen.
+    let pings = 0;
+    const until = Date.now() + 200;
+    while (Date.now() < until) {
+      const { done, value } = await reader.read();
+      assert.equal(done, false, 'stream must stay open for an active consumer');
+      if (value && new TextDecoder().decode(value).includes('ping')) pings++;
+    }
+    assert.ok(pings >= 2, `expected several pings while consuming, got ${pings}`);
+
+    cleanup();
+    await reader.cancel();
+    assert.equal(mock.listenerCount('healthy-1'), 0);
+  });
+
+  it('should lose no events: events emitted during a stall replay on reconnect', async () => {
+    const mock = new MockRunManager();
+    mock.setTerminal('replay-1', false);
+
+    const { stream } = createSSEStream(mock as unknown as RunManager, 'replay-1', 0);
+    const reader = stream.getReader();
+
+    // Stall the consumer (no reads), then emit events INTO THE BUFFER while
+    // stalled. They are skipped on the live stream but remain in run.events.
+    mock.emitLiveEvent('replay-1', { type: 'text_delta', delta: 'buffered-1' });
+    mock.emitLiveEvent('replay-1', { type: 'text_delta', delta: 'buffered-2' });
+    mock.emitLiveEvent('replay-1', { type: 'text_delta', delta: 'buffered-3' });
+
+    await sleep(500);                   // let the stall-close fire (~60ms)
+    await drainUntilDone(reader, 1000); // proves the stream actually closed
+
+    // Client reconnects (EventSource auto-reconnect / watchdog) → daemon
+    // replays everything buffered with id > 0. Mark terminal BEFORE creating
+    // the stream: start() replays then closes immediately for terminal runs.
+    mock.setTerminal('replay-1', true);
+    const { stream: stream2 } = createSSEStream(mock as unknown as RunManager, 'replay-1', 0);
+    const reader2 = stream2.getReader();
+    const replayed = await drainUntilDone(reader2, 2000);
+
+    const joined = replayed.join('');
+    assert.ok(joined.includes('buffered-1'), 'event 1 must survive the stall');
+    assert.ok(joined.includes('buffered-2'), 'event 2 must survive the stall');
+    assert.ok(joined.includes('buffered-3'), 'event 3 must survive the stall');
+  });
+});

--- a/apps/desktop/src/capped-buffer.js
+++ b/apps/desktop/src/capped-buffer.js
@@ -1,0 +1,44 @@
+/**
+ * Fixed-capacity ring buffer for recent lines.
+ *
+ * main.js uses this to hold daemon stdout/stderr lines for exit-time
+ * diagnostics. The previous implementation used a plain array that pushed
+ * every line forever — after a day of runtime, a full day of daemon output
+ * accumulated in the Electron main process's memory (part of the 3GB
+ * memory-growth report). The ring buffer keeps only the most recent
+ * `maxEntries` lines; the tail is exactly what the exit diagnostics need.
+ */
+export class CappedBuffer {
+  /** @param {number} maxEntries — maximum number of items to retain */
+  constructor(maxEntries) {
+    if (!Number.isInteger(maxEntries) || maxEntries < 1) {
+      throw new Error('CappedBuffer: maxEntries must be a positive integer');
+    }
+    this.maxEntries = maxEntries;
+    /** @type {string[]} */
+    this.items = [];
+  }
+
+  /**
+   * Append an item, evicting the oldest when over capacity.
+   * @param {string} item
+   */
+  push(item) {
+    this.items.push(item);
+    if (this.items.length > this.maxEntries) {
+      // Single bulk splice instead of per-item shift — avoids O(n²) under
+      // sustained writes (a noisy daemon could emit many lines per second).
+      this.items.splice(0, this.items.length - this.maxEntries);
+    }
+  }
+
+  /** Snapshot of retained items, oldest → newest. Returns a copy. */
+  toArray() {
+    return [...this.items];
+  }
+
+  /** Number of items currently retained. */
+  get length() {
+    return this.items.length;
+  }
+}

--- a/apps/desktop/src/logger.js
+++ b/apps/desktop/src/logger.js
@@ -16,6 +16,32 @@ const MAX_LOG_SIZE = 1024 * 1024; // 1 MB
 let customLogDir = null;
 let logDir = null;
 let logFile = null;
+/** Tracked size of the live log file — avoids a statSync per write. */
+let currentSize = 0;
+/** Cached console-mirror decision (null = not resolved yet). */
+let mirrorConsole = null;
+
+/**
+ * Mirror log lines to the console ONLY in development. In packaged builds
+ * the main-process console goes nowhere useful, and error-level lines get
+ * captured by the ARMS consoleError collector — flooding 异常统计 with
+ * routine daemon stderr forwards. File logging (with rotation) remains the
+ * single source of truth in production.
+ *
+ * Plain Node.js (tests, scripts) has no electron — fall back to mirroring
+ * so the dev/test experience keeps console output.
+ */
+function shouldMirrorConsole() {
+  if (mirrorConsole !== null) return mirrorConsole;
+  try {
+    const require = createRequire(import.meta.url);
+    const { app } = require('electron');
+    mirrorConsole = !app.isPackaged;
+  } catch {
+    mirrorConsole = true;
+  }
+  return mirrorConsole;
+}
 
 /**
  * Override the log directory (for testing or custom deployments).
@@ -49,12 +75,20 @@ function ensureLogPath() {
 
   // Rotate if existing log is too large
   try {
-    if (existsSync(logFile) && statSync(logFile).size > MAX_LOG_SIZE) {
-      const rotated = logFile + '.old';
-      renameSync(logFile, rotated);
+    if (existsSync(logFile)) {
+      const size = statSync(logFile).size;
+      if (size > MAX_LOG_SIZE) {
+        renameSync(logFile, logFile + '.old');
+        currentSize = 0;
+      } else {
+        currentSize = size;
+      }
+    } else {
+      currentSize = 0;
     }
   } catch {
     // Ignore rotation errors — just keep appending
+    currentSize = 0;
   }
 }
 
@@ -68,13 +102,24 @@ export function log(level, tag, message) {
   const ts = new Date().toISOString();
   const line = `[${ts}] [${level.toUpperCase()}] [${tag}] ${message}\n`;
 
-  // Always mirror to console for dev experience
-  const consoleFn = level === 'error' ? console.error : console.log;
-  consoleFn(line.trimEnd());
+  // Console mirror: dev only (see shouldMirrorConsole). Production keeps
+  // everything in the rotated log file.
+  if (shouldMirrorConsole()) {
+    const consoleFn = level === 'error' ? console.error : console.log;
+    consoleFn(line.trimEnd());
+  }
 
   try {
     ensureLogPath();
+    // In-session rotation: the startup-only check let a long-running session
+    // (a day of daemon log forwards) grow the file unbounded. Track size in
+    // memory — no extra statSync per write.
+    if (currentSize > MAX_LOG_SIZE) {
+      renameSync(logFile, logFile + '.old');
+      currentSize = 0;
+    }
     appendFileSync(logFile, line, 'utf-8');
+    currentSize += Buffer.byteLength(line, 'utf-8');
   } catch {
     // File logging failure must never crash the app
   }
@@ -94,4 +139,6 @@ export function _reset() {
   customLogDir = null;
   logDir = null;
   logFile = null;
+  currentSize = 0;
+  mirrorConsole = null;
 }

--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -6,6 +6,7 @@ import { setupAutoUpdater } from './updater.js';
 import { log, getLogPath } from './logger.js';
 import { startFetchServer } from './wiki-fetcher.js';
 import { openFeishuLogin, getFeishuLoginStatus } from './wiki-fetcher-login.js';
+import { CappedBuffer } from './capped-buffer.js';
 
 const errMsg = (err) => (err instanceof Error ? err.message : String(err));
 
@@ -91,9 +92,12 @@ async function startDaemonProduction() {
       stdio: 'pipe',
     });
 
-    // Collect stderr/stdout for diagnostics if daemon fails to start
-    const stderrChunks = [];
-    const stdoutChunks = [];
+    // Collect stderr/stdout for diagnostics if daemon fails to start.
+    // Capped buffers: the previous plain arrays pushed every line forever,
+    // so a day of runtime left a day of daemon output sitting in main
+    // process memory. The tail (200 lines) is all exit diagnostics need.
+    const stderrChunks = new CappedBuffer(200);
+    const stdoutChunks = new CappedBuffer(200);
     let started = false;
 
     daemonProcess.stdout?.on('data', (data) => {
@@ -137,10 +141,10 @@ async function startDaemonProduction() {
       log('error', 'main', `daemon exited with code=${code} signal=${signal}`);
       if (code !== 0 && code !== null) {
         if (stdoutChunks.length > 0) {
-          log('error', 'main', `daemon stdout tail:\n${stdoutChunks.slice(-20).join('\n')}`);
+          log('error', 'main', `daemon stdout tail:\n${stdoutChunks.toArray().join('\n')}`);
         }
         if (stderrChunks.length > 0) {
-          log('error', 'main', `daemon stderr:\n${stderrChunks.join('\n')}`);
+          log('error', 'main', `daemon stderr tail:\n${stderrChunks.toArray().join('\n')}`);
         }
       }
       daemonProcess = null;

--- a/apps/desktop/test/capped-buffer.test.js
+++ b/apps/desktop/test/capped-buffer.test.js
@@ -1,0 +1,54 @@
+/**
+ * Regression tests for capped-buffer.js.
+ *
+ * Bug context: main.js previously collected daemon stdout/stderr into plain
+ * arrays that grew without bound — after a day of runtime the Electron main
+ * process held a full day of daemon log lines in memory (contributor to the
+ * 3GB memory-growth report). CappedBuffer must retain only the most recent
+ * N lines, in order.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { CappedBuffer } from '../src/capped-buffer.js';
+
+describe('CappedBuffer', () => {
+  it('should keep all items when under capacity', () => {
+    const buf = new CappedBuffer(5);
+    buf.push('a');
+    buf.push('b');
+    assert.equal(buf.length, 2);
+    assert.deepEqual(buf.toArray(), ['a', 'b']);
+  });
+
+  it('should evict oldest items once over capacity, preserving order', () => {
+    const buf = new CappedBuffer(3);
+    for (const line of ['a', 'b', 'c', 'd', 'e']) buf.push(line);
+    assert.equal(buf.length, 3);
+    assert.deepEqual(buf.toArray(), ['c', 'd', 'e']);
+  });
+
+  it('should stay bounded under sustained writes (the leak scenario)', () => {
+    const buf = new CappedBuffer(200);
+    for (let i = 0; i < 100_000; i++) buf.push(`daemon line ${i}`);
+    assert.equal(buf.length, 200);
+    const tail = buf.toArray();
+    assert.equal(tail[0], 'daemon line 99800');
+    assert.equal(tail[199], 'daemon line 99999');
+  });
+
+  it('should return a snapshot copy from toArray', () => {
+    const buf = new CappedBuffer(3);
+    buf.push('a');
+    const snap = buf.toArray();
+    snap.push('mutated');
+    assert.deepEqual(buf.toArray(), ['a']);
+  });
+
+  it('should reject invalid capacity', () => {
+    assert.throws(() => new CappedBuffer(0), /positive integer/);
+    assert.throws(() => new CappedBuffer(-1), /positive integer/);
+    assert.throws(() => new CappedBuffer(1.5), /positive integer/);
+    assert.throws(() => new CappedBuffer('10'), /positive integer/);
+  });
+});

--- a/apps/desktop/test/logger.test.js
+++ b/apps/desktop/test/logger.test.js
@@ -7,7 +7,7 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { log, getLogPath, setLogDir, _reset } from '../src/logger.js';
@@ -98,6 +98,22 @@ describe('log rotation', () => {
     const newContent = readFileSync(logPath, 'utf-8');
     assert.ok(newContent.includes('after rotation'));
     assert.ok(!newContent.includes('xxxxx'), 'new file should not contain old content');
+  });
+
+  it('should rotate within a long session, not only at startup', () => {
+    // Regression: rotation used to run once in ensureLogPath at first use, so
+    // a session running for a day (heavy daemon stderr forwarding) grew the
+    // log file without bound. log() must rotate mid-session past 1MB.
+    const logPath = path.join(tmpDir, 'updater.log');
+    const payload = 'y'.repeat(1000);
+    // ~1200 lines × ~1060 bytes ≈ 1.24MB → comfortably past the 1MB cap.
+    for (let i = 0; i < 1200; i++) {
+      log('info', 'daemon', `line ${i} ${payload}`);
+    }
+
+    assert.ok(existsSync(logPath + '.old'), 'mid-session rotation should produce .old');
+    const size = statSync(logPath).size;
+    assert.ok(size < 1024 * 1024, `live log (${size} bytes) should be back under the cap`);
   });
 });
 

--- a/apps/web/src/api/sse.ts
+++ b/apps/web/src/api/sse.ts
@@ -53,7 +53,13 @@ export function subscribeToRun(
     }
     try {
       const envelope: SSEEnvelope = JSON.parse(msg.data);
-      console.debug('[sse] recv readyState=' + es.readyState + ' seq=' + envelope.seq + ' type=' + envelope.event.type);
+      // DEBUG-level: dev only. This fires per SSE frame — in a production
+      // build with DevTools open, Chromium retains every console message for
+      // the session, so per-frame debug output grows renderer memory without
+      // bound over a day of use. Vite strips this block from prod builds.
+      if (import.meta.env.DEV) {
+        console.debug('[sse] recv readyState=' + es.readyState + ' seq=' + envelope.seq + ' type=' + envelope.event.type);
+      }
       onEvent(envelope.event, envelope.seq);
     } catch {
       // Ignore parse errors for any non-JSON keepalive variant
@@ -77,7 +83,9 @@ export function subscribeToRun(
   };
 
   // Log open lifecycle once so we can see when a subscription is (re)established.
-  console.debug('[sse] subscribe runId=' + runId + ' openSilent=' + openSilent);
+  if (import.meta.env.DEV) {
+    console.debug('[sse] subscribe runId=' + runId + ' openSilent=' + openSilent);
+  }
 
   return es;
 }

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -259,7 +259,12 @@ export function useChatCore(options: UseChatCoreOptions) {
     // callbacks + ?after=<lastSeq> on reconnect) ---
     const onEventCb = (event: AgentEvent, seq?: number) => {
       const currentId = assistantIdRef.current;
-      console.debug('[chat] event type=' + event.type + ' runId=' + runId + ' assistantId=' + (currentId ?? '(empty)'));
+      // DEBUG-level, dev only: fires per SSE event. In production this would
+      // accumulate in Chromium's console buffer whenever DevTools is open —
+      // a real contributor to the renderer's day-long memory growth.
+      if (import.meta.env.DEV) {
+        console.debug('[chat] event type=' + event.type + ' runId=' + runId + ' assistantId=' + (currentId ?? '(empty)'));
+      }
       if (seq && seq > (lastSeqRef.current || 0)) lastSeqRef.current = seq;
       // Any frame (event or ping) = connection alive: reset backoff + watchdog.
       reconnectAttemptRef.current = 0;


### PR DESCRIPTION
## 背景

应用开一天一夜后内存占用达到 3GB。排查三个进程(Electron main / renderer / daemon)后确认多处无界增长,本 PR 修复其中确定性的部分。

## 修复内容

### desktop(Electron main)
| 文件 | 问题 | 修复 |
|---|---|---|
| `main.js` | daemon stdout/stderr 每行 push 进数组,**从启动到退出只进不出** | 新增 `CappedBuffer` 环形缓冲,只保留最近 200 行(退出诊断只需 tail) |
| `logger.js` | 轮转只在启动时检查一次,长会话日志文件照样涨;生产环境镜像 console 被 ARMS consoleError 收集成噪音 | 会话内超 1MB 即轮转;`app.isPackaged` 时不再镜像 console |

### daemon
| 文件 | 问题 | 修复 |
|---|---|---|
| `debug-log.ts` | `dbgLog` 无条件写文件 + console.warn,`sse-debug.log` 无轮转(实测 1.4MB 持续增长) | DEBUG 级通道:**生产默认静默**(`MOLIO_DEBUG=1` 启用排查);启用后 1MB 大小轮转,保留 `.old` |
| `runs-log-prune.ts`(新) | `~/.molio/runs/<runId>/` JSONL 日志**从不清理**,实测积累 1952 个目录/72MB | daemon 启动时清理 mtime 超 7 天的 run 日志目录 |
| `sse.ts` | SSE 流 ping + 实时事件**无条件 enqueue**,客户端停止消费(窗口最小化被节流)时 daemon 在流内队列堆积整个 run 的输出 | 背压检查 `controller.desiredSize`:停滞后停止入队,连续 4 个 ping 周期(约 60s)后主动关流;前端 EventSource 自动重连走 `?after=` 回放,**无数据丢失** |

### web(renderer)
- `api/sse.ts` / `useChatCore.ts`:每帧 SSE 都触发的 `console.debug` 加 `import.meta.env.DEV` 门禁,生产构建剔除——DevTools 打开时 Chromium 会无限保留 console 记录,是渲染进程膨胀主因之一。

## 测试

- daemon: 867/874 通过(新增 5 个测试文件:debug-log 轮转、debug-log 分级门禁、runs-log-prune、sse-stall 背压三场景——含停滞后重连无丢失回放验证)
- desktop: 193/193 通过(新增 capped-buffer 测试、logger 会话内轮转测试)
- web: typecheck 通过
- 唯一失败 `env.test "should not add dirs that do not exist"` 是**预存在的机器环境依赖测试**(本机装了 Python,其 Scripts 目录真实存在导致断言失败),与本 PR diff 无关,CI 机器通过

## 排查时确认无界的(无需改动)

RunManager 事件缓冲(2000 条上限 + 30min TTL)、wiki-fetcher LRU(50)、MessageDedup(TTL sweep)、ARMS offlineQueue(100)、VaultWatcher、Web 端 EventSource 生命周期。

## 已知遗留(后续 PR)

渲染进程的更大嫌疑:`ChatPane` 无虚拟化(`messages.map` 全量渲染)+ chat 状态挂在 App 根永不卸载,长会话/重任务(wiki build 的大量 tool 输出)下 DOM+state 累积。需要独立设计虚拟滚动或消息分页。

## 注意事项

- 与 #183(监控 stderr 降噪)有相邻改动(main.js / debug-log.ts / index.ts),合并时若冲突 rebase 解决,冲突面很小
- 调试开关:`set MOLIO_DEBUG=1` 后启动可重新获得 sse-debug.log 诊断通道

🤖 Generated with [Claude Code](https://claude.com/claude-code)