### PR TITLE
fix(desktop): 修复 dev:desktop 启动失败 — Node 24 electron 安装死锁 + #183 dev 窗口隐藏回归

### DIFF
--- a/apps/desktop/src/main.js
+++ b/apps/desktop/src/main.js
@@ -260,6 +260,19 @@ function createWindow() {
   });
 
   if (isDevMode()) {
+    // Dev-only show path. Production shows the window in loadApp() /
+    // showDaemonErrorPage() after the single app navigation (ARMS SDK
+    // auto-injection requires one navigation = one injection), but dev
+    // skips ARMS entirely, so showing as soon as the page is ready is
+    // correct here. Without this handler nothing ever calls show() in dev
+    // mode — the window stays hidden forever while the process looks
+    // healthy (renderer ready, DevTools docked inside a hidden window).
+    // This was the #183 regression: removing the shared ready-to-show
+    // handler fixed production splash→app double injection but silently
+    // dropped the only dev-mode show path.
+    mainWindow.once('ready-to-show', () => {
+      mainWindow?.show();
+    });
     mainWindow.webContents.openDevTools();
     mainWindow.loadURL('http://localhost:5173');
   }

--- a/apps/desktop/test/dev-window-show.test.js
+++ b/apps/desktop/test/dev-window-show.test.js
@@ -1,0 +1,82 @@
+/**
+ * Regression test — dev-mode main window never shown.
+ *
+ * #183 removed the shared `ready-to-show` handler from createWindow() to fix
+ * the ARMS Browser SDK double-injection problem (splash → app navigation).
+ * That was correct for production — loadApp() / showDaemonErrorPage() show
+ * the window after the single app navigation — but dev mode has no loadApp()
+ * call, so nothing ever called show(): `pnpm dev:desktop` left every process
+ * healthy (daemon up, vite up, renderer ready) with an invisible window.
+ *
+ * Dev mode skips ARMS init entirely, so a dev-only ready-to-show → show()
+ * handler is safe and restores the pre-#183 behaviour.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSource = readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf-8');
+
+/** Extract the createWindow() function body (up to the next top-level function). */
+function createWindowSource() {
+  const start = mainSource.indexOf('function createWindow()');
+  assert.notEqual(start, -1, 'createWindow() must exist in main.js');
+  const end = mainSource.indexOf('function loadApp()', start);
+  assert.notEqual(end, -1, 'loadApp() must follow createWindow() in main.js');
+  return mainSource.slice(start, end);
+}
+
+/** Extract the dev-mode branch inside createWindow(). */
+function devBranchSource() {
+  const body = createWindowSource();
+  const start = body.indexOf('if (isDevMode())');
+  assert.notEqual(start, -1, 'createWindow() must have a dev-mode branch');
+  // Take everything from the dev branch to the end of createWindow — the
+  // dev branch is the last statement in the function.
+  return body.slice(start);
+}
+
+describe('main.js dev-mode window visibility (regression: dev window never shown)', () => {
+  it('dev branch registers a ready-to-show handler that shows the window', () => {
+    const dev = devBranchSource();
+    assert.match(
+      dev,
+      /ready-to-show[\s\S]*?\.show\(\)/,
+      'dev mode must show the window via ready-to-show — without it nothing ' +
+        'ever calls show() and the window stays hidden forever',
+    );
+  });
+
+  it('dev branch still loads the Vite dev server', () => {
+    const dev = devBranchSource();
+    assert.ok(
+      dev.includes('http://localhost:5173'),
+      'dev mode must load the Vite dev server URL',
+    );
+  });
+
+  it('production show paths (loadApp / error page) are untouched', () => {
+    // The ARMS one-navigation-one-injection design requires production to
+    // keep showing the window only after the real app URL finishes loading.
+    const loadAppStart = mainSource.indexOf('function loadApp()');
+    assert.notEqual(loadAppStart, -1, 'loadApp() must exist');
+    const loadAppSrc = mainSource.slice(
+      loadAppStart,
+      mainSource.indexOf('function showDaemonErrorPage()', loadAppStart),
+    );
+    assert.match(
+      loadAppSrc,
+      /once\(\s*['"]did-finish-load['"]\s*,\s*onFinish\s*\)/,
+      'loadApp() must keep showing the window via did-finish-load',
+    );
+    assert.match(
+      loadAppSrc,
+      /onFinish\s*=[\s\S]*?\.show\(\)/,
+      'loadApp() onFinish must call mainWindow.show()',
+    );
+  });
+});

--- a/apps/desktop/test/electron-binary.test.js
+++ b/apps/desktop/test/electron-binary.test.js
@@ -69,11 +69,33 @@ describe('electron binary install guard (Node 24.16~24.17 zip deadlock)', () => 
         '(the yauzl override in pnpm-workspace.yaml repairs extraction);\n' +
         '  long term: upgrade Node.js to >=24.18.0.'
     );
-    const size = statSync(binaryPath).size;
+    // Truncation check must target the heavy payload, which differs by
+    // platform: on Windows/Linux the path.txt entry IS the monolithic
+    // binary (>100MB); on macOS it is a small launcher stub (~30KB) and
+    // the engine lives in Electron Framework.framework.
+    const heavyRel =
+      process.platform === 'darwin'
+        ? path.join(
+            'Electron.app',
+            'Contents',
+            'Frameworks',
+            'Electron Framework.framework',
+            'Versions',
+            'A',
+            'Electron Framework'
+          )
+        : binaryRel;
+    const heavyPath = path.join(electronDir, 'dist', heavyRel);
+    assert.ok(
+      existsSync(heavyPath),
+      `electron payload missing: ${heavyRel} — truncated extraction, ` +
+        'delete node_modules and reinstall (nodejs/node#63487)'
+    );
+    const size = statSync(heavyPath).size;
     assert.ok(
       size > 1024 * 1024,
-      `electron binary is only ${size} bytes — truncated extraction, ` +
-        'delete node_modules and reinstall (nodejs/node#63487)'
+      `electron payload ${heavyRel} is only ${size} bytes — truncated ` +
+        'extraction, delete node_modules and reinstall (nodejs/node#63487)'
     );
   });
 });

--- a/apps/desktop/test/electron-binary.test.js
+++ b/apps/desktop/test/electron-binary.test.js
@@ -1,0 +1,79 @@
+/**
+ * Regression test for: `pnpm dev:desktop` fails with
+ *   [desktop] [ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @molio/desktop dev: `electron .`
+ *   Electron failed to install correctly, please delete node_modules/electron ...
+ *
+ * Root cause: Node.js 24.16.0~24.17.x ships a streams regression
+ * (https://github.com/nodejs/node/issues/63487). electron's postinstall
+ * unzips the artifact via extract-zip@2 -> yauzl@2 -> fd-slicer@1, whose
+ * legacy end-of-stream idiom (`self.destroyed = true; self.push(null)`)
+ * deadlocks the new backpressure-resume path on large zip entries.
+ * install.js then "succeeds" mid-extraction (silent exit 0) and leaves a
+ * truncated dist/ without electron.exe; pnpm's store build cache replays
+ * the poisoned result on every later install, skipping install.js entirely.
+ *
+ * Fix: override yauzl to >=3.3.1 in pnpm-workspace.yaml (3.3.1 rewrote the
+ * stream handling), workaround per https://github.com/electron/forge/issues/4277.
+ * Upstream Node fix landed in 24.18.0 (revert PR nodejs/node#63834).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const pkgRoot = path.resolve(import.meta.dirname, '..');
+const repoRoot = path.resolve(pkgRoot, '../..');
+const electronDir = path.join(pkgRoot, 'node_modules', 'electron');
+
+describe('electron binary install guard (Node 24.16~24.17 zip deadlock)', () => {
+  it('pnpm-workspace.yaml must override yauzl to >=3.3.1', () => {
+    const yaml = readFileSync(path.join(repoRoot, 'pnpm-workspace.yaml'), 'utf-8');
+    const m = yaml.match(/yauzl:\s*['"]?[~^]?(\d+)\.(\d+)\.(\d+)/);
+    assert.ok(
+      m,
+      'overrides.yauzl missing in pnpm-workspace.yaml — electron postinstall ' +
+        'deadlocks on Node 24.16.0~24.17.x (nodejs/node#63487)'
+    );
+    const major = Number(m[1]);
+    const minor = Number(m[2]);
+    assert.ok(
+      major > 3 || (major === 3 && minor >= 3),
+      `yauzl override must be >=3.3.1 (found "${m[0]}") — older yauzl ` +
+        'deadlocks while extracting the electron zip on Node 24.16~24.17'
+    );
+  });
+
+  it('electron dist binary exists and is not truncated', () => {
+    const pathTxt = path.join(electronDir, 'path.txt');
+    if (!existsSync(pathTxt)) {
+      // ELECTRON_SKIP_BINARY_DOWNLOAD intentionally skips the download.
+      assert.ok(
+        process.env.ELECTRON_SKIP_BINARY_DOWNLOAD,
+        'node_modules/electron/path.txt missing — electron postinstall never ' +
+          'completed. Delete node_modules and re-run `pnpm install`; if on ' +
+          'Node 24.16.0~24.17.x upgrade to >=24.18.0 (nodejs/node#63487).'
+      );
+      return;
+    }
+    const binaryRel = readFileSync(pathTxt, 'utf-8').trim();
+    // electron/index.js resolves the binary as <pkg>/dist/<path.txt>.
+    const binaryPath = path.join(electronDir, 'dist', binaryRel);
+    assert.ok(
+      existsSync(binaryPath),
+      `electron binary missing: ${binaryRel}.\n` +
+        '  electron postinstall silently extracted a truncated zip (Node ' +
+        '24.16~24.17 streams deadlock, nodejs/node#63487) and pnpm cached ' +
+        'the broken result.\n' +
+        '  Fix: delete all node_modules and re-run `pnpm install` ' +
+        '(the yauzl override in pnpm-workspace.yaml repairs extraction);\n' +
+        '  long term: upgrade Node.js to >=24.18.0.'
+    );
+    const size = statSync(binaryPath).size;
+    assert.ok(
+      size > 1024 * 1024,
+      `electron binary is only ${size} bytes — truncated extraction, ` +
+        'delete node_modules and reinstall (nodejs/node#63487)'
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  yauzl: ^3.3.1
+
 importers:
 
   .:
@@ -178,7 +181,7 @@ importers:
         version: 19.2.16
       '@types/react-dom':
         specifier: ^19.0.0
-        version: 19.2.3(@types/react@19.2.16)
+        version: 19.2.4(@types/react@19.2.16)
       '@types/turndown':
         specifier: ^5.0.6
         version: 5.0.6
@@ -1139,8 +1142,8 @@ packages:
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
       '@types/react': ^19.2.0
 
@@ -1782,9 +1785,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3335,8 +3335,9 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5036,7 +5037,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       get-stream: 5.2.0
-      yauzl: 2.10.0
+      yauzl: 3.4.0
     optionalDependencies:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
@@ -5060,10 +5061,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6633,10 +6630,9 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
-  yauzl@2.10.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4215,7 +4215,7 @@ snapshots:
     dependencies:
       '@types/node': 24.13.1
 
-  '@types/react-dom@19.2.3(@types/react@19.2.16)':
+  '@types/react-dom@19.2.4(@types/react@19.2.16)':
     dependencies:
       '@types/react': 19.2.16
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 packages:
   - "packages/*"
   - "apps/*"
+# Node.js 24.16.0~24.17.x 存在 streams 回归（nodejs/node#63487），
+# 导致 electron postinstall 的解压链（extract-zip@2 → yauzl@2 → fd-slicer@1）
+# 在大文件条目上背压死锁、静默退出 0，electron.exe 装不出来，
+# pnpm dev:desktop 报 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL /
+# "Electron failed to install correctly"。yauzl 3.3.1 修复了该流处理缺陷，
+# 覆盖后无需锁定 Node 小版本（Node >=26 同样受益）。
+overrides:
+  yauzl: ^3.3.1
 onlyBuiltDependencies:
   - electron
   - esbuild


### PR DESCRIPTION
## Summary

- **问题**：`pnpm dev:desktop` 报 `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` / \"Electron failed to install correctly\"，electron.exe 缺失。与日志监控降噪 PR (#183) 时间上巧合，但实际根因是本机 Node 升级到了 **v24.16.0**。
- **根因**：Node.js 24.16.0~24.17.x 的 streams 回归（[nodejs/node#63487](https://github.com/nodejs/node/issues/63487)）使 electron postinstall 的解压链 `extract-zip@2 → yauzl@2 → fd-slicer@1` 在大 zip 条目上背压死锁、静默退出 0，留下残缺 dist；pnpm 构建缓存还会把残缺产物回放给后续每次安装，导致所有新 worktree 复现。
- **修复**：`pnpm-workspace.yaml` 覆盖 `yauzl: ^3.3.1`（解析为 3.4.0，重写了流处理、彻底移除 fd-slicer 依赖，workaround 来自 [electron/forge#4277](https://github.com/electron/forge/issues/4277)）。已在**仍为 Node 24.16.0** 的本机验证：完整解压出 electron.exe，`pnpm dev:desktop` 三进程全部正常（daemon :3100 / web :5173 / electron 窗口）。
- **测试**：按错误驱动测试规则新增 `apps/desktop/test/electron-binary.test.js` 守卫测试（校验 yauzl override 存在 + electron 二进制完整，缺失时报出修复指引）；desktop 全量 205 用例通过（198 pass / 0 fail）。

> Node 上游修复已随 24.18.0 发布（revert [nodejs/node#63834](https://github.com/nodejs/node/pull/63834)）。建议本机 Node 升级到 >=24.18.0；有本 override 后 Molio 在受影响 Node 版本上也不再受影响。
>
> 附注：lockfile 含一处无关漂移（`@types/react-dom` 19.2.3→19.2.4，types-only patch，系强制重解析带入），与磁盘安装状态一致。

## Test plan

- [x] `node --test apps/desktop/test/electron-binary.test.js` 通过
- [x] `pnpm --filter @molio/desktop test` 全量通过
- [x] Node 24.16.0 下全新安装完整解出 electron.exe（214MB）
- [x] `pnpm dev:desktop` 启动验证：daemon/web 均 200，electron 进程存活、renderer ready

## 追加修复（0265808，maintainer 补充）

安装死锁修好后，`pnpm dev:desktop` 仍看不到窗口——这是 **#183 (33e400f) 引入的另一个独立回归**，与本 PR 的 Node 版本问题无关：

- **根因**：#183 为修 ARMS Browser SDK splash→app 双重注入，移除了 `createWindow()` 的共享 `ready-to-show` handler；生产模式改由 `loadApp()` 在应用加载完成后显示窗口，但 dev 模式没有 `loadApp()` 路径，窗口以 `show: false` 创建后**永远不显示**。三进程全部正常（daemon/vite/renderer ready）、DevTools 停靠在隐藏窗口里，表现为"进程活着但看不到窗口"。
- **修复**：dev 模式完全跳过 ARMS 初始化（无注入顾虑），在 `createWindow()` dev 分支恢复 `ready-to-show → show()`；生产显示路径不动。
- **测试**：新增 `apps/desktop/test/dev-window-show.test.js`（对修复前源码失败 ✖ / 修复后通过 ✔）；desktop 全套 208/208 绿。
