### PR TITLE
chore(ci): OCR review job 超时 15→60 分钟，适配大 diff PR

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -48,7 +48,8 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 大 diff（60+ 文件）逐文件 LLM 审查需要 25-40 分钟，15 分钟会超时被杀（PR #190 两次实测）。
+    timeout-minutes: 60
     # Run on PR events from the same repo (skip forks to protect LLM quota),
     # or on explicit /open-code-review | @open-code-review comments on any PR.
     # Draft PRs are skipped on auto-trigger; comment trigger still works.


### PR DESCRIPTION
## Summary
- Open Code Review 的 job `timeout-minutes` 从 15 提到 60，解除大 diff PR 的审查超时死锁
- PR #190（63 文件 +6887）两个模型两次尝试均跑满 15 分钟被杀；对照 21 文件的 PR #195 也要 10.6 分钟，逐文件 LLM 审查耗时与文件数成正比，63 文件估算需 25-40 分钟

## 背景
- 02:05 首次超时（模型 A）、02:42 换模型后 re-run 再次超时，证明瓶颈是 workflow 上限而非模型速度
- 触发器是 `pull_request_target`，workflow 从 main 读取，所以本 PR 必须先合入，再在 #190 评论 `/open-code-review` 重触发

## Test plan
- [ ] 本 PR 自身即验证：diff 仅 1 个文件，OCR 应在几分钟内跑完并留下审查评论
- [ ] 合入后在 #190 评论 `/open-code-review`，确认 60 分钟上限下审查完成