### PR TITLE
fix(ci): OCR review 在 PR 标题含双引号时崩溃 — 标题改经 env 传递

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -118,6 +118,15 @@ jobs:
 
       - name: Run OpenCodeReview
         id: review
+        env:
+          # Pass the PR title via an env var instead of inline ${{ }} expansion.
+          # Actions expands ${{ }} as plain text BEFORE the shell runs, so a title
+          # containing double quotes (e.g. `消除 ARMS "fetch failed" 自报噪音`,
+          # PR #206) breaks the shell quoting around --background: the leftover
+          # words become positional args and cobra rejects them with
+          # `unknown command "..." for "ocr review"`. Env vars are set by the
+          # runner without shell parsing, so any title characters are safe.
+          PR_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
         run: |
           # Get base ref and head SHA from PR context (different for comment triggers)
           # Note: We use HEAD_SHA instead of origin/${HEAD_REF} to support fork PRs,
@@ -138,7 +147,7 @@ jobs:
             --to "${HEAD_SHA}" \
             --format json \
             --audience agent \
-            --background "${{ github.event.pull_request.title || github.event.issue.title }}" \
+            --background "${PR_TITLE}" \
             > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log || true
 
           echo "OCR review completed. Output:"


### PR DESCRIPTION
## Summary

- **问题**：`ocr-review.yml` 把 PR 标题用 `${{ }}` 内联展开进 `run:` 的 shell 命令。Actions 先做文本替换再交给 shell，标题含双引号时（如 PR #206 `消除 ARMS "fetch failed" 自报噪音`）会提前闭合 `--background` 的引号，残余词变成位置参数，cobra 报 `unknown command "failed 自报噪音" for "ocr review"`，整个 review 不产出任何内容
- **修复**：标题改经 step-level `env: PR_TITLE` 传递，runner 直接设环境变量不经 shell 解析，任何标题字符（引号/反引号/`$`）都安全。`--background "${PR_TITLE}"` 引用
- #206 已通过改标题 + `/open-code-review` 评论重触发；本 PR 合并后此类标题不再需要规避

## 备注

同一步骤里 `BASE_REF`/`HEAD_SHA` 也是内联展开，但 git ref 名不允许空格/引号，风险低，本次不动。

## Test plan

- [x] 修改后 YAML 经 js-yaml 解析通过
- [ ] 合并后在任一标题含双引号的 PR 上验证 OCR 正常产出（或直接观察下一个普通 PR）