### PR TITLE
fix(daemon): 编码检测样本边界截断多字节字符导致 UTF-8 文件误判为 gb18030

### DIFF
--- a/apps/daemon/src/core/encoding.ts
+++ b/apps/daemon/src/core/encoding.ts
@@ -23,15 +23,47 @@ const FALLBACK_ENCODINGS = ['gb18030', 'big5', 'shift_jis', 'euc-jp', 'euc-kr'];
  */
 export function detectEncoding(sample: Buffer): string {
   if (sample.length === 0) return 'utf-8';
-  // BOM (TextDecoder('utf-8') strips a leading UTF-8 BOM automatically; UTF-16
-  // BOMs are handled by their own decoders, but we don't special-case them
-  // here — they are rare in .txt novels and would fail UTF-8 strict then
-  // fall through to lenient gb18030.)
-  if (validates(sample, 'utf-8')) return 'utf-8';
+  // A leading UTF-8 BOM is an authoritative signal from the writing tool —
+  // trust it outright. (TextDecoder('utf-8') strips it on decode; UTF-16 BOMs
+  // are rare in .txt/.md and would fail UTF-8 strict then fall through to
+  // lenient gb18030.)
+  if (sample.length >= 3 && sample[0] === 0xef && sample[1] === 0xbb && sample[2] === 0xbf) {
+    return 'utf-8';
+  }
+  // The fixed-size head read can cut a multibyte char in half at the sample
+  // boundary (e.g. bytes 65534-65535 of a 3-byte CJK char), which would make
+  // strict UTF-8 validation reject a perfectly valid file and mis-detect it as
+  // gb18030. Drop the partial tail so validation only sees complete
+  // sequences. Fallback encodings still validate on the ORIGINAL sample:
+  // trimming could remove a complete final DBCS char and break a validation
+  // that would otherwise pass.
+  const complete = trimPartialUtf8Tail(sample);
+  if (validates(complete, 'utf-8')) return 'utf-8';
   for (const enc of FALLBACK_ENCODINGS) {
     if (validates(sample, enc)) return enc;
   }
   return 'gb18030'; // lenient fallback
+}
+
+/**
+ * Drop a trailing incomplete UTF-8 sequence from a sample. Walk back at most
+ * 3 bytes (the max number of continuation bytes in a 4-byte sequence).
+ */
+function trimPartialUtf8Tail(buf: Buffer): Buffer {
+  for (let back = 1; back <= Math.min(3, buf.length); back += 1) {
+    const b = buf[buf.length - back];
+    if (b === undefined) return buf; // unreachable (back ≤ length) — be safe
+    if ((b & 0x80) === 0) return buf; // ASCII byte — clean boundary
+    if ((b & 0xc0) !== 0x80) {
+      // Lead byte: expected sequence length from the bit pattern.
+      const seqLen =
+        (b & 0xe0) === 0xc0 ? 2 :
+        (b & 0xf0) === 0xe0 ? 3 :
+        (b & 0xf8) === 0xf0 ? 4 : 1; // invalid lead — let strict check reject
+      return back < seqLen ? buf.subarray(0, buf.length - back) : buf;
+    }
+  }
+  return buf; // only continuation bytes found — let strict check reject
 }
 
 function validates(buf: Buffer, enc: string): boolean {

--- a/apps/daemon/test/core/encoding.test.ts
+++ b/apps/daemon/test/core/encoding.test.ts
@@ -30,6 +30,32 @@ describe('detectEncoding', () => {
     const enc = detectEncoding(Buffer.from([0xfe, 0xfe, 0xff, 0xff, 0x80, 0x81]));
     assert.ok(['gb18030', 'utf-8'].includes(enc));
   });
+  // Regression (2026-08-03): a 116KB UTF-8-BOM 国标文档 displayed as mojibake.
+  // The 64KB sample cut landed inside a 3-byte char (的 = e7 9a 84 split as
+  // e7 9a | 84), strict UTF-8 validation failed on the truncated sample, and
+  // detection fell through to the lenient gb18030 fallback.
+  it('utf-8 sample truncated mid-char at 64KB boundary → utf-8', () => {
+    const pad = Buffer.alloc(65534, 0x61); // 'a' × 65534
+    const splitChar = Buffer.from('的', 'utf8').subarray(0, 2); // e7 9a | 84 cut
+    assert.equal(detectEncoding(Buffer.concat([pad, splitChar])), 'utf-8');
+  });
+  it('utf-8 sample truncated mid-char (2-byte and 4-byte chars)', () => {
+    const pad = Buffer.alloc(100, 0x61);
+    assert.equal(detectEncoding(Buffer.concat([pad, Buffer.from([0xc2])])), 'utf-8'); // é = c2 a9 cut
+    assert.equal(detectEncoding(Buffer.concat([pad, Buffer.from([0xf0, 0x9f, 0x98])])), 'utf-8'); // 😀 cut
+  });
+  it('utf-8 BOM with truncated tail still → utf-8', () => {
+    const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+    const sample = Buffer.concat([bom, Buffer.alloc(64, 0x61), Buffer.from([0xe7])]);
+    assert.equal(detectEncoding(sample), 'utf-8');
+  });
+  it('complete multibyte char at sample tail is NOT trimmed', () => {
+    // 中 = e4 b8 ad fully present at the end — must stay utf-8, and GBK bytes
+    // that end on a char boundary must still detect as gb18030 (trim must not
+    // eat a complete final DBCS pair and change fallback validation).
+    assert.equal(detectEncoding(Buffer.concat([Buffer.alloc(10, 0x61), Buffer.from('中', 'utf8')])), 'utf-8');
+    assert.equal(detectEncoding(Buffer.from([0xc4, 0xe3, 0xba, 0xc3])), 'gb18030');
+  });
 });
 
 describe('decodeAll', () => {

--- a/apps/daemon/test/core/knowledge.test.ts
+++ b/apps/daemon/test/core/knowledge.test.ts
@@ -40,6 +40,26 @@ describe('readFile encoding + tiers', () => {
     assert.equal(f.content, 'hi');
   });
 
+  // Regression (2026-08-03): a 116KB UTF-8-BOM 国标 .md showed mojibake — the
+  // 64KB detection sample cut a 3-byte CJK char in half, strict UTF-8 failed,
+  // and the file was decoded as gb18030.
+  it('large utf-8 .md with 64KB boundary splitting a multibyte char → utf-8, intact content', () => {
+    const char = Buffer.from('的', 'utf8'); // e7 9a 84 — straddles byte 65536
+    const tail = '可燃气体探测器';
+    const body = Buffer.concat([
+      Buffer.alloc(65531, 0x61),           // 'a' × 65531 → with 3-byte BOM, char starts at 65534
+      char,                                 // occupies 65534-65536 (last byte past the cut)
+      Buffer.from(tail, 'utf8'),
+    ]);
+    writeFileSync(join(vp, 'big-split.md'), Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), body]));
+    const f = readFile(vp, 'big-split.md');
+    assert.equal(f.encoding, 'utf-8');
+    assert.ok(f.content.startsWith('aaaa'), 'content decoded, not mojibake');
+    assert.ok(f.content.includes('的'), 'split char intact');
+    assert.ok(f.content.endsWith(tail), 'tail intact');
+    assert.ok(!f.content.includes('锘'), 'no BOM-as-gb18030 mojibake marker');
+  });
+
   it('returns tooLarge (no content) when over soft cap, with encoding from sample', () => {
     // Lower the caps via env by writing a file just over MOLIO_MAX_VIEW_SIZE.
     // We instead test via a real >cap file using a sparse write is avoided:


### PR DESCRIPTION
## 问题

116KB 的 UTF-8（带 BOM）国标文档 `《可燃气体探测器 第1部分…》（GB 15322.1-2026）.md` 在 Molio 中打开显示乱码（开头出现「锘」等典型 GBK 误读痕迹）。

## 根因

`readFile` 取文件前 64KB 做编码检测（`detectEncoding`）：

1. 该文件在第 65534–65535 字节处，3 字节汉字「的」（`e7 9a 84`）正好骑在 64KB 切割线上，样本尾部只剩残序列 `e7 9a`
2. 严格 UTF-8 校验（`TextDecoder fatal`）因此失败
3. 兜底编码（gb18030/big5/shift_jis/euc-jp/euc-kr）严格校验也全部失败（同一残尾字节）
4. 落入宽松兜底 `return 'gb18030'` → 整个文件被当 GBK 解码 → 乱码（2674 个 U+FFFD）

## 修复（apps/daemon/src/core/encoding.ts）

- **BOM 快速路径**：样本开头为 `EF BB BF` 时直接判定 `utf-8`（写盘工具的权威信号，`TextDecoder('utf-8')` 解码时自动剥离）
- **`trimPartialUtf8Tail`**：严格 UTF-8 校验前，从样本尾部回退最多 3 字节，裁掉不完整的 UTF-8 序列，让校验只看到完整字符。兜底编码校验**仍用原始样本**——裁剪可能删掉完整的 DBCS 末字符，把原本通过的校验变成失败

## 验证

- 新增单元测试（encoding.test.ts）：64KB 边界骑线截断、2 字节/4 字节字符截断、BOM+残尾、完整字符不误裁、GBK 检测不受影响
- 新增端到端回归用例（knowledge.test.ts）：`readFile` 读 >64KB 且字符骑线的 .md，断言编码 utf-8 + 内容完整
- **先红后绿**：新测试在旧代码上失败（3 + 1 个），修复后全部通过
- 受影响套件（encoding / knowledge / routes-knowledge）119/119 通过；`pnpm typecheck` 全绿
- 用原始问题文件实测修复后管线：判定 `utf-8`，0 个替换字符，内容完整

## 影响面

仅 `detectEncoding` 内部逻辑，签名与返回值不变；`readFile` / 路由层无改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)