### PR TITLE
feat(daemon): 技能管理优化 — vault 技能目录改用可读名称

### DIFF
--- a/apps/daemon/src/core/skills/builtin.ts
+++ b/apps/daemon/src/core/skills/builtin.ts
@@ -15,7 +15,8 @@
  *    unreadable source dir.
  *  - **core** (writing trio): Molio's core job. The body is written to
  *    `~/.molio/skills/<id>/SKILL.md` and synced into every vault like a
- *    library skill (single-file `molio--<id>` dirs).
+ *    library skill (single-file `molio--<dirName>` dirs, dirName planned from
+ *    the display name by sync.planSyncTargets).
  *
  * Seeding is idempotent: an existing row (by id) only gets its name/description
  * refreshed — `enabled`/`core` are NEVER overwritten, so the user's toggle state
@@ -25,7 +26,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type Database from 'better-sqlite3';
 import { parseSkillMd } from '@molio/contracts';
-import { assertSafeSkillId, type SkillPathsOpts } from './paths.js';
+import { assertSafeSkillPathSegment, type SkillPathsOpts } from './paths.js';
 import { createSkill, getSkill } from './store.js';
 import { BUILTIN_SKILLS, RETIRED_BUNDLED_SKILLS, resolveSkillsSourceDir } from '../skill-installer.js';
 
@@ -73,9 +74,9 @@ export function readBundledInstructions(slug: string, sourceDir?: string): strin
   try {
     // Defense in depth: this is an exported file-read entry point (GET
     // /api/skills/:id). Callers pass DB-derived slugs today, but a traversal
-    // id like '../..' must never build a path — assertSafeSkillId throws and
-    // the catch below degrades to ''.
-    assertSafeSkillId(slug);
+    // id like '../..' must never build a path — assertSafeSkillPathSegment
+    // throws and the catch below degrades to ''.
+    assertSafeSkillPathSegment(slug);
     const md = path.join(sourceDir ?? resolveSkillsSourceDir(), slug, 'SKILL.md');
     if (!fs.existsSync(md)) return '';
     return parseSkillMd(fs.readFileSync(md, 'utf8')).instructions;

--- a/apps/daemon/src/core/skills/dirsync.ts
+++ b/apps/daemon/src/core/skills/dirsync.ts
@@ -1,6 +1,6 @@
 /**
  * Generic directory-mirroring primitives shared by both sync paths:
- *  - library/core skills → `molio--<id>/` dirs (sync.ts),
+ *  - library/core skills → `molio--<dirName>/` dirs (sync.ts),
  *  - bundled skills → plain `<slug>/` whole dirs (skill-installer.ts).
  *
  * One staleness rule for both: a destination is fresh iff it byte-for-byte

--- a/apps/daemon/src/core/skills/hub.ts
+++ b/apps/daemon/src/core/skills/hub.ts
@@ -16,20 +16,26 @@
  * coexist as separate installs.
  *
  * The hub API needs no auth for browse/download:
- *   GET <base>/api/skills?page=&pageSize=&keyword=&category=   catalog list
+ *   GET <base>/api/skills?page=&pageSize=&keyword=&category=[&sortBy=&order=]  catalog list
  *   GET <base>/api/v1/categories                               category list
+ *   GET <base>/api/v1/skills/<slug>[?namespace=]               skill detail (plain JSON)
+ *   GET <base>/api/v1/skills/<slug>/file?path=SKILL.md[&namespace=]  raw SKILL.md (302 → COS)
  *   GET <base>/api/v1/download?slug=<slug>[&version=][&namespace=]  zip package
  *
- * Package format == Molio's own: SKILL.md (+ optional _meta.json / siblings).
+ * List sortBy ∈ {score (default), downloads, updated_at, stars, installs};
+ * order ∈ {asc, desc}. The detail endpoint returns the skill page data
+ * (stats/owner/securityReports/…) WITHOUT the {code,data} envelope the list
+ * uses. Package format == Molio's own: SKILL.md (+ optional _meta.json / siblings).
  */
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Unzip, UnzipInflate } from 'fflate';
 import type Database from 'better-sqlite3';
-import { parseSkillMd } from '@molio/contracts';
+import { parseSkillMd, stripFrontmatter } from '@molio/contracts';
 import type {
   HubCategory,
+  HubSkillDetail,
   HubSkillSummary,
   HubSkillsQuery,
   InstallHubSkillRequest,
@@ -160,12 +166,28 @@ export interface HubListResult {
 
 const HUB_PAGE_SIZE_MAX = 50;
 
+/**
+ * Sort options accepted by our API → upstream list params. The hub rejects
+ * unknown sortBy values with a 400, so anything not in this map (including
+ * 'default' and garbage from the query string) silently keeps the hub's own
+ * ranking instead of erroring our UI.
+ */
+const HUB_SORT_MAP: Record<string, { sortBy: string; order: string }> = {
+  downloads: { sortBy: 'downloads', order: 'desc' },
+  updated: { sortBy: 'updated_at', order: 'desc' },
+};
+
 export async function fetchHubSkills(query: HubSkillsQuery): Promise<HubListResult> {
   const page = Math.max(1, Math.floor(query.page ?? 1) || 1);
   const pageSize = Math.min(HUB_PAGE_SIZE_MAX, Math.max(1, Math.floor(query.pageSize ?? 20) || 20));
   const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
   if (query.keyword?.trim()) params.set('keyword', query.keyword.trim());
   if (query.category?.trim()) params.set('category', query.category.trim());
+  const sortCfg = HUB_SORT_MAP[query.sort ?? ''];
+  if (sortCfg) {
+    params.set('sortBy', sortCfg.sortBy);
+    params.set('order', sortCfg.order);
+  }
 
   const body = await hubFetchJson(`${hubApiBase()}/api/skills?${params.toString()}`);
   // Envelope: { code: 0, data: { skills: [...], total }, message }
@@ -201,6 +223,119 @@ export async function fetchHubCategories(): Promise<HubCategory[]> {
         (typeof b.sortOrder === 'number' ? b.sortOrder : 0),
     )
     .map((c) => ({ key: asString(c.key), name: asString(c.name) }));
+}
+
+// ─── Skill detail (store detail modal) ───
+
+/** Cap on the SKILL.md fetched for the detail view — text-only bomb guard. */
+export const MAX_HUB_README_BYTES = 256 * 1024;
+
+function asNumber(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+/** Loose typing of the raw `GET /api/v1/skills/<slug>` response (no envelope). */
+interface RawHubSkillDetail {
+  slug?: unknown;
+  skill?: {
+    category?: unknown;
+    createdAt?: unknown;
+    displayName?: unknown;
+    iconUrl?: unknown;
+    labels?: { requires_api_key?: unknown } | null;
+    slug?: unknown;
+    sourceUrl?: unknown;
+    stats?: { downloads?: unknown; installs?: unknown; stars?: unknown; versions?: unknown } | null;
+    summary?: unknown;
+    summary_zh?: unknown;
+    updatedAt?: unknown;
+    verified?: unknown;
+  } | null;
+  latestVersion?: { version?: unknown; changelog?: unknown } | null;
+  owner?: { handle?: unknown; displayName?: unknown } | null;
+  namespace?: { handle?: unknown } | null;
+  securityReports?: {
+    keen?: { statusText?: unknown } | null;
+    sanbu?: { statusText?: unknown } | null;
+  } | null;
+}
+
+/**
+ * Fetch the latest SKILL.md body for `slug`, frontmatter stripped. ANY failure
+ * (404, network, oversize) resolves to '' — the readme enriches the detail
+ * modal but must never block the detail itself.
+ */
+async function fetchHubSkillReadme(slug: string, namespace: string | undefined): Promise<string> {
+  try {
+    const params = new URLSearchParams({ path: 'SKILL.md' });
+    if (namespace) params.set('namespace', namespace);
+    const res = await hubFetch(
+      `${hubApiBase()}/api/v1/skills/${encodeURIComponent(slug)}/file?${params.toString()}`,
+      HUB_LIST_TIMEOUT_MS,
+    );
+    if (!res.ok) return '';
+    // The file endpoint 302s to COS (fetch follows it); the CDN usually sends
+    // Content-Length, so pre-check before buffering the body.
+    const len = Number(res.headers.get('content-length'));
+    if (Number.isFinite(len) && len > MAX_HUB_README_BYTES) return '';
+    const text = await res.text();
+    if (text.length > MAX_HUB_README_BYTES) return '';
+    return stripFrontmatter(text).trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Aggregate one hub skill's detail page: `GET /api/v1/skills/<slug>` (stats,
+ * owner, security verdicts, latest version) + its SKILL.md body. Throws
+ * HubError NOT_FOUND for an unknown slug, HUB_UNAVAILABLE on network/parse
+ * failures — same contract as the list endpoints.
+ */
+export async function fetchHubSkillDetail(slug: string, namespace?: string): Promise<HubSkillDetail> {
+  const trimmed = slug.trim();
+  if (!trimmed) throw new HubError('BAD_REQUEST', 'slug is required');
+  const ns = namespace?.trim() || undefined;
+  const qs = ns ? `?namespace=${encodeURIComponent(ns)}` : '';
+  const body = (await hubFetchJson(
+    `${hubApiBase()}/api/v1/skills/${encodeURIComponent(trimmed)}${qs}`,
+  )) as unknown as RawHubSkillDetail;
+
+  const skill = body.skill ?? {};
+  const finalSlug = asString(skill.slug).trim() || trimmed;
+  const nsHandle = asString(body.namespace?.handle).trim() || ns || '';
+  const readme = await fetchHubSkillReadme(trimmed, ns);
+  // Prefer the Chinese summary — same zh-first rule as the list mapper.
+  const description = asString(skill.summary_zh).trim() || asString(skill.summary).trim();
+  const changelog = asString(body.latestVersion?.changelog).trim();
+  const keen = asString(body.securityReports?.keen?.statusText).trim();
+  const sanbu = asString(body.securityReports?.sanbu?.statusText).trim();
+
+  return {
+    slug: finalSlug,
+    name: asString(skill.displayName).trim() || finalSlug,
+    description,
+    category: asString(skill.category),
+    sourceUrl: asString(skill.sourceUrl),
+    iconUrl: asString(skill.iconUrl),
+    createdAt: asNumber(skill.createdAt),
+    updatedAt: asNumber(skill.updatedAt),
+    verified: skill.verified === true,
+    requiresApiKey: skill.labels?.requires_api_key === 'true',
+    ownerName:
+      asString(body.owner?.displayName).trim() || asString(body.owner?.handle).trim() || nsHandle,
+    ...(nsHandle ? { namespace: nsHandle } : {}),
+    latestVersion: asString(body.latestVersion?.version),
+    ...(changelog ? { changelog } : {}),
+    stats: {
+      downloads: asNumber(skill.stats?.downloads),
+      installs: asNumber(skill.stats?.installs),
+      stars: asNumber(skill.stats?.stars),
+      versions: asNumber(skill.stats?.versions),
+    },
+    readme,
+    ...(keen || sanbu ? { security: { ...(keen ? { keen } : {}), ...(sanbu ? { sanbu } : {}) } } : {}),
+  };
 }
 
 // ─── Package download + extraction ───

--- a/apps/daemon/src/core/skills/hub.ts
+++ b/apps/daemon/src/core/skills/hub.ts
@@ -275,11 +275,24 @@ async function fetchHubSkillReadme(slug: string, namespace: string | undefined):
     );
     if (!res.ok) return '';
     // The file endpoint 302s to COS (fetch follows it); the CDN usually sends
-    // Content-Length, so pre-check before buffering the body.
+    // Content-Length, so pre-check before touching the body.
     const len = Number(res.headers.get('content-length'));
     if (Number.isFinite(len) && len > MAX_HUB_README_BYTES) return '';
-    const text = await res.text();
-    if (text.length > MAX_HUB_README_BYTES) return '';
+    // Stream the body with a hard byte cap: res.text() would buffer the WHOLE
+    // response before any check could run, so a missing/lying Content-Length
+    // would let an arbitrarily large SKILL.md balloon daemon memory (OOM).
+    // Same early-abort pattern as downloadHubZip. Chunks are collected (not
+    // string-concatenated per chunk) so a multi-byte UTF-8 char split across
+    // two chunks still decodes cleanly.
+    if (!res.body) return '';
+    const chunks: Uint8Array[] = [];
+    let bytes = 0;
+    for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+      bytes += chunk.byteLength;
+      if (bytes > MAX_HUB_README_BYTES) return '';
+      chunks.push(chunk);
+    }
+    const text = Buffer.concat(chunks).toString('utf8');
     return stripFrontmatter(text).trim();
   } catch {
     return '';

--- a/apps/daemon/src/core/skills/paths.ts
+++ b/apps/daemon/src/core/skills/paths.ts
@@ -70,13 +70,26 @@ export function assertSafeSkillPathSegment(segment: string): void {
 const MAX_SLUG_LEN = 64;
 
 /**
+ * Max UTF-8 BYTES of a slug. Filesystems cap a single path component at 255
+ * BYTES (NAME_MAX on Linux/APFS — the Docker/NAS deploy targets), and a code
+ * point cap alone does not bound bytes: 64 astral-plane letters (4-byte UTF-8,
+ * e.g. CJK Extension B) are 256 bytes — ENAMETOOLONG before the `molio--`
+ * prefix is even added, and that skill would then fail to sync on EVERY
+ * reconcile. 200 bytes leaves headroom for the prefix plus collision suffixes
+ * added by planSyncTargets (`-<id8>` = 9B, `-<full uuid>` = 37B, escalated
+ * `-<full uuid>-<id8>` = 46B): worst case 7 + 200 + 46 = 253 ≤ 255.
+ */
+const MAX_SLUG_BYTES = 200;
+
+/**
  * Slugify a skill's display name into a readable, filesystem-safe dir segment
  * (the part after the `molio--` prefix in synced skill dirs).
  *
  * Rules: NFKC-normalize first (full-width ｖ２ → v2); keep Unicode letters and
  * digits (Chinese names stay readable); lowercase (case-insensitive filesystem
  * parity + runtime naming convention); map every other char to `-`; collapse
- * `-` runs; trim edge `-`; cap at MAX_SLUG_LEN code points.
+ * `-` runs; trim edge `-`; cap at MAX_SLUG_LEN code points AND MAX_SLUG_BYTES
+ * UTF-8 bytes (either cap alone is insufficient — see MAX_SLUG_BYTES).
  *
  * May return '' (e.g. emoji-only names) — callers fall back to an id-derived
  * segment. Every NON-EMPTY output satisfies isValidSkillPathSegment (no
@@ -97,6 +110,16 @@ export function slugifySkillName(name: string): string {
   const points = Array.from(slug);
   if (points.length > MAX_SLUG_LEN) {
     slug = points.slice(0, MAX_SLUG_LEN).join('').replace(/-+$/, '');
+  }
+  // Byte cap (NAME_MAX safety — see MAX_SLUG_BYTES). The code-point cap does
+  // not bound bytes for 4-byte astral characters, so trim code points from the
+  // end until the UTF-8 encoding fits.
+  if (Buffer.byteLength(slug, 'utf8') > MAX_SLUG_BYTES) {
+    const pts = Array.from(slug);
+    while (pts.length > 0 && Buffer.byteLength(pts.join(''), 'utf8') > MAX_SLUG_BYTES) {
+      pts.pop();
+    }
+    slug = pts.join('').replace(/-+$/, '');
   }
   return slug;
 }

--- a/apps/daemon/src/core/skills/paths.ts
+++ b/apps/daemon/src/core/skills/paths.ts
@@ -3,12 +3,19 @@
  *
  * Source of truth: `~/.molio/skills/<id>/SKILL.md` (library/core content) +
  *                   the daemon's `skills` table (metadata + master switch).
- * Effect (sync):    `<vault>/.claude/skills/molio--<id>/SKILL.md` — per-vault
- *                   fan-out driven by vault-config.ts (claudeHome is pointed at
- *                   the vault's `.claude`). The `molio--` prefix namespaces
- *                   Molio-owned skills so we never touch the user's own skills.
+ * Effect (sync):    `<vault>/.claude/skills/molio--<dirName>/SKILL.md` —
+ *                   per-vault fan-out driven by vault-config.ts (claudeHome is
+ *                   pointed at the vault's `.claude`). dirName is the skill's
+ *                   slugified DISPLAY NAME (slugifySkillName below, collisions
+ *                   resolved by sync.planSyncTargets), so runtime CLI skill
+ *                   lists show readable names instead of DB uuids. The
+ *                   `molio--` prefix namespaces Molio-owned skills so we never
+ *                   touch the user's own skills.
  * Legacy:           pre-per-vault builds synced to `~/.claude/skills/molio--*`;
  *                   startup cleanup removes those (cleanupLegacyGlobalSync).
+ *                   Older per-vault builds used `molio--<uuid>` dir names; to
+ *                   the name-based reconcile those are plain orphans and get
+ *                   swept automatically — no migration code needed.
  *
  * Every helper accepts optional `molioHome` / `claudeHome` overrides so tests
  * can point them at temp directories (no HOME monkey-patching needed).
@@ -33,29 +40,65 @@ export function defaultClaudeHome(): string {
 }
 
 /**
- * True when `id` is a single safe path segment (no separators, no `.`/`..`,
- * bounded length). Skill ids are interpolated into filesystem paths; enforcing
- * the invariant HERE — the module that owns the path layout — means no caller
- * (DB row, route param, imported filename) can ever escape the skills dirs.
+ * True when `segment` is a single safe path segment (no separators, no
+ * `.`/`..`, bounded length). Skill ids AND synced dir names (slugified display
+ * names) are interpolated into filesystem paths; enforcing the invariant HERE —
+ * the module that owns the path layout — means no caller (DB row, route param,
+ * imported filename, user-chosen display name) can ever escape the skills dirs.
  */
-export function isValidSkillId(id: string): boolean {
+export function isValidSkillPathSegment(segment: string): boolean {
   return (
-    typeof id === 'string' &&
-    id.length > 0 &&
-    id.length <= 128 &&
-    id !== '.' &&
-    id !== '..' &&
-    !id.includes('/') &&
-    !id.includes('\\') &&
-    id === path.basename(id)
+    typeof segment === 'string' &&
+    segment.length > 0 &&
+    segment.length <= 128 &&
+    segment !== '.' &&
+    segment !== '..' &&
+    !segment.includes('/') &&
+    !segment.includes('\\') &&
+    segment === path.basename(segment)
   );
 }
 
-/** Throw when `id` is not a safe skill id (see isValidSkillId). */
-export function assertSafeSkillId(id: string): void {
-  if (!isValidSkillId(id)) {
-    throw new Error(`Invalid skill id: ${JSON.stringify(id)}`);
+/** Throw when `segment` is not a safe path segment (see isValidSkillPathSegment). */
+export function assertSafeSkillPathSegment(segment: string): void {
+  if (!isValidSkillPathSegment(segment)) {
+    throw new Error(`Invalid skill path segment: ${JSON.stringify(segment)}`);
   }
+}
+
+/** Max code points of a slugified skill dir name (bounded well under the 128 segment cap). */
+const MAX_SLUG_LEN = 64;
+
+/**
+ * Slugify a skill's display name into a readable, filesystem-safe dir segment
+ * (the part after the `molio--` prefix in synced skill dirs).
+ *
+ * Rules: NFKC-normalize first (full-width ｖ２ → v2); keep Unicode letters and
+ * digits (Chinese names stay readable); lowercase (case-insensitive filesystem
+ * parity + runtime naming convention); map every other char to `-`; collapse
+ * `-` runs; trim edge `-`; cap at MAX_SLUG_LEN code points.
+ *
+ * May return '' (e.g. emoji-only names) — callers fall back to an id-derived
+ * segment. Every NON-EMPTY output satisfies isValidSkillPathSegment (no
+ * separators/dots/spaces survive, so no Windows reserved-name or trailing-dot
+ * traps; the molio-- prefix additionally guarantees the full dir name is
+ * never a bare reserved word like `con`).
+ */
+export function slugifySkillName(name: string): string {
+  let slug = '';
+  for (const ch of name.normalize('NFKC')) {
+    if (/^[\p{L}\p{N}]$/u.test(ch)) {
+      slug += ch.toLowerCase();
+    } else if (slug.length > 0 && !slug.endsWith('-')) {
+      slug += '-';
+    }
+  }
+  if (slug.endsWith('-')) slug = slug.slice(0, -1);
+  const points = Array.from(slug);
+  if (points.length > MAX_SLUG_LEN) {
+    slug = points.slice(0, MAX_SLUG_LEN).join('').replace(/-+$/, '');
+  }
+  return slug;
 }
 
 /** `~/.molio/skills` */
@@ -65,7 +108,7 @@ export function skillsDir(opts?: SkillPathsOpts): string {
 
 /** `~/.molio/skills/<id>` */
 export function skillContentDir(id: string, opts?: SkillPathsOpts): string {
-  assertSafeSkillId(id);
+  assertSafeSkillPathSegment(id);
   return path.join(skillsDir(opts), id);
 }
 
@@ -74,10 +117,14 @@ export function claudeSkillsDir(opts?: SkillPathsOpts): string {
   return path.join(opts?.claudeHome ?? defaultClaudeHome(), 'skills');
 }
 
-/** `~/.claude/skills/molio--<id>` */
-export function molioSkillDir(id: string, opts?: SkillPathsOpts): string {
-  assertSafeSkillId(id);
-  return path.join(claudeSkillsDir(opts), `${MOLIO_PREFIX}${id}`);
+/**
+ * `<claudeHome>/skills/molio--<dirName>` — `dirName` is the PLANNED segment
+ * for the vault side (slugified display name, see sync.planSyncTargets), NOT
+ * a skill id. Library content stays keyed by id under `~/.molio/skills/`.
+ */
+export function molioSkillDir(dirName: string, opts?: SkillPathsOpts): string {
+  assertSafeSkillPathSegment(dirName);
+  return path.join(claudeSkillsDir(opts), `${MOLIO_PREFIX}${dirName}`);
 }
 
 /** Neutral scratch dir used as cwd for throwaway prefill runs (no project CLAUDE.md leaks in). */

--- a/apps/daemon/src/core/skills/sync.ts
+++ b/apps/daemon/src/core/skills/sync.ts
@@ -7,6 +7,12 @@
  * its own copy; cleanupLegacyGlobalSync uses the default (`~/.claude`) to sweep
  * out leftovers of the pre-per-vault global sync.
  *
+ * Dir naming: synced dirs are `molio--<dirName>` where dirName is the skill's
+ * slugified DISPLAY name (readable in runtime skill lists, unlike the DB uuid).
+ * planSyncTargets plans the names deterministically — earliest skill keeps the
+ * plain slug, later same-name arrivals get a stable id-derived suffix — so
+ * repeated reconciles never flip-flop the orphan cleanup.
+ *
  * Safety red line: we ONLY ever create/modify/delete directories whose name
  * starts with `molio--`. The user's own skills are never touched —
  * reconcileSync removes only orphaned `molio--*` dirs. Ownership contract:
@@ -21,18 +27,65 @@ import {
   claudeSkillsDir,
   molioSkillDir,
   skillContentDir,
+  slugifySkillName,
   type SkillPathsOpts,
 } from './paths.js';
 import { mirrorDirIfChanged, sweepStaleMirrorArtifacts, isMirrorArtifactName } from './dirsync.js';
 
+/** Fields planSyncTargets needs from a skill entry. */
+export interface SkillSyncInput {
+  id: string;
+  name: string;
+  createdAt: number;
+}
+
+/** One planned mirror: library content keyed by id, vault dir by dirName. */
+export interface SyncTarget {
+  /** Library content dir key (`~/.molio/skills/<id>`). */
+  id: string;
+  /** Dir segment after the `molio--` prefix in the synced skills dir. */
+  dirName: string;
+}
+
 /**
- * Mirror the library skill's whole content dir into its namespaced
- * `molio--<id>/` dir. A single-file skill copies just its SKILL.md; a
+ * Plan each skill's `molio--` dir name from its display name:
+ *  - base = slugifySkillName(name); an empty slug (emoji-only names) falls
+ *    back to `skill-<id prefix>`;
+ *  - same-name collisions get a `-<id prefix>` suffix: deterministic across
+ *    reconciles because it derives from the immutable id, NOT a random number
+ *    minted at sync time (a random suffix would make the orphan cleanup delete
+ *    and rebuild the dir on every reconcile).
+ * Assignment order is createdAt ASC (tie-break id), so the EARLIEST skill
+ * keeps the plain readable name and later arrivals carry the suffix — stable
+ * as the library grows.
+ */
+export function planSyncTargets(entries: SkillSyncInput[]): SyncTarget[] {
+  const sorted = [...entries].sort(
+    (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+  );
+  const taken = new Set<string>();
+  const targets: SyncTarget[] = [];
+  for (const entry of sorted) {
+    let dirName = slugifySkillName(entry.name) || `skill-${entry.id.slice(0, 8)}`;
+    if (taken.has(dirName)) {
+      const suffixed = `${dirName}-${entry.id.slice(0, 8)}`;
+      dirName = taken.has(suffixed) ? `${dirName}-${entry.id}` : suffixed;
+    }
+    taken.add(dirName);
+    targets.push({ id: entry.id, dirName });
+  }
+  return targets;
+}
+
+/**
+ * Mirror the library skill's whole content dir into its planned
+ * `molio--<dirName>/` dir (dirName comes from planSyncTargets — the slugified
+ * display name, not the id). A single-file skill copies just its SKILL.md; a
  * multi-file (imported) skill copies SKILL.md + every sibling so
  * references/scripts the SKILL.md points at actually reach the runtime.
  * Staleness detection + atomic rebuild live in dirsync.mirrorDirIfChanged.
  */
-export function syncSkill(id: string, opts?: SkillPathsOpts): void {
+export function syncSkill(id: string, dirName: string, opts?: SkillPathsOpts): void {
   const srcDir = skillContentDir(id, opts);
   try {
     fs.lstatSync(srcDir);
@@ -40,12 +93,12 @@ export function syncSkill(id: string, opts?: SkillPathsOpts): void {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT' || code === 'ENOTDIR') {
       // Source vanished (manual deletion, disk cleanup, corrupted home) while
-      // the DB row lives on: remove the stale mirror too. The id is still in
-      // enabledIds, so the orphan cleanup below would SKIP it — without this
-      // the outdated copy stays in every vault and runtime CLIs load it
-      // forever. (existsSync was NOT enough here: it also reports false on
-      // EACCES, so a NAS permission blip deleted healthy mirrors.)
-      fs.rmSync(molioSkillDir(id, opts), { recursive: true, force: true });
+      // the DB row lives on: remove the stale mirror too. The target is still
+      // in the planned set, so the orphan cleanup below would SKIP it —
+      // without this the outdated copy stays in every vault and runtime CLIs
+      // load it forever. (existsSync was NOT enough here: it also reports
+      // false on EACCES, so a NAS permission blip deleted healthy mirrors.)
+      fs.rmSync(molioSkillDir(dirName, opts), { recursive: true, force: true });
       return;
     }
     // Any other error (EACCES/EBUSY/…) means "can't tell", not "gone": keep
@@ -56,21 +109,26 @@ export function syncSkill(id: string, opts?: SkillPathsOpts): void {
     );
     return;
   }
-  mirrorDirIfChanged(srcDir, molioSkillDir(id, opts));
+  mirrorDirIfChanged(srcDir, molioSkillDir(dirName, opts));
 }
 
 /**
- * Reconcile the target skills dir with the set of enabled skill ids:
- *  1. ensure every enabled id has its `molio--<id>/SKILL.md` present;
- *  2. remove any `molio--*` dir whose id is NOT enabled (orphan cleanup).
+ * Reconcile the target skills dir with the planned target set:
+ *  1. ensure every target has its `molio--<dirName>/SKILL.md` present;
+ *  2. remove any `molio--*` dir NOT in the planned set (orphan cleanup).
  * Non-`molio--` directories are left strictly untouched.
+ *
+ * Orphan cleanup is dirName-based, which makes rename + legacy-layout
+ * convergence automatic: a renamed skill's old dir (and any pre-name-based
+ * `molio--<uuid>` dir left by older builds) simply stops matching the planned
+ * set and is swept on the next reconcile.
  */
-export function reconcileSync(enabledIds: string[], opts?: SkillPathsOpts): void {
-  for (const id of enabledIds) {
+export function reconcileSync(targets: SyncTarget[], opts?: SkillPathsOpts): void {
+  for (const target of targets) {
     try {
-      syncSkill(id, opts);
+      syncSkill(target.id, target.dirName, opts);
     } catch (err) {
-      console.error(`[skills] Failed to sync skill "${id}":`, err instanceof Error ? err.message : err);
+      console.error(`[skills] Failed to sync skill "${target.id}":`, err instanceof Error ? err.message : err);
     }
   }
 
@@ -92,16 +150,16 @@ export function reconcileSync(enabledIds: string[], opts?: SkillPathsOpts): void
     console.warn('[skills] Orphan cleanup scan failed:', err instanceof Error ? err.message : err);
     return;
   }
-  const enabledSet = new Set(enabledIds);
+  const planned = new Set(targets.map((t) => t.dirName));
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     if (!entry.name.startsWith(MOLIO_PREFIX)) continue; // never touch user skills
-    // Staging artifacts (`molio--<id>.tmp/bak-…`) belong to the sweep's
+    // Staging artifacts (`molio--<x>.tmp/bak-…`) belong to the sweep's
     // age-guarded domain: an in-flight mirror of a FRESH artifact would be
     // rm -rf'd under the other process if the orphan scan claimed it here.
     if (isMirrorArtifactName(entry.name)) continue;
-    const id = entry.name.slice(MOLIO_PREFIX.length);
-    if (!enabledSet.has(id)) {
+    const dirName = entry.name.slice(MOLIO_PREFIX.length);
+    if (!planned.has(dirName)) {
       try {
         fs.rmSync(path.join(dir, entry.name), { recursive: true, force: true });
       } catch (err) {

--- a/apps/daemon/src/core/skills/sync.ts
+++ b/apps/daemon/src/core/skills/sync.ts
@@ -69,7 +69,16 @@ export function planSyncTargets(entries: SkillSyncInput[]): SyncTarget[] {
     let dirName = slugifySkillName(entry.name) || `skill-${entry.id.slice(0, 8)}`;
     if (taken.has(dirName)) {
       const suffixed = `${dirName}-${entry.id.slice(0, 8)}`;
-      dirName = taken.has(suffixed) ? `${dirName}-${entry.id}` : suffixed;
+      if (!taken.has(suffixed)) {
+        dirName = suffixed;
+      } else {
+        // EVERY form must be checked against `taken`: a crafted/imported
+        // display name can slugify to another skill's id-suffixed form, and an
+        // unchecked assignment would hand two skills the SAME dirName — they
+        // would silently overwrite each other's mirror.
+        const fullIdName = `${dirName}-${entry.id}`;
+        dirName = taken.has(fullIdName) ? `${fullIdName}-${entry.id.slice(0, 8)}` : fullIdName;
+      }
     }
     taken.add(dirName);
     targets.push({ id: entry.id, dirName });
@@ -122,12 +131,23 @@ export function syncSkill(id: string, dirName: string, opts?: SkillPathsOpts): v
  * convergence automatic: a renamed skill's old dir (and any pre-name-based
  * `molio--<uuid>` dir left by older builds) simply stops matching the planned
  * set and is swept on the next reconcile.
+ *
+ * BUT the sweep only runs on a FULLY SUCCESSFUL pass. A rename changes the
+ * planned dirName, so if the NEW dir fails to sync (the NAS EACCES/EBUSY
+ * class of errors this module degrades on) while the sweep still runs, the
+ * OLD dir is removed as an orphan and the vault is left with NO copy of the
+ * skill. Skipping the sweep on a degraded pass trades slower garbage
+ * collection for the module's standing rule: a failure degrades to "old
+ * content stays", never "skill gone". Convergence resumes on the next clean
+ * pass.
  */
 export function reconcileSync(targets: SyncTarget[], opts?: SkillPathsOpts): void {
+  let failedSyncs = 0;
   for (const target of targets) {
     try {
       syncSkill(target.id, target.dirName, opts);
     } catch (err) {
+      failedSyncs += 1;
       console.error(`[skills] Failed to sync skill "${target.id}":`, err instanceof Error ? err.message : err);
     }
   }
@@ -138,6 +158,14 @@ export function reconcileSync(targets: SyncTarget[], opts?: SkillPathsOpts): voi
   // Remove staging dirs a killed daemon left inside the scanned skills dir
   // (best-effort, age-guarded; see dirsync.sweepStaleMirrorArtifacts).
   sweepStaleMirrorArtifacts(dir);
+
+  if (failedSyncs > 0) {
+    console.warn(
+      `[skills] Skipping orphan cleanup: ${failedSyncs} target(s) failed to sync this pass ` +
+        '(removing dirs now could delete the only copy of a renamed skill)',
+    );
+    return;
+  }
 
   // Orphan cleanup — fully tolerant: this runs against NAS-mounted vaults
   // where any single fs call can hit EACCES/EBUSY, and it is also called from

--- a/apps/daemon/src/core/skills/vault-config.ts
+++ b/apps/daemon/src/core/skills/vault-config.ts
@@ -25,8 +25,9 @@
  *
  * Sync splits the effective set by kind:
  *  - **library + core** → `reconcileSync` (sync.ts) pointed at `<vault>/.claude`,
- *    writing single-file `molio--<id>/SKILL.md` dirs (keeps the molio-- red line
- *    + orphan cleanup for free);
+ *    writing single-file `molio--<dirName>/SKILL.md` dirs where dirName is the
+ *    slugified display name planned by `planSyncTargets` (keeps the molio-- red
+ *    line + orphan cleanup for free);
  *  - **bundled** → `reconcileBundledSync` (skill-installer.ts), syncing whole
  *    multi-file directories under their plain names and converging the CLAUDE.md
  *    rule blocks.
@@ -42,7 +43,7 @@ import type Database from 'better-sqlite3';
 import type { SkillManifestEntry, Vault } from '@molio/contracts';
 import { listVaults } from '../db.js';
 import { listSkills } from './store.js';
-import { reconcileSync } from './sync.js';
+import { reconcileSync, planSyncTargets } from './sync.js';
 import { reconcileBundledSync, RETIRED_BUNDLED_SKILLS } from '../skill-installer.js';
 import type { SkillPathsOpts } from './paths.js';
 
@@ -64,7 +65,8 @@ export function getEffectiveSkillIds(db: Database.Database, vaultId: string): st
 /**
  * Reconcile one vault's `<vault.path>/.claude/skills/` against its effective
  * skill set, splitting by kind:
- *  - library + core → `reconcileSync` (single-file `molio--<id>/SKILL.md`);
+ *  - library + core → `reconcileSync` (single-file `molio--<dirName>/SKILL.md`,
+ *    dirName = slugified display name);
  *  - bundled → `reconcileBundledSync` (whole multi-file dirs, plain names, plus
  *    CLAUDE.md rule convergence).
  * Best-effort: an EACCES on the mounted dir logs and returns rather than
@@ -75,8 +77,10 @@ export function reconcileVault(db: Database.Database, vault: Vault, opts?: Skill
     const effective = getEffectiveSkills(db, vault.id);
 
     // library + core → molio-- single-file sync (orphan cleanup included).
-    const singleFileIds = effective.filter((s) => s.kind !== 'bundled').map((s) => s.id);
-    reconcileSync(singleFileIds, { ...opts, claudeHome: path.join(vault.path, '.claude') });
+    // Dir names are planned from display names (readable in runtime skill
+    // lists); same-name collisions get deterministic id-derived suffixes.
+    const singleFile = effective.filter((s) => s.kind !== 'bundled');
+    reconcileSync(planSyncTargets(singleFile), { ...opts, claudeHome: path.join(vault.path, '.claude') });
 
     // bundled → whole-dir sync. Managed = every bundled row the DB knows about
     // PLUS the retired bundled slugs: their DB rows are deleted on startup

--- a/apps/daemon/src/routes/skills.ts
+++ b/apps/daemon/src/routes/skills.ts
@@ -41,6 +41,7 @@ import { prefillFromContent } from '../core/skills/prefill.js';
 import {
   fetchHubSkills,
   fetchHubCategories,
+  fetchHubSkillDetail,
   installHubSkill,
   listHubInstalls,
   hubInstallKey,
@@ -90,6 +91,8 @@ export function skillsRoutes(db: Database.Database, runManager: RunManager): Hon
         pageSize: Number.isFinite(pageSize) && pageSize > 0 ? Math.floor(pageSize) : undefined,
         keyword: q['keyword'],
         category: q['category'],
+        // Unknown values fall back to the hub's default ranking in fetchHubSkills.
+        sort: q['sort'] as 'default' | 'downloads' | 'updated' | undefined,
       });
       // Keyed by (namespace, slug) — same slug in different namespaces are
       // separate installs (hubInstallKey normalizes a missing namespace to '').
@@ -102,6 +105,31 @@ export function skillsRoutes(db: Database.Database, runManager: RunManager): Hon
         return { ...s, installed: true, installedVersion: rec.version };
       });
       return c.json({ skills, total: result.total, page: result.page, pageSize: result.pageSize });
+    } catch (err) {
+      return mapHubError(c, err);
+    }
+  });
+
+  // GET /api/skills/hub/skill — one hub skill's detail (store detail modal):
+  // upstream detail + SKILL.md body, annotated with the local install state.
+  // Registered BEFORE the by-id routes: a catalog lookup, never a local id.
+  app.get('/hub/skill', async (c) => {
+    const slug = c.req.query('slug')?.trim();
+    if (!slug) {
+      return c.json({ error: { code: 'BAD_REQUEST', message: 'slug is required' } }, 400);
+    }
+    const namespace = c.req.query('namespace')?.trim() || undefined;
+    try {
+      const detail = await fetchHubSkillDetail(slug, namespace);
+      // Same installed annotation as /hub/skills (incl. the stale-record check).
+      const rec = listHubInstalls(db).find(
+        (r) => hubInstallKey(r.slug, r.namespace) === hubInstallKey(slug, namespace ?? ''),
+      );
+      if (rec && getSkill(db, rec.skill_id)) {
+        detail.installed = true;
+        detail.installedVersion = rec.version;
+      }
+      return c.json({ detail });
     } catch (err) {
       return mapHubError(c, err);
     }

--- a/apps/daemon/test/core/skills/hub.test.ts
+++ b/apps/daemon/test/core/skills/hub.test.ts
@@ -513,13 +513,23 @@ describe('skills/hub — fetchHubSkillDetail', () => {
   });
 
   it('an oversized readme is dropped (bomb guard)', async () => {
-    // Two shapes: a huge Content-Length header (pre-check) and a genuinely
-    // huge body without the header (post-read check).
+    // Three shapes: a huge Content-Length header (pre-check), a genuinely huge
+    // body WITHOUT the header, and a LYING header claiming a small body — the
+    // last two are caught by the streaming byte cap, never by res.text()
+    // buffering the whole response first.
     _setHubFetchForTests(serveDetail(DETAIL_BODY, 'small', MAX_HUB_README_BYTES + 1));
     assert.equal((await fetchHubSkillDetail('demo')).readme, '');
 
     _setHubFetchForTests(serveDetail(DETAIL_BODY, 'x'.repeat(MAX_HUB_README_BYTES + 1)));
     assert.equal((await fetchHubSkillDetail('demo')).readme, '');
+
+    _setHubFetchForTests(serveDetail(DETAIL_BODY, 'x'.repeat(MAX_HUB_README_BYTES + 1), 10));
+    assert.equal((await fetchHubSkillDetail('demo')).readme, '');
+  });
+
+  it('a readme at exactly the byte cap still passes (stream boundary)', async () => {
+    _setHubFetchForTests(serveDetail(DETAIL_BODY, 'x'.repeat(MAX_HUB_README_BYTES)));
+    assert.equal((await fetchHubSkillDetail('demo')).readme.length, MAX_HUB_README_BYTES);
   });
 
   it('maps an unknown slug (upstream 404) to NOT_FOUND', async () => {

--- a/apps/daemon/test/core/skills/hub.test.ts
+++ b/apps/daemon/test/core/skills/hub.test.ts
@@ -12,6 +12,8 @@ import {
   getHubInstall,
   fetchHubSkills,
   fetchHubCategories,
+  fetchHubSkillDetail,
+  MAX_HUB_README_BYTES,
   HubError,
   _setHubFetchForTests,
 } from '../../../src/core/skills/hub.js';
@@ -373,5 +375,163 @@ describe('skills/hub — catalog fetch mapping', () => {
       { key: 'a', name: '甲' },
       { key: 'b', name: '乙' },
     ]);
+  });
+});
+
+describe('skills/hub — sort param mapping', () => {
+  function captureUrlFetch(): { fake: typeof fetch; urls: string[] } {
+    const urls: string[] = [];
+    const fake = (async (input: unknown) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify({ code: 0, data: { skills: [], total: 0 } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+    return { fake, urls };
+  }
+
+  it('downloads sort → sortBy=downloads&order=desc upstream', async () => {
+    const { fake, urls } = captureUrlFetch();
+    _setHubFetchForTests(fake);
+    await fetchHubSkills({ sort: 'downloads' });
+    assert.ok(urls[0]?.includes('sortBy=downloads'), urls[0]);
+    assert.ok(urls[0]?.includes('order=desc'), urls[0]);
+  });
+
+  it('updated sort → sortBy=updated_at&order=desc upstream', async () => {
+    const { fake, urls } = captureUrlFetch();
+    _setHubFetchForTests(fake);
+    await fetchHubSkills({ sort: 'updated' });
+    assert.ok(urls[0]?.includes('sortBy=updated_at'), urls[0]);
+    assert.ok(urls[0]?.includes('order=desc'), urls[0]);
+  });
+
+  it('default / unknown sorts keep the hub default ranking (no sortBy)', async () => {
+    for (const sort of [undefined, 'default', 'bogus'] as const) {
+      const { fake, urls } = captureUrlFetch();
+      _setHubFetchForTests(fake);
+      // eslint-disable-next-line no-await-in-loop -- sequential by design
+      await fetchHubSkills(sort === undefined ? {} : { sort: sort as 'default' });
+      assert.ok(!urls[0]?.includes('sortBy='), `sort=${String(sort)} leaked sortBy: ${urls[0]}`);
+    }
+  });
+});
+
+describe('skills/hub — fetchHubSkillDetail', () => {
+  const DETAIL_BODY = {
+    slug: 'demo',
+    contentZhAvailable: true,
+    skill: {
+      slug: 'demo',
+      displayName: 'Demo 技能',
+      category: 'office-efficiency',
+      sourceUrl: 'https://clawhub.ai/alice/demo',
+      iconUrl: 'https://cdn.example/icon.png',
+      createdAt: 1772740044096,
+      updatedAt: 1786541460768,
+      verified: true,
+      labels: { requires_api_key: 'true' },
+      summary: 'english summary',
+      summary_zh: '中文简介',
+      stats: { downloads: 174518, installs: 23940, stars: 518, comments: 3, versions: 4 },
+    },
+    latestVersion: { version: '1.0.2', changelog: 'bugfix release', createdAt: 1774623104337 },
+    owner: { handle: 'alice', displayName: 'Alice', image: null },
+    namespace: { handle: 'alice', canonicalName: '@alice/demo', displayName: 'alice' },
+    securityReports: {
+      keen: { status: 'benign', statusText: '安全，无风险', reportUrl: 'https://report' },
+      sanbu: { status: 'benign', statusText: '安全' },
+    },
+  };
+
+  /** Fake hub: detail JSON + raw SKILL.md text (readme=null → 404 on the file). */
+  function serveDetail(detailBody: unknown, readme: string | null, readmeBytes?: number): typeof fetch {
+    return (async (input: unknown) => {
+      const url = String(input);
+      if (url.includes('/file?path=SKILL.md')) {
+        if (readme === null) return new Response('missing', { status: 404 });
+        const headers: Record<string, string> = { 'Content-Type': 'text/plain' };
+        if (readmeBytes !== undefined) headers['Content-Length'] = String(readmeBytes);
+        return new Response(readme, { status: 200, headers });
+      }
+      if (url.includes('/api/v1/skills/')) {
+        return new Response(JSON.stringify(detailBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch;
+  }
+
+  it('aggregates detail + SKILL.md readme with frontmatter stripped', async () => {
+    _setHubFetchForTests(
+      serveDetail(DETAIL_BODY, '---\nname: Demo\nversion: 1.0.2\n---\n\n## When to Use\n正文内容'),
+    );
+    const detail = await fetchHubSkillDetail('demo');
+    assert.equal(detail.slug, 'demo');
+    assert.equal(detail.name, 'Demo 技能');
+    assert.equal(detail.description, '中文简介'); // zh-first, same as the list
+    assert.equal(detail.category, 'office-efficiency');
+    assert.equal(detail.sourceUrl, 'https://clawhub.ai/alice/demo');
+    assert.equal(detail.createdAt, 1772740044096);
+    assert.equal(detail.updatedAt, 1786541460768);
+    assert.equal(detail.verified, true);
+    assert.equal(detail.requiresApiKey, true);
+    assert.equal(detail.ownerName, 'Alice');
+    assert.equal(detail.namespace, 'alice');
+    assert.equal(detail.latestVersion, '1.0.2');
+    assert.equal(detail.changelog, 'bugfix release');
+    assert.deepEqual(detail.stats, { downloads: 174518, installs: 23940, stars: 518, versions: 4 });
+    assert.equal(detail.security?.keen, '安全，无风险');
+    assert.equal(detail.security?.sanbu, '安全');
+    assert.equal(detail.readme, '## When to Use\n正文内容'); // frontmatter gone, trimmed
+  });
+
+  it('passes namespace through to both upstream calls', async () => {
+    const urls: string[] = [];
+    _setHubFetchForTests((async (input: unknown) => {
+      urls.push(String(input));
+      const url = String(input);
+      if (url.includes('/file?path=SKILL.md')) return new Response('正文', { status: 200 });
+      return new Response(JSON.stringify(DETAIL_BODY), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch);
+    await fetchHubSkillDetail('demo', 'alice');
+    assert.ok(urls.some((u) => u.includes('/api/v1/skills/demo?namespace=alice')), urls.join('\n'));
+    assert.ok(urls.some((u) => u.includes('/file?path=SKILL.md') && u.includes('namespace=alice')), urls.join('\n'));
+  });
+
+  it('a readme failure never blocks the detail (404 → empty readme)', async () => {
+    _setHubFetchForTests(serveDetail(DETAIL_BODY, null));
+    const detail = await fetchHubSkillDetail('demo');
+    assert.equal(detail.name, 'Demo 技能');
+    assert.equal(detail.readme, '');
+  });
+
+  it('an oversized readme is dropped (bomb guard)', async () => {
+    // Two shapes: a huge Content-Length header (pre-check) and a genuinely
+    // huge body without the header (post-read check).
+    _setHubFetchForTests(serveDetail(DETAIL_BODY, 'small', MAX_HUB_README_BYTES + 1));
+    assert.equal((await fetchHubSkillDetail('demo')).readme, '');
+
+    _setHubFetchForTests(serveDetail(DETAIL_BODY, 'x'.repeat(MAX_HUB_README_BYTES + 1)));
+    assert.equal((await fetchHubSkillDetail('demo')).readme, '');
+  });
+
+  it('maps an unknown slug (upstream 404) to NOT_FOUND', async () => {
+    _setHubFetchForTests((async () => new Response('missing', { status: 404 })) as typeof fetch);
+    await assert.rejects(fetchHubSkillDetail('ghost'), (err: unknown) => {
+      return err instanceof HubError && err.code === 'NOT_FOUND';
+    });
+  });
+
+  it('rejects an empty slug with BAD_REQUEST', async () => {
+    await assert.rejects(fetchHubSkillDetail('  '), (err: unknown) => {
+      return err instanceof HubError && err.code === 'BAD_REQUEST';
+    });
   });
 });

--- a/apps/daemon/test/core/skills/store.test.ts
+++ b/apps/daemon/test/core/skills/store.test.ts
@@ -111,8 +111,11 @@ describe('skills/store', () => {
       'body',
       opts,
     );
-    const syncedDir = path.join(claudeHome, 'skills', `molio--${entry.id}`);
-    assert.ok(!fs.existsSync(syncedDir), 'store must not write to .claude/skills');
+    const skillsRoot = path.join(claudeHome, 'skills');
+    const molioDirs = fs.existsSync(skillsRoot)
+      ? fs.readdirSync(skillsRoot).filter((n) => n.startsWith('molio--'))
+      : [];
+    assert.deepEqual(molioDirs, [], 'store must not write to .claude/skills');
   });
 
   it('updateSkill rewrites frontmatter (name) and keeps instructions', () => {
@@ -158,7 +161,11 @@ describe('skills/store', () => {
     toggleSkill(db, entry.id, true);
     assert.equal(getSkill(db, entry.id)?.enabled, true);
     // store never writes to .claude/skills
-    assert.ok(!fs.existsSync(path.join(claudeHome, 'skills', `molio--${entry.id}`)));
+    const skillsRoot = path.join(claudeHome, 'skills');
+    const molioDirs = fs.existsSync(skillsRoot)
+      ? fs.readdirSync(skillsRoot).filter((n) => n.startsWith('molio--'))
+      : [];
+    assert.deepEqual(molioDirs, [], 'store must not write to .claude/skills');
   });
 
   it('deleteSkill removes content dir and DB row', () => {

--- a/apps/daemon/test/core/skills/sync.test.ts
+++ b/apps/daemon/test/core/skills/sync.test.ts
@@ -6,10 +6,15 @@ import path from 'node:path';
 import os from 'node:os';
 import type Database from 'better-sqlite3';
 import { openDatabase, closeDatabase } from '../../../src/core/db.js';
-import { syncSkill, reconcileSync } from '../../../src/core/skills/sync.js';
+import { syncSkill, reconcileSync, planSyncTargets } from '../../../src/core/skills/sync.js';
 import { copyDirSync, isAlreadySynced } from '../../../src/core/skills/dirsync.js';
 import { createSkill } from '../../../src/core/skills/store.js';
-import type { SkillPathsOpts } from '../../../src/core/skills/paths.js';
+import { slugifySkillName, type SkillPathsOpts } from '../../../src/core/skills/paths.js';
+
+/** Dir a library skill named `name` syncs into under the molio-- prefix. */
+function molioDir(name: string): string {
+  return `molio--${slugifySkillName(name)}`;
+}
 
 let molioHome: string;
 let claudeHome: string;
@@ -33,15 +38,17 @@ afterEach(() => {
 });
 
 describe('skills/sync', () => {
-  it('syncSkill writes the library SKILL.md into molio--<id>/', () => {
-    const entry = createSkill(db, { name: 'S', description: '', enabled: false, builtIn: false }, 'body', opts);
-    syncSkill(entry.id, opts);
-    const synced = path.join(claudeHome, 'skills', `molio--${entry.id}`, 'SKILL.md');
+  it('syncSkill writes the library SKILL.md into molio--<dirName>/ (slugified display name)', () => {
+    const entry = createSkill(db, { name: 'My Skill', description: '', enabled: false, builtIn: false }, 'body', opts);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
+    const synced = path.join(claudeHome, 'skills', molioDir('My Skill'), 'SKILL.md');
     assert.ok(fs.existsSync(synced));
     assert.ok(fs.readFileSync(synced, 'utf8').includes('body'));
+    // The vault dir is name-based — the DB uuid must NOT appear in the path.
+    assert.ok(!fs.existsSync(path.join(claudeHome, 'skills', `molio--${entry.id}`)));
   });
 
-  it('syncSkill mirrors a multi-file skill (SKILL.md + siblings) into molio--<id>/', () => {
+  it('syncSkill mirrors a multi-file skill (SKILL.md + siblings) into molio--<dirName>/', () => {
     // Build a multi-file source dir and import it verbatim as the skill content.
     const srcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'molio-skills-sync-src-'));
     try {
@@ -55,9 +62,9 @@ describe('skills/sync', () => {
         '',
         opts,
       );
-      syncSkill(entry.id, opts);
+      syncSkill(entry.id, slugifySkillName(entry.name), opts);
 
-      const dest = path.join(claudeHome, 'skills', `molio--${entry.id}`);
+      const dest = path.join(claudeHome, 'skills', molioDir('M'));
       assert.ok(fs.existsSync(path.join(dest, 'SKILL.md')), 'SKILL.md synced');
       assert.ok(fs.existsSync(path.join(dest, 'references', 'g.md')), 'nested sibling synced');
       assert.equal(fs.readFileSync(path.join(dest, 'references', 'g.md'), 'utf8'), 'guide\n');
@@ -68,13 +75,13 @@ describe('skills/sync', () => {
 
   it('syncSkill is a read-only no-op when dest already mirrors src', () => {
     const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'body', opts);
-    syncSkill(entry.id, opts);
-    const dest = path.join(claudeHome, 'skills', `molio--${entry.id}`);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
+    const dest = path.join(claudeHome, 'skills', molioDir('S'));
     const skillMd = path.join(dest, 'SKILL.md');
     const before = fs.statSync(skillMd).mtimeMs;
 
     // Second sync with unchanged source must not rewrite (short-circuit).
-    syncSkill(entry.id, opts);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
     assert.equal(fs.statSync(skillMd).mtimeMs, before, 'unchanged source → no rewrite');
     // And it must not leave temp dirs behind in the skills root.
     const leftovers = fs
@@ -85,24 +92,24 @@ describe('skills/sync', () => {
 
   it('syncSkill rewrites when source content changed', () => {
     const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'v1', opts);
-    syncSkill(entry.id, opts);
-    const skillMd = path.join(claudeHome, 'skills', `molio--${entry.id}`, 'SKILL.md');
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
+    const skillMd = path.join(claudeHome, 'skills', molioDir('S'), 'SKILL.md');
     assert.ok(fs.readFileSync(skillMd, 'utf8').includes('v1'));
 
     // Change the library source, re-sync → dest converges to the new content.
     fs.writeFileSync(path.join(molioHome, 'skills', entry.id, 'SKILL.md'), 'v2 changed\n', 'utf8');
-    syncSkill(entry.id, opts);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
     assert.ok(fs.readFileSync(skillMd, 'utf8').includes('v2 changed'), 'dest updated on change');
   });
 
   it('syncSkill drops stale siblings on re-sync (rm-first converge)', () => {
     const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'body', opts);
-    syncSkill(entry.id, opts);
-    const dest = path.join(claudeHome, 'skills', `molio--${entry.id}`);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
+    const dest = path.join(claudeHome, 'skills', molioDir('S'));
     // Simulate an old version having synced an extra sibling that no longer exists.
     fs.writeFileSync(path.join(dest, 'stale.txt'), 'old', 'utf8');
 
-    syncSkill(entry.id, opts);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
     assert.ok(!fs.existsSync(path.join(dest, 'stale.txt')), 'stale sibling removed on re-sync');
     assert.ok(fs.existsSync(path.join(dest, 'SKILL.md')), 'SKILL.md still present');
   });
@@ -121,20 +128,20 @@ describe('skills/sync', () => {
     // an enabled library skill — must be synced
     const entry = createSkill(db, { name: 'S', description: '', enabled: false, builtIn: false }, 'body', opts);
 
-    reconcileSync([entry.id], opts);
+    reconcileSync(planSyncTargets([entry]), opts);
 
     assert.ok(fs.existsSync(path.join(userDir, 'SKILL.md')), 'user skill must be untouched');
     assert.ok(!fs.existsSync(orphanDir), 'orphan molio dir must be removed');
-    assert.ok(fs.existsSync(path.join(claudeHome, 'skills', `molio--${entry.id}`, 'SKILL.md')), 'enabled skill synced');
+    assert.ok(fs.existsSync(path.join(claudeHome, 'skills', molioDir('S'), 'SKILL.md')), 'enabled skill synced');
   });
 
   it('reconcileSync is idempotent', () => {
     const entry = createSkill(db, { name: 'S', description: '', enabled: false, builtIn: false }, 'body', opts);
-    reconcileSync([entry.id], opts);
-    const synced = path.join(claudeHome, 'skills', `molio--${entry.id}`, 'SKILL.md');
+    reconcileSync(planSyncTargets([entry]), opts);
+    const synced = path.join(claudeHome, 'skills', molioDir('S'), 'SKILL.md');
     const mtime1 = fs.statSync(synced).mtimeMs;
 
-    reconcileSync([entry.id], opts);
+    reconcileSync(planSyncTargets([entry]), opts);
     assert.ok(fs.existsSync(synced), 'still present after second reconcile');
     // Content identical even if rewritten.
     assert.ok(fs.readFileSync(synced, 'utf8').includes('body'));
@@ -143,16 +150,17 @@ describe('skills/sync', () => {
 
   it('syncSkill removes the stale mirror when the library source dir vanished', () => {
     // Regression: the source dir can vanish (manual deletion, disk cleanup,
-    // corrupted home) while the DB row lives on. The id stays in enabledIds,
-    // so the orphan cleanup SKIPS it — without an explicit removal the outdated
-    // copy stays in every vault and runtime CLIs load it forever.
+    // corrupted home) while the DB row lives on. The target stays in the
+    // planned set, so the orphan cleanup SKIPS it — without an explicit
+    // removal the outdated copy stays in every vault and runtime CLIs load it
+    // forever.
     const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'body', opts);
-    syncSkill(entry.id, opts);
-    const dest = path.join(claudeHome, 'skills', `molio--${entry.id}`);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
+    const dest = path.join(claudeHome, 'skills', molioDir('S'));
     assert.ok(fs.existsSync(dest), 'mirror created first');
 
     fs.rmSync(path.join(molioHome, 'skills', entry.id), { recursive: true, force: true });
-    syncSkill(entry.id, opts);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
 
     assert.ok(!fs.existsSync(dest), 'stale mirror removed when the source is gone');
   });
@@ -170,14 +178,14 @@ describe('skills/sync', () => {
       return;
     }
     const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'body', opts);
-    syncSkill(entry.id, opts);
-    const dest = path.join(claudeHome, 'skills', `molio--${entry.id}`);
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
+    const dest = path.join(claudeHome, 'skills', molioDir('S'));
     assert.ok(fs.existsSync(dest), 'mirror created first');
 
     const libraryDir = path.join(molioHome, 'skills');
     fs.chmodSync(libraryDir, 0o000); // lstat of <library>/<id> now fails EACCES
     try {
-      syncSkill(entry.id, opts);
+      syncSkill(entry.id, slugifySkillName(entry.name), opts);
       assert.ok(fs.existsSync(path.join(dest, 'SKILL.md')), 'mirror kept on EACCES');
     } finally {
       fs.chmodSync(libraryDir, 0o755); // restore so afterEach cleanup works
@@ -217,10 +225,10 @@ describe('skills/sync', () => {
     fs.writeFileSync(stray, 'x', 'utf8');
 
     const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'body', opts);
-    reconcileSync([entry.id], opts); // must not throw
+    reconcileSync(planSyncTargets([entry]), opts); // must not throw
 
     assert.ok(fs.existsSync(stray), 'non-directory entries are left alone');
-    assert.ok(fs.existsSync(path.join(skillsDir, `molio--${entry.id}`, 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(skillsDir, molioDir('S'), 'SKILL.md')));
   });
 
   it('mirroring skips symlinks entirely (no follow, no copy, hash parity kept)', (t) => {
@@ -288,18 +296,108 @@ describe('skills/sync', () => {
     }
   });
 
-  it('reconcileSync with empty enabled set removes all molio dirs but keeps user dirs', () => {
+  it('reconcileSync with empty planned set removes all molio dirs but keeps user dirs', () => {
     const userDir = path.join(claudeHome, 'skills', 'keep-me');
     fs.mkdirSync(userDir, { recursive: true });
     fs.writeFileSync(path.join(userDir, 'SKILL.md'), 'x', 'utf8');
     // Set up a synced molio dir explicitly (createSkill no longer auto-syncs).
     const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'body', opts);
-    syncSkill(entry.id, opts);
-    assert.ok(fs.existsSync(path.join(claudeHome, 'skills', `molio--${entry.id}`)));
+    syncSkill(entry.id, slugifySkillName(entry.name), opts);
+    assert.ok(fs.existsSync(path.join(claudeHome, 'skills', molioDir('S'))));
 
     reconcileSync([], opts);
 
-    assert.ok(!fs.existsSync(path.join(claudeHome, 'skills', `molio--${entry.id}`)));
+    assert.ok(!fs.existsSync(path.join(claudeHome, 'skills', molioDir('S'))));
     assert.ok(fs.existsSync(userDir), 'user dir survives');
+  });
+
+  it('reconcileSync sweeps legacy molio--<uuid> dirs left by older builds (upgrade migration)', () => {
+    // Pre-name-based builds synced as molio--<uuid>. After the upgrade those
+    // dirs are orphans to the name-based reconcile and must be removed while
+    // the same skill's new readable dir is created — no migration code needed.
+    const entry = createSkill(db, { name: 'Report', description: '', enabled: true, builtIn: false }, 'body', opts);
+    const legacyDir = path.join(claudeHome, 'skills', `molio--${entry.id}`);
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'SKILL.md'), 'old uuid-named copy', 'utf8');
+
+    reconcileSync(planSyncTargets([entry]), opts);
+
+    assert.ok(!fs.existsSync(legacyDir), 'legacy uuid-named dir removed');
+    assert.ok(
+      fs.existsSync(path.join(claudeHome, 'skills', molioDir('Report'), 'SKILL.md')),
+      'readable name-based dir created',
+    );
+  });
+});
+
+describe('skills/sync: slugifySkillName (paths)', () => {
+  it('keeps CJK + ASCII letters/digits, lowercases, maps the rest to single hyphens', () => {
+    assert.equal(slugifySkillName('微信 Article 提取!'), '微信-article-提取');
+    assert.equal(slugifySkillName('  --Foo  Bar-- '), 'foo-bar');
+    assert.equal(slugifySkillName('C++ 编程'), 'c-编程');
+  });
+
+  it('NFKC-normalizes full-width characters', () => {
+    assert.equal(slugifySkillName('ｖ２全角'), 'v2全角');
+  });
+
+  it('returns empty string when nothing slugifiable remains', () => {
+    assert.equal(slugifySkillName('!!!'), '');
+    assert.equal(slugifySkillName('🚀🚀'), '');
+  });
+
+  it('caps length at 64 code points without a trailing hyphen', () => {
+    const slug = slugifySkillName('a'.repeat(100));
+    assert.equal(Array.from(slug).length, 64);
+    const capped = slugifySkillName('字'.repeat(70));
+    assert.equal(Array.from(capped).length, 64);
+    // a hyphen sitting exactly at the cut point must not survive
+    const withHyphenAtCut = slugifySkillName(`${'a'.repeat(63)}!bbb`);
+    assert.ok(!withHyphenAtCut.endsWith('-'));
+    assert.ok(Array.from(withHyphenAtCut).length <= 64);
+  });
+
+  it('output is always a safe path segment', () => {
+    for (const name of ['../evil', 'a/b\\c', 'CON.', '  x  ', '技能: v1.0 <beta>']) {
+      const slug = slugifySkillName(name);
+      assert.ok(!slug.includes('/') && !slug.includes('\\'), `no separators in ${JSON.stringify(slug)}`);
+      assert.ok(slug !== '.' && slug !== '..', `no dot segments in ${JSON.stringify(slug)}`);
+    }
+  });
+});
+
+describe('skills/sync: planSyncTargets (readable dir names + deterministic collisions)', () => {
+  it('uses the slugified display name', () => {
+    const targets = planSyncTargets([{ id: 'u-1', name: '周报生成', createdAt: 1 }]);
+    assert.deepEqual(targets, [{ id: 'u-1', dirName: '周报生成' }]);
+  });
+
+  it('falls back to skill-<id prefix> when the slug is empty', () => {
+    const targets = planSyncTargets([{ id: 'abcdef12-34', name: '🚀', createdAt: 1 }]);
+    assert.deepEqual(targets, [{ id: 'abcdef12-34', dirName: 'skill-abcdef12' }]);
+  });
+
+  it('same-name skills get a stable id-derived suffix; earliest keeps the plain name', () => {
+    const older = { id: '11111111-aaaa', name: '报告', createdAt: 100 };
+    const newer = { id: '22222222-bbbb', name: '报告', createdAt: 200 };
+    const targets = planSyncTargets([older, newer]);
+    assert.deepEqual(targets, [
+      { id: older.id, dirName: '报告' },
+      { id: newer.id, dirName: '报告-22222222' },
+    ]);
+  });
+
+  it('is deterministic regardless of input order (created_at drives assignment)', () => {
+    const a = { id: '11111111-aaaa', name: '报告', createdAt: 100 };
+    const b = { id: '22222222-bbbb', name: '报告', createdAt: 200 };
+    assert.deepEqual(planSyncTargets([b, a]), planSyncTargets([a, b]));
+  });
+
+  it('distinct names that slugify identically also disambiguate', () => {
+    const a = { id: '11111111-aaaa', name: 'Foo Bar', createdAt: 100 };
+    const b = { id: '22222222-bbbb', name: 'foo--bar!', createdAt: 200 };
+    const targets = planSyncTargets([a, b]);
+    assert.deepEqual(new Set(targets.map((t) => t.dirName)).size, 2, 'no duplicate dir names');
+    assert.equal(targets[0]?.dirName, 'foo-bar');
   });
 });

--- a/apps/daemon/test/core/skills/sync.test.ts
+++ b/apps/daemon/test/core/skills/sync.test.ts
@@ -311,6 +311,49 @@ describe('skills/sync', () => {
     assert.ok(fs.existsSync(userDir), 'user dir survives');
   });
 
+  it('reconcileSync skips the orphan sweep when any target failed to sync', () => {
+    // Regression (PR #212 review): a rename changes the planned dirName, so a
+    // failed sync of the NEW dir (the NAS EACCES/EBUSY class this module
+    // degrades on) plus an unconditional sweep deleted the OLD dir too — the
+    // vault was left with NO copy of the skill. A degraded pass must keep
+    // everything and retry on the next clean reconcile.
+    const skillsDir = path.join(claudeHome, 'skills');
+
+    // The skill's last good copy under its OLD name — an "orphan" to the
+    // planned set after the rename.
+    const oldCopy = path.join(skillsDir, 'molio--old-name');
+    fs.mkdirSync(oldCopy, { recursive: true });
+    fs.writeFileSync(path.join(oldCopy, 'SKILL.md'), 'last good copy', 'utf8');
+
+    // A genuine orphan (would be swept on a clean pass).
+    const orphan = path.join(skillsDir, 'molio--orphan');
+    fs.mkdirSync(orphan, { recursive: true });
+    fs.writeFileSync(path.join(orphan, 'SKILL.md'), 'stale', 'utf8');
+
+    // Corrupt the library source — a FILE where a dir should be — so
+    // syncSkill throws deterministically on every platform (lstat succeeds,
+    // the mirror copy then hits ENOTDIR), emulating the failure class.
+    const entry = createSkill(db, { name: 'S', description: '', enabled: true, builtIn: false }, 'body', opts);
+    fs.rmSync(path.join(molioHome, 'skills', entry.id), { recursive: true, force: true });
+    fs.writeFileSync(path.join(molioHome, 'skills', entry.id), 'corrupted — not a dir', 'utf8');
+
+    reconcileSync(planSyncTargets([entry]), opts);
+
+    assert.ok(fs.existsSync(path.join(oldCopy, 'SKILL.md')), 'old copy kept when the new-name sync failed');
+    assert.ok(fs.existsSync(orphan), 'orphan sweep skipped on a degraded pass');
+    assert.ok(!fs.existsSync(path.join(skillsDir, molioDir('S'))), 'failed target left no partial mirror');
+
+    // Heal the source → the next pass converges: sync succeeds AND both the
+    // old copy and the orphan are swept.
+    fs.rmSync(path.join(molioHome, 'skills', entry.id), { force: true });
+    fs.mkdirSync(path.join(molioHome, 'skills', entry.id), { recursive: true });
+    fs.writeFileSync(path.join(molioHome, 'skills', entry.id, 'SKILL.md'), 'body', 'utf8');
+    reconcileSync(planSyncTargets([entry]), opts);
+    assert.ok(fs.existsSync(path.join(skillsDir, molioDir('S'), 'SKILL.md')), 'clean pass synced the skill');
+    assert.ok(!fs.existsSync(oldCopy), 'clean pass swept the stale old-name copy');
+    assert.ok(!fs.existsSync(orphan), 'clean pass swept the orphan');
+  });
+
   it('reconcileSync sweeps legacy molio--<uuid> dirs left by older builds (upgrade migration)', () => {
     // Pre-name-based builds synced as molio--<uuid>. After the upgrade those
     // dirs are orphans to the name-based reconcile and must be removed while
@@ -357,6 +400,23 @@ describe('skills/sync: slugifySkillName (paths)', () => {
     assert.ok(Array.from(withHyphenAtCut).length <= 64);
   });
 
+  it('caps UTF-8 bytes for 4-byte astral characters (255-byte NAME_MAX safety)', () => {
+    // Regression (PR #212 review): filesystems cap ONE path component at 255
+    // BYTES, and CJK-Extension-B-style astral letters encode as 4 UTF-8 bytes
+    // each — 64 of them are 256 bytes, ENAMETOOLONG before the `molio--`
+    // prefix even counts. The code-point cap alone cannot catch this.
+    const astral = '\u{20000}';
+    const slug = slugifySkillName(astral.repeat(64));
+    assert.ok(Array.from(slug).length > 0, 'astral letters are slugifiable');
+    assert.ok(Array.from(slug).length < 64, 'byte cap kicks in below the code-point cap');
+    assert.ok(Buffer.byteLength(slug, 'utf8') <= 200, `slug is ${Buffer.byteLength(slug, 'utf8')} bytes`);
+    // The FULL synced dir name — prefix plus the longest collision suffix
+    // planSyncTargets can append (`-<full uuid>-<id8>`) — must stay within one
+    // 255-byte path component.
+    const worstCase = `molio--${slug}-${'u'.repeat(36)}-${'x'.repeat(8)}`;
+    assert.ok(Buffer.byteLength(worstCase, 'utf8') <= 255, worstCase);
+  });
+
   it('output is always a safe path segment', () => {
     for (const name of ['../evil', 'a/b\\c', 'CON.', '  x  ', '技能: v1.0 <beta>']) {
       const slug = slugifySkillName(name);
@@ -399,5 +459,35 @@ describe('skills/sync: planSyncTargets (readable dir names + deterministic colli
     const targets = planSyncTargets([a, b]);
     assert.deepEqual(new Set(targets.map((t) => t.dirName)).size, 2, 'no duplicate dir names');
     assert.equal(targets[0]?.dirName, 'foo-bar');
+  });
+
+  it('full-id fallback checks the taken set and escalates instead of colliding', () => {
+    // Regression (PR #212 review): crafted/imported display names can occupy
+    // BOTH fallback forms of a later skill. Unchecked, the full-id form was
+    // assigned anyway — two skills sharing one dirName silently overwrite each
+    // other's mirror. b's path here: base '报告' taken (a) → suffixed
+    // '报告-22222222' taken (c) → full-id '报告-22222222-bbbb' taken (d) →
+    // must escalate one more level.
+    const c = { id: '33333333-cccc', name: '报告-22222222', createdAt: 50 };
+    const a = { id: '11111111-aaaa', name: '报告', createdAt: 100 };
+    const d = { id: '44444444-dddd', name: '报告-22222222-bbbb', createdAt: 150 };
+    const b = { id: '22222222-bbbb', name: '报告', createdAt: 200 };
+
+    const targets = planSyncTargets([b, d, a, c]);
+    const names = targets.map((t) => t.dirName);
+    assert.equal(new Set(names).size, 4, `dir names must be unique, got: ${names.join(', ')}`);
+    assert.equal(targets.find((t) => t.id === b.id)?.dirName, '报告-22222222-bbbb-22222222');
+  });
+
+  it('planned dir names stay within the 255-byte NAME_MAX even for astral-character names', () => {
+    const name = '\u{20000}'.repeat(64);
+    const a = { id: '11111111-aaaa', name, createdAt: 1 };
+    const b = { id: '22222222-bbbb', name, createdAt: 2 };
+    for (const t of planSyncTargets([a, b])) {
+      assert.ok(
+        Buffer.byteLength(`molio--${t.dirName}`, 'utf8') <= 255,
+        `molio--${t.dirName} exceeds NAME_MAX`,
+      );
+    }
   });
 });

--- a/apps/daemon/test/core/skills/vault-config.test.ts
+++ b/apps/daemon/test/core/skills/vault-config.test.ts
@@ -5,8 +5,8 @@ import path from 'node:path';
 import os from 'node:os';
 import Database from 'better-sqlite3';
 import { openDatabase, closeDatabase, createVault } from '../../../src/core/db.js';
-import { createSkill, toggleSkill } from '../../../src/core/skills/store.js';
-import type { SkillPathsOpts } from '../../../src/core/skills/paths.js';
+import { createSkill, toggleSkill, updateSkill } from '../../../src/core/skills/store.js';
+import { slugifySkillName, type SkillPathsOpts } from '../../../src/core/skills/paths.js';
 import {
   getEffectiveSkillIds,
   reconcileVault,
@@ -51,9 +51,9 @@ function makeVault(name: string) {
   return { dir, vault };
 }
 
-/** Path to a synced skill dir inside a vault's .claude/skills. */
-function molioDirIn(vaultDir: string, id: string): string {
-  return path.join(vaultDir, '.claude', 'skills', `molio--${id}`);
+/** Path to a synced skill dir inside a vault's .claude/skills (name-based). */
+function molioDirIn(vaultDir: string, displayName: string): string {
+  return path.join(vaultDir, '.claude', 'skills', `molio--${slugifySkillName(displayName)}`);
 }
 
 describe('skills/vault-config', () => {
@@ -93,8 +93,8 @@ describe('skills/vault-config', () => {
 
     reconcileVault(db, vault, opts);
 
-    assert.ok(fs.existsSync(path.join(molioDirIn(dir, 'keep'), 'SKILL.md')), 'effective skill synced');
-    assert.ok(!fs.existsSync(molioDirIn(dir, 'off')), 'non-effective skill not present');
+    assert.ok(fs.existsSync(path.join(molioDirIn(dir, 'Keep'), 'SKILL.md')), 'effective skill synced');
+    assert.ok(!fs.existsSync(molioDirIn(dir, 'Off')), 'non-effective skill not present');
     assert.ok(!fs.existsSync(path.join(skillsRoot, 'molio--stale')), 'orphan molio-- dir removed');
     assert.ok(fs.existsSync(path.join(skillsRoot, 'wiki-query', 'SKILL.md')), 'builtin dir untouched');
     assert.ok(fs.existsSync(path.join(skillsRoot, 'my-own', 'SKILL.md')), 'user dir untouched');
@@ -107,20 +107,35 @@ describe('skills/vault-config', () => {
     reconcileVault(db, vault, opts);
     reconcileVault(db, vault, opts);
 
-    assert.ok(fs.existsSync(path.join(molioDirIn(dir, 'x'), 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(molioDirIn(dir, 'X'), 'SKILL.md')));
     const entries = fs.readdirSync(path.join(dir, '.claude', 'skills')).filter((e) => e.startsWith('molio--'));
     assert.deepEqual(entries, ['molio--x']);
+  });
+
+  it('reconcileVault converges the vault dir when a skill is renamed', () => {
+    // The vault dir follows the display name: renaming must remove the old
+    // slug's dir and create the new one on the next reconcile (orphan cleanup
+    // keyed on the planned dir-name set does this automatically).
+    const { dir, vault } = makeVault('V');
+    const entry = createSkill(db, { name: 'Old Name', description: '', enabled: true, builtIn: false }, 'body', opts);
+    reconcileVault(db, vault, opts);
+    assert.ok(fs.existsSync(molioDirIn(dir, 'Old Name')));
+
+    updateSkill(db, entry.id, { name: 'New Name' }, opts);
+    reconcileVault(db, vault, opts);
+    assert.ok(!fs.existsSync(molioDirIn(dir, 'Old Name')), 'old slug dir removed');
+    assert.ok(fs.existsSync(path.join(molioDirIn(dir, 'New Name'), 'SKILL.md')), 'new slug dir synced');
   });
 
   it('reconcileVault removes a skill that gets disabled after being synced', () => {
     const { dir, vault } = makeVault('V');
     createSkill(db, { id: 'y', name: 'Y', description: '', enabled: true, builtIn: false }, 'body', opts);
     reconcileVault(db, vault, opts);
-    assert.ok(fs.existsSync(molioDirIn(dir, 'y')));
+    assert.ok(fs.existsSync(molioDirIn(dir, 'Y')));
 
     toggleSkill(db, 'y', false);
     reconcileVault(db, vault, opts);
-    assert.ok(!fs.existsSync(molioDirIn(dir, 'y')), 'global disable removes the dir');
+    assert.ok(!fs.existsSync(molioDirIn(dir, 'Y')), 'global disable removes the dir');
   });
 
   // ── reconcileAllVaults ──
@@ -132,8 +147,8 @@ describe('skills/vault-config', () => {
 
     reconcileAllVaults(db, opts);
 
-    assert.ok(fs.existsSync(path.join(molioDirIn(v1.dir, 'all'), 'SKILL.md')));
-    assert.ok(fs.existsSync(path.join(molioDirIn(v2.dir, 'all'), 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(molioDirIn(v1.dir, 'All'), 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(molioDirIn(v2.dir, 'All'), 'SKILL.md')));
 
     fs.rmSync(v1.dir, { recursive: true, force: true });
     fs.rmSync(v2.dir, { recursive: true, force: true });
@@ -174,8 +189,8 @@ describe('skills/vault-config: reconcileAllVaultsAsync (startup fan-out must not
 
     await reconcileAllVaultsAsync(db, opts);
 
-    assert.ok(fs.existsSync(path.join(molioDirIn(v1.dir, 'all'), 'SKILL.md')));
-    assert.ok(fs.existsSync(path.join(molioDirIn(v2.dir, 'all'), 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(molioDirIn(v1.dir, 'All'), 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(molioDirIn(v2.dir, 'All'), 'SKILL.md')));
 
     fs.rmSync(v1.dir, { recursive: true, force: true });
     fs.rmSync(v2.dir, { recursive: true, force: true });

--- a/apps/daemon/test/routes/skills-hub.test.ts
+++ b/apps/daemon/test/routes/skills-hub.test.ts
@@ -39,13 +39,47 @@ function zipOf(files: Record<string, string>): Uint8Array {
 }
 
 /**
- * Fake hub: catalog list + categories + zip download. `failAll` flips every
- * request into a network error to exercise the 502 mapping.
+ * Fake hub: catalog list + categories + zip download + skill detail/readme.
+ * `failAll` flips every request into a network error to exercise the 502 mapping.
  */
 function fakeHubFetch(opts: { failAll?: boolean } = {}): typeof fetch {
   return (async (input: unknown) => {
     if (opts.failAll) throw new Error('ECONNREFUSED (fake)');
     const url = String(input);
+    // Checked BEFORE the detail branch: the readme URL also matches /api/v1/skills/.
+    if (url.includes('/file?path=SKILL.md')) {
+      return new Response('---\nname: 商店技能\nversion: 1.0.0\n---\n\n商店技能详情正文', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+    if (url.includes('/api/v1/skills/')) {
+      const slug = /\/api\/v1\/skills\/([\w.-]+)/.exec(url)?.[1];
+      if (slug === 'alpha-skill' || slug === 'beta-skill') {
+        return new Response(
+          JSON.stringify({
+            slug,
+            skill: {
+              slug,
+              displayName: slug === 'alpha-skill' ? 'Alpha 详情' : 'Beta 详情',
+              summary: 'english summary',
+              summary_zh: slug === 'alpha-skill' ? '阿尔法详情' : '贝塔详情',
+              category: 'office-efficiency',
+              createdAt: 1785000000000,
+              updatedAt: 1786000000000,
+              labels: { requires_api_key: 'false' },
+              stats: { downloads: 10, installs: 2, stars: 1, versions: 1 },
+            },
+            latestVersion: { version: '1.0.0', changelog: 'init' },
+            owner: { handle: slug === 'alpha-skill' ? 'alice' : 'bob', displayName: 'Owner' },
+            namespace: { handle: slug === 'alpha-skill' ? 'alice' : 'bob' },
+            securityReports: { keen: { status: 'benign', statusText: '安全，无风险' } },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('missing', { status: 404 });
+    }
     if (url.includes('/api/skills?')) {
       return new Response(
         JSON.stringify({
@@ -265,7 +299,57 @@ describe('Skills hub routes', () => {
     assert.notEqual(alpha.installed, true);
   });
 
-  it('hub unreachable → 502 on catalog and install', async () => {
+  it('GET /hub/skill returns detail with readme and the installed annotation', async () => {
+    // From the previous tests: alpha is installed ONLY under namespace
+    // 'alice'; beta under 'bob' + 'carol'. The annotation must follow the
+    // REQUESTED namespace, not the detail response's own namespace field.
+    const alpha = await app.request('/api/skills/hub/skill?slug=alpha-skill');
+    assert.equal(alpha.status, 200);
+    const aBody = ((await json(alpha))['detail'] as Record<string, unknown>);
+    assert.equal(aBody['name'], 'Alpha 详情');
+    assert.equal(aBody['description'], '阿尔法详情'); // zh-first
+    assert.equal(aBody['readme'], '商店技能详情正文'); // frontmatter stripped
+    assert.equal(aBody['installed'], undefined); // no namespace-less install exists
+    assert.equal(aBody['latestVersion'], '1.0.0');
+    assert.deepEqual(aBody['security'], { keen: '安全，无风险' });
+
+    const bob = await app.request('/api/skills/hub/skill?slug=beta-skill&namespace=bob');
+    assert.equal(bob.status, 200);
+    const bBody = ((await json(bob))['detail'] as Record<string, unknown>);
+    assert.equal(bBody['installed'], true);
+    assert.equal(bBody['installedVersion'], '1.0.0');
+
+    // carol's record of the same slug is a separate install — its annotation
+    // must not leak into bob's view and vice versa.
+    const carol = await app.request('/api/skills/hub/skill?slug=beta-skill&namespace=carol');
+    assert.equal(carol.status, 200);
+    assert.equal(((await json(carol))['detail'] as Record<string, unknown>)['installed'], true);
+  });
+
+  it('GET /hub/skill validates input and maps upstream errors', async () => {
+    assert.equal((await app.request('/api/skills/hub/skill')).status, 400);
+    assert.equal((await app.request('/api/skills/hub/skill?slug=ghost-skill')).status, 404);
+  });
+
+  it('GET /hub/skills forwards the sort param upstream', async () => {
+    const urls: string[] = [];
+    _setHubFetchForTests((async (input: unknown) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify({ code: 0, data: { skills: [], total: 0 } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch);
+    try {
+      const res = await app.request('/api/skills/hub/skills?sort=downloads');
+      assert.equal(res.status, 200);
+      assert.ok(urls.some((u) => u.includes('sortBy=downloads') && u.includes('order=desc')), urls.join('\n'));
+    } finally {
+      _setHubFetchForTests(fakeHubFetch());
+    }
+  });
+
+  it('hub unreachable → 502 on catalog, install and detail', async () => {
     _setHubFetchForTests(fakeHubFetch({ failAll: true }));
     try {
       const list = await app.request('/api/skills/hub/skills');
@@ -278,6 +362,8 @@ describe('Skills hub routes', () => {
       assert.equal(install.status, 502);
       const errBody = await json(install);
       assert.match(String((errBody['error'] as { message: string }).message), /SkillHub/);
+      const detail = await app.request('/api/skills/hub/skill?slug=alpha-skill');
+      assert.equal(detail.status, 502);
     } finally {
       _setHubFetchForTests(fakeHubFetch());
     }

--- a/apps/daemon/test/routes/skills.test.ts
+++ b/apps/daemon/test/routes/skills.test.ts
@@ -170,7 +170,8 @@ describe('Skills routes', () => {
         body: JSON.stringify({ name: '传播', description: '', instructions: 'body' }),
       });
       const skill = (await json(created))['skill'] as SkillManifestEntry;
-      const inVault = join(vaultDir, '.claude', 'skills', `molio--${skill.id}`, 'SKILL.md');
+      // Vault dir is name-based (slugified display name), not the DB uuid.
+      const inVault = join(vaultDir, '.claude', 'skills', `molio--${skill.name}`, 'SKILL.md');
       assert.ok(existsSync(inVault), 'enabled skill should be synced into the vault');
 
       // Toggle it off → reconcile removes it from the vault.

--- a/apps/web/e2e/skill-hub.spec.ts
+++ b/apps/web/e2e/skill-hub.spec.ts
@@ -66,12 +66,16 @@ const MOCK_CATEGORIES = [
 interface HubMockState {
   /** When true the list endpoint answers 502 (hub unreachable). */
   failList: boolean;
+  /** When true the install endpoint answers 502 (install failure feedback). */
+  failInstall?: boolean;
   /** Artificial install latency so the busy button state is observable. */
   installDelayMs: number;
   /** Captured POST /hub/install bodies. */
   installRequests: Array<Record<string, unknown>>;
   /** Captured GET /hub/skills request URLs (sort param assertions). */
   listRequests: string[];
+  /** Overrides the readme in the detail payload (untrusted-rendering tests). */
+  readmeOverride?: string;
 }
 
 /** Build the detail payload the daemon's GET /hub/skill would return. */
@@ -116,10 +120,12 @@ async function setupHubMocks(page: import('@playwright/test').Page, state: HubMo
         body: JSON.stringify({ error: { code: 'NOT_FOUND', message: 'E2E模拟详情不存在' } }),
       });
     }
+    const detail = mockDetailFor(src);
+    if (state.readmeOverride !== undefined) detail.readme = state.readmeOverride;
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ detail: mockDetailFor(src) }),
+      body: JSON.stringify({ detail }),
     });
   });
 
@@ -163,6 +169,13 @@ async function setupHubMocks(page: import('@playwright/test').Page, state: HubMo
     state.installRequests.push(body);
     if (state.installDelayMs > 0) {
       await new Promise((r) => setTimeout(r, state.installDelayMs));
+    }
+    if (state.failInstall) {
+      return route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'HUB_UNAVAILABLE', message: 'E2E模拟安装失败' } }),
+      });
     }
     const src = MOCK_SKILLS.find((s) => s.slug === body.slug);
     return route.fulfill({
@@ -437,5 +450,81 @@ test.describe('Skill store (skillhub.cn)', () => {
     await expect(page.getByTestId('hub-notice')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('hub-detail-overlay')).toHaveCount(0);
     expect(state.installRequests).toHaveLength(1);
+  });
+
+  test('keyboard: Enter on the install button installs instead of opening the modal', async ({ page }) => {
+    const state: HubMockState = { failList: false, installDelayMs: 200, installRequests: [], listRequests: [] };
+    await setupHubMocks(page, state);
+
+    await gotoSkillsHub(page);
+    await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible({ timeout: 10_000 });
+
+    // Regression (PR #212 review): the card's onKeyDown swallowed keydowns
+    // bubbling up from the install button — a keyboard user pressing Enter on
+    // the focused button never triggered the install, and the detail modal
+    // popped open instead.
+    await page.getByTestId('hub-install-pdf-tools').focus();
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByTestId('hub-notice')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('hub-detail-overlay')).toHaveCount(0);
+    expect(state.installRequests).toHaveLength(1);
+  });
+
+  test('install failure from the detail modal surfaces inside the modal', async ({ page }) => {
+    const state: HubMockState = {
+      failList: false,
+      failInstall: true,
+      installDelayMs: 0,
+      installRequests: [],
+      listRequests: [],
+    };
+    await setupHubMocks(page, state);
+
+    await gotoSkillsHub(page);
+    await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByTestId('hub-card-pdf-tools').click();
+    await expect(page.getByTestId('hub-detail-overlay')).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('hub-detail-install').click();
+
+    // Regression (PR #212 review): the panel's error banner renders BEHIND the
+    // fixed full-viewport overlay and the error path keeps the modal open —
+    // the user got zero feedback. The modal must surface the error itself.
+    await expect(page.getByTestId('hub-detail-notice')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('hub-detail-notice')).toContainText('E2E模拟安装失败');
+    await expect(page.getByTestId('hub-detail-overlay')).toBeVisible();
+    expect(state.installRequests).toHaveLength(1);
+  });
+
+  test('untrusted readme: raw HTML never survives sanitization', async ({ page }) => {
+    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [], listRequests: [] };
+    // A malicious hub publisher's SKILL.md: raw-HTML script vectors that the
+    // local-content rendering affordances (onerror allowlist) used to let pass.
+    state.readmeOverride = [
+      '# 恶意 readme',
+      '',
+      '<img src="http://molio-e2e.invalid/x.png" onerror="window.__hubXssImg = 1">',
+      '',
+      '[点我](javascript:window.__hubXssLink = 1)',
+    ].join('\n');
+    await setupHubMocks(page, state);
+
+    await gotoSkillsHub(page);
+    await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('hub-card-pdf-tools').click();
+
+    const readme = page.getByTestId('hub-detail-readme');
+    await expect(readme).toBeVisible({ timeout: 10_000 });
+    await expect(readme).toContainText('恶意 readme');
+
+    // Give a wrongly-surviving onerror handler the chance to fire on the
+    // broken image, then assert nothing executed and no dangerous attribute
+    // or href survived the strict profile.
+    await page.waitForTimeout(500);
+    expect(await page.evaluate(() => (window as unknown as Record<string, unknown>).__hubXssImg)).toBeUndefined();
+    expect(await page.evaluate(() => (window as unknown as Record<string, unknown>).__hubXssLink)).toBeUndefined();
+    expect(await readme.locator('[onerror]').count()).toBe(0);
+    expect(await readme.locator('a[href^="javascript:"]').count()).toBe(0);
   });
 });

--- a/apps/web/e2e/skill-hub.spec.ts
+++ b/apps/web/e2e/skill-hub.spec.ts
@@ -70,6 +70,30 @@ interface HubMockState {
   installDelayMs: number;
   /** Captured POST /hub/install bodies. */
   installRequests: Array<Record<string, unknown>>;
+  /** Captured GET /hub/skills request URLs (sort param assertions). */
+  listRequests: string[];
+}
+
+/** Build the detail payload the daemon's GET /hub/skill would return. */
+function mockDetailFor(s: MockSkill) {
+  return {
+    slug: s.slug,
+    name: s.name,
+    description: s.description,
+    category: s.category,
+    sourceUrl: `https://skillhub.cn/skills/${s.slug}`,
+    iconUrl: '',
+    createdAt: s.updatedAt - 86_400_000,
+    updatedAt: s.updatedAt,
+    verified: s.verified,
+    requiresApiKey: s.requiresApiKey,
+    ownerName: s.ownerName,
+    latestVersion: s.version,
+    stats: { downloads: s.downloads, installs: Math.floor(s.downloads / 2), stars: 12, versions: 3 },
+    readme: `# ${s.name} 使用说明\n\n这是 ${s.slug} 的 E2E mock readme 正文。`,
+    security: { keen: '安全，无风险' },
+    installed: s.installed,
+  };
 }
 
 /**
@@ -77,7 +101,30 @@ interface HubMockState {
  * (the list + categories requests fire on panel mount).
  */
 async function setupHubMocks(page: import('@playwright/test').Page, state: HubMockState) {
+  // Detail endpoint (GET /hub/skill?slug=…). A REGEX route on purpose: the
+  // glob '**/api/skills/hub/skill*' would also swallow the LIST endpoint
+  // ('/hub/skills…'), and glob '?' is a one-char wildcard, so 'skill?*'
+  // can't disambiguate either.
+  await page.route(/\/api\/skills\/hub\/skill\?/, (route) => {
+    const url = new URL(route.request().url());
+    const slug = url.searchParams.get('slug') ?? '';
+    const src = MOCK_SKILLS.find((s) => s.slug === slug);
+    if (!src) {
+      return route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'NOT_FOUND', message: 'E2E模拟详情不存在' } }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: mockDetailFor(src) }),
+    });
+  });
+
   await page.route('**/api/skills/hub/skills*', (route) => {
+    state.listRequests.push(route.request().url());
     if (state.failList) {
       return route.fulfill({
         status: 502,
@@ -148,7 +195,7 @@ async function gotoSkillsHub(page: import('@playwright/test').Page) {
 
 test.describe('Skill store (skillhub.cn)', () => {
   test('store view renders catalog cards with meta and category filter', async ({ page }) => {
-    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [] };
+    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [], listRequests: [] };
     await setupHubMocks(page, state);
 
     await gotoSkillsHub(page);
@@ -170,7 +217,7 @@ test.describe('Skill store (skillhub.cn)', () => {
   });
 
   test('search and category filter re-query the catalog', async ({ page }) => {
-    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [] };
+    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [], listRequests: [] };
     await setupHubMocks(page, state);
 
     await gotoSkillsHub(page);
@@ -198,7 +245,7 @@ test.describe('Skill store (skillhub.cn)', () => {
 
   test('install click posts the slug and flips the card to installed', async ({ page }) => {
     // Deliberate latency so the 安装中… busy state is observable.
-    const state: HubMockState = { failList: false, installDelayMs: 800, installRequests: [] };
+    const state: HubMockState = { failList: false, installDelayMs: 800, installRequests: [], listRequests: [] };
     await setupHubMocks(page, state);
 
     await gotoSkillsHub(page);
@@ -224,7 +271,7 @@ test.describe('Skill store (skillhub.cn)', () => {
   });
 
   test('one install at a time: every install button is gated while one is in flight', async ({ page }) => {
-    const state: HubMockState = { failList: false, installDelayMs: 800, installRequests: [] };
+    const state: HubMockState = { failList: false, installDelayMs: 800, installRequests: [], listRequests: [] };
     await setupHubMocks(page, state);
 
     await gotoSkillsHub(page);
@@ -247,7 +294,7 @@ test.describe('Skill store (skillhub.cn)', () => {
   });
 
   test('hub browsing state survives switching to the library tab and back', async ({ page }) => {
-    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [] };
+    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [], listRequests: [] };
     await setupHubMocks(page, state);
 
     await gotoSkillsHub(page);
@@ -270,7 +317,7 @@ test.describe('Skill store (skillhub.cn)', () => {
   });
 
   test('hub unreachable shows the error banner; retry recovers', async ({ page }) => {
-    const state: HubMockState = { failList: true, installDelayMs: 0, installRequests: [] };
+    const state: HubMockState = { failList: true, installDelayMs: 0, installRequests: [], listRequests: [] };
     await setupHubMocks(page, state);
 
     await gotoSkillsHub(page);
@@ -285,5 +332,110 @@ test.describe('Skill store (skillhub.cn)', () => {
     await page.getByTestId('hub-error').locator('button').click();
     await expect(page.getByTestId('hub-grid')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible();
+  });
+
+  test('sort buttons re-query the catalog with the matching sort param', async ({ page }) => {
+    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [], listRequests: [] };
+    await setupHubMocks(page, state);
+
+    await gotoSkillsHub(page);
+    await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible({ timeout: 10_000 });
+
+    // Default ranking is active initially; its request carries no sort param.
+    await expect(page.getByTestId('hub-sort-default')).toHaveClass(/sk-seg__item--active/);
+    expect(state.listRequests.some((u) => u.includes('sort='))).toBe(false);
+
+    // Downloads sort → the debounced re-query carries sort=downloads.
+    await page.getByTestId('hub-sort-downloads').click();
+    await expect(page.getByTestId('hub-sort-downloads')).toHaveClass(/sk-seg__item--active/);
+    await expect
+      .poll(() => state.listRequests.some((u) => u.includes('sort=downloads')), { timeout: 10_000 })
+      .toBe(true);
+
+    // Recently updated → sort=updated.
+    await page.getByTestId('hub-sort-updated').click();
+    await expect
+      .poll(() => state.listRequests.some((u) => u.includes('sort=updated')), { timeout: 10_000 })
+      .toBe(true);
+
+    // Back to default: the newest request drops the sort param entirely.
+    await page.getByTestId('hub-sort-default').click();
+    await expect(page.getByTestId('hub-sort-default')).toHaveClass(/sk-seg__item--active/);
+    await expect
+      .poll(() => {
+        const last = state.listRequests[state.listRequests.length - 1];
+        return !!last && !last.includes('sort=');
+      }, { timeout: 10_000 })
+      .toBe(true);
+  });
+
+  test('clicking a card opens the detail modal with readme and stats', async ({ page }) => {
+    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [], listRequests: [] };
+    await setupHubMocks(page, state);
+
+    await gotoSkillsHub(page);
+    await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByTestId('hub-card-pdf-tools').click();
+
+    const overlay = page.getByTestId('hub-detail-overlay');
+    await expect(overlay).toBeVisible({ timeout: 10_000 });
+
+    // Header name, author and the rendered SKILL.md readme come from the mock.
+    await expect(page.locator('.hub-detail-name')).toHaveText('PDF Tools');
+    await expect(page.getByTestId('hub-detail-body')).toContainText('acme');
+    await expect(page.getByTestId('hub-detail-readme')).toContainText('pdf-tools 的 E2E mock readme 正文');
+    // Security verdict badges show when the detail reports them.
+    await expect(page.getByTestId('hub-detail-security')).toBeVisible();
+    // Not installed in the mock → install button enabled.
+    await expect(page.getByTestId('hub-detail-install')).toBeEnabled();
+
+    // Esc closes the modal (same convention as the resources lightbox).
+    await page.keyboard.press('Escape');
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test('install from the detail modal posts the request and closes the modal', async ({ page }) => {
+    const state: HubMockState = { failList: false, installDelayMs: 0, installRequests: [], listRequests: [] };
+    await setupHubMocks(page, state);
+
+    await gotoSkillsHub(page);
+    await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible({ timeout: 10_000 });
+
+    const cardBtn = page.getByTestId('hub-install-pdf-tools');
+    const labelBefore = await cardBtn.textContent();
+
+    await page.getByTestId('hub-card-pdf-tools').click();
+    await expect(page.getByTestId('hub-detail-overlay')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('hub-detail-install')).toBeEnabled();
+
+    await page.getByTestId('hub-detail-install').click();
+
+    // The success banner is the feedback; the modal closes behind it.
+    await expect(page.getByTestId('hub-notice')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.hub-notice--success')).toBeVisible();
+    await expect(page.getByTestId('hub-detail-overlay')).toHaveCount(0);
+
+    // The daemon received the install request and the card flipped state
+    // (安装 → 更新), asserted on the CHANGE to stay locale-independent.
+    expect(state.installRequests).toHaveLength(1);
+    expect(state.installRequests[0]).toMatchObject({ slug: 'pdf-tools', version: '1.2.0' });
+    await expect(cardBtn).not.toHaveText(labelBefore ?? '');
+  });
+
+  test('clicking the install button on a card does not open the detail modal', async ({ page }) => {
+    const state: HubMockState = { failList: false, installDelayMs: 300, installRequests: [], listRequests: [] };
+    await setupHubMocks(page, state);
+
+    await gotoSkillsHub(page);
+    await expect(page.getByTestId('hub-card-pdf-tools')).toBeVisible({ timeout: 10_000 });
+
+    // Direct install from the card: the click must not bubble into the card's
+    // own onClick (which opens the detail modal).
+    await page.getByTestId('hub-install-pdf-tools').click();
+
+    await expect(page.getByTestId('hub-notice')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('hub-detail-overlay')).toHaveCount(0);
+    expect(state.installRequests).toHaveLength(1);
   });
 });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   ImportSkillRequest, PrefillResult,
   HubSkillsQuery, HubSkillsListResponse, HubCategoriesResponse,
   InstallHubSkillRequest, InstallHubSkillResponse,
+  HubSkillDetailQuery, HubSkillDetailResponse,
 } from '@molio/contracts';
 
 export type WeixinLoginStatus = 'idle' | 'waiting_scan' | 'scanned' | 'logged_in' | 'error';
@@ -882,11 +883,24 @@ export const api = {
     if (query.pageSize) params.set('pageSize', String(query.pageSize));
     if (query.keyword?.trim()) params.set('keyword', query.keyword.trim());
     if (query.category?.trim()) params.set('category', query.category.trim());
+    if (query.sort && query.sort !== 'default') params.set('sort', query.sort);
     const qs = params.toString();
     const res = await fetch(`${BASE}/skills/hub/skills${qs ? `?${qs}` : ''}`);
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.error?.message ?? `Failed to fetch hub skills: ${res.status}`);
+    }
+    return res.json();
+  },
+
+  /** One hub skill's detail (stats + SKILL.md readme + security verdicts). */
+  async hubSkillDetail(query: HubSkillDetailQuery): Promise<HubSkillDetailResponse> {
+    const params = new URLSearchParams({ slug: query.slug });
+    if (query.namespace?.trim()) params.set('namespace', query.namespace.trim());
+    const res = await fetch(`${BASE}/skills/hub/skill?${params.toString()}`);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error?.message ?? `Failed to fetch hub skill detail: ${res.status}`);
     }
     return res.json();
   },

--- a/apps/web/src/components/kb/MdRenderer.tsx
+++ b/apps/web/src/components/kb/MdRenderer.tsx
@@ -38,6 +38,13 @@ export interface MdRendererProps {
   options?: Partial<IOpts>;
   /** Additional CSS class */
   className?: string;
+  /**
+   * Content is UNTRUSTED (e.g. a remote hub SKILL.md readme): render under
+   * the strict sanitization profile — no `onerror` allowlist, no
+   * mermaid/infographic protect-and-restore. Leave unset for
+   * locally-authored content (KB docs), which relies on those affordances.
+   */
+  untrusted?: boolean;
 }
 
 // Default renderer options
@@ -71,6 +78,7 @@ export const MdRenderer = memo(function MdRenderer({
   themeConfig,
   options = defaultOptions,
   className,
+  untrusted = false,
 }: MdRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [renderedHtml, setRenderedHtml] = useState('');
@@ -99,14 +107,18 @@ export const MdRenderer = memo(function MdRenderer({
     }
 
     try {
-      const { html, readingTime } = renderMarkdown(content, renderer);
+      const { html, readingTime } = renderMarkdown(
+        content,
+        renderer,
+        untrusted ? { untrusted: true } : undefined,
+      );
       const finalHtml = postProcessHtml(html, readingTime, renderer);
       setRenderedHtml(finalHtml);
     } catch (error) {
       console.error('Markdown rendering error:', error);
       setRenderedHtml(`<p>Error rendering content: ${String(error)}</p>`);
     }
-  }, [content, renderer]);
+  }, [content, renderer, untrusted]);
 
   // Apply theme CSS when themeConfig changes.
   // The doocs/md theme system handles all styles — do NOT inject styles manually.

--- a/apps/web/src/components/settings/HubSkillDetailModal.tsx
+++ b/apps/web/src/components/settings/HubSkillDetailModal.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react';
+import type { HubSkillDetail, HubSkillSummary } from '@molio/contracts';
+import { api } from '../../api/client';
+import { useI18n } from '../../i18n';
+import { MdRenderer } from '../kb/MdRenderer';
+import { defaultThemeConfig } from '../kb/MdStylePanel';
+
+/** Compact count like the hub site (2249 → 2249, 120000 → 12.0万 / 12.0w). */
+export function formatDownloads(n: number, zh: boolean): string {
+  if (n < 10000) return String(n);
+  const v = (n / 10000).toFixed(1);
+  return zh ? `${v}万` : `${v}w`;
+}
+
+/**
+ * Skill store detail modal: fetches the hub detail (stats, security verdicts,
+ * SKILL.md readme) for one catalog entry on open. The readme is rendered with
+ * the shared doocs/md engine; a readme fetch failure never blocks the detail
+ * (the daemon returns readme: '' in that case).
+ */
+export function HubSkillDetailModal({
+  skill,
+  busy,
+  onClose,
+  onInstall,
+}: {
+  skill: HubSkillSummary;
+  /** ANY install is in flight — same one-at-a-time gating as the card grid. */
+  busy: boolean;
+  onClose: () => void;
+  onInstall: () => void;
+}) {
+  const { t, locale } = useI18n();
+  const zh = locale.startsWith('zh');
+  const [detail, setDetail] = useState<HubSkillDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .hubSkillDetail({ slug: skill.slug, namespace: skill.namespace })
+      .then((res) => {
+        if (!cancelled) setDetail(res.detail);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [skill.slug, skill.namespace, attempt]);
+
+  // Esc closes, same convention as the resources lightbox.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Prefer the detail's live installed flag; fall back to the list annotation
+  // while the detail is still loading.
+  const installed = detail?.installed ?? skill.installed ?? false;
+  const name = detail?.name ?? skill.name;
+
+  return (
+    <div
+      className="hub-detail-overlay"
+      data-testid="hub-detail-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="hub-detail-modal" role="dialog" aria-modal="true" aria-label={name}>
+        <div className="hub-detail-header">
+          <span className="hub-detail-name" title={name}>
+            {name}
+          </span>
+          {(detail?.verified ?? skill.verified) && (
+            <span className="hub-badge hub-badge--verified" title={t('hub.verified')}>
+              ✓
+            </span>
+          )}
+          {(detail?.requiresApiKey ?? skill.requiresApiKey) && (
+            <span className="hub-badge hub-badge--key">{t('hub.requiresApiKey')}</span>
+          )}
+          <button className="hub-detail-close" onClick={onClose} aria-label={t('hub.detail.close')}>
+            ×
+          </button>
+        </div>
+
+        <div className="hub-detail-body" data-testid="hub-detail-body">
+          {loading ? (
+            <div className="rt-loading">{t('hub.detail.loading')}</div>
+          ) : error ? (
+            <div className="rt-error" data-testid="hub-detail-error">
+              <span>{error}</span>
+              <button
+                className="rt-btn rt-btn--sm rt-btn--ghost"
+                onClick={() => setAttempt((a) => a + 1)}
+              >
+                {t('hub.retry')}
+              </button>
+            </div>
+          ) : detail ? (
+            <>
+              <div className="hub-detail-meta">
+                <span className="hub-detail-meta__author" title={detail.ownerName}>
+                  {detail.ownerName}
+                </span>
+                {detail.latestVersion && <span>{t('hub.version', { version: detail.latestVersion })}</span>}
+                <span title={String(detail.stats.downloads)}>
+                  {t('hub.downloads', { count: formatDownloads(detail.stats.downloads, zh) })}
+                </span>
+                {detail.stats.stars > 0 && (
+                  <span title={String(detail.stats.stars)}>
+                    {t('hub.detail.stars', { n: formatDownloads(detail.stats.stars, zh) })}
+                  </span>
+                )}
+                {detail.updatedAt > 0 && (
+                  <span>
+                    {t('hub.detail.updatedAt', {
+                      date: new Date(detail.updatedAt).toLocaleDateString(locale),
+                    })}
+                  </span>
+                )}
+              </div>
+
+              {detail.security && (detail.security.keen || detail.security.sanbu) && (
+                <div className="hub-detail-security" data-testid="hub-detail-security">
+                  <span>{t('hub.detail.security')}</span>
+                  {detail.security.keen && (
+                    <span className="hub-detail-security__item">{detail.security.keen}</span>
+                  )}
+                  {detail.security.sanbu && (
+                    <span className="hub-detail-security__item">{detail.security.sanbu}</span>
+                  )}
+                </div>
+              )}
+
+              {detail.description && <p className="hub-detail-desc">{detail.description}</p>}
+
+              {detail.readme ? (
+                <div className="hub-detail-readme" data-testid="hub-detail-readme">
+                  <MdRenderer content={detail.readme} themeConfig={defaultThemeConfig} />
+                </div>
+              ) : (
+                <p className="hub-detail-noreadme">{t('hub.detail.noReadme')}</p>
+              )}
+            </>
+          ) : null}
+        </div>
+
+        <div className="hub-detail-footer">
+          <button
+            className={`rt-btn${installed ? ' rt-btn--ghost' : ''}`}
+            data-testid="hub-detail-install"
+            onClick={onInstall}
+            disabled={busy}
+          >
+            {busy ? t('hub.installing') : installed ? t('hub.update') : t('hub.install')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/HubSkillDetailModal.tsx
+++ b/apps/web/src/components/settings/HubSkillDetailModal.tsx
@@ -13,6 +13,22 @@ export function formatDownloads(n: number, zh: boolean): string {
 }
 
 /**
+ * The readme is attacker-controllable (any hub publisher writes their own
+ * SKILL.md), so it renders under the strict untrusted profile. On top of
+ * that, executable diagram fences are demoted to plain code blocks: their
+ * renderers inject results into the DOM AFTER sanitization (mermaid via
+ * innerHTML, plantuml via outerHTML — and plantuml additionally issues an
+ * external request to plantuml.com with the block content). Showing the
+ * diagram SOURCE as a code block keeps the readme informative without any of
+ * those side channels.
+ */
+const EXECUTABLE_DIAGRAM_FENCE_RE = /^```(?:mermaid|plantuml|infographic)(?=\r?\n)/gm;
+
+export function neutralizeDiagramFences(markdown: string): string {
+  return markdown.replace(EXECUTABLE_DIAGRAM_FENCE_RE, '```text');
+}
+
+/**
  * Skill store detail modal: fetches the hub detail (stats, security verdicts,
  * SKILL.md readme) for one catalog entry on open. The readme is rendered with
  * the shared doocs/md engine; a readme fetch failure never blocks the detail
@@ -21,12 +37,20 @@ export function formatDownloads(n: number, zh: boolean): string {
 export function HubSkillDetailModal({
   skill,
   busy,
+  notice,
   onClose,
   onInstall,
 }: {
   skill: HubSkillSummary;
   /** ANY install is in flight — same one-at-a-time gating as the card grid. */
   busy: boolean;
+  /**
+   * Install feedback from the parent panel. Rendered INSIDE the modal too:
+   * the panel's own banner sits behind the fixed full-viewport overlay, so a
+   * failed install from the modal would otherwise give zero feedback (the
+   * success path closes the modal, the error path keeps it open).
+   */
+  notice: { kind: 'success' | 'error'; text: string } | null;
   onClose: () => void;
   onInstall: () => void;
 }) {
@@ -150,7 +174,11 @@ export function HubSkillDetailModal({
 
               {detail.readme ? (
                 <div className="hub-detail-readme" data-testid="hub-detail-readme">
-                  <MdRenderer content={detail.readme} themeConfig={defaultThemeConfig} />
+                  <MdRenderer
+                    content={neutralizeDiagramFences(detail.readme)}
+                    themeConfig={defaultThemeConfig}
+                    untrusted
+                  />
                 </div>
               ) : (
                 <p className="hub-detail-noreadme">{t('hub.detail.noReadme')}</p>
@@ -158,6 +186,15 @@ export function HubSkillDetailModal({
             </>
           ) : null}
         </div>
+
+        {notice && (
+          <div
+            className={notice.kind === 'success' ? 'hub-notice hub-notice--success' : 'rt-error'}
+            data-testid="hub-detail-notice"
+          >
+            <span>{notice.text}</span>
+          </div>
+        )}
 
         <div className="hub-detail-footer">
           <button

--- a/apps/web/src/components/settings/SkillHubPanel.tsx
+++ b/apps/web/src/components/settings/SkillHubPanel.tsx
@@ -34,6 +34,11 @@ function HubCard({
       data-testid={`hub-card-${skill.slug}`}
       onClick={onOpenDetail}
       onKeyDown={(e) => {
+        // Only react to keys pressed on the card ITSELF: keydowns from the
+        // nested install button bubble up here, and preventDefault would
+        // swallow the button's native keyboard activation (Enter fires click
+        // on keydown, Space on keyup) — a keyboard user could never install.
+        if (e.target !== e.currentTarget) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onOpenDetail();
@@ -256,6 +261,7 @@ export function SkillHubPanel({ onInstalled }: { onInstalled: (res: InstallHubSk
         <HubSkillDetailModal
           skill={detailSkill}
           busy={installingSlug !== null}
+          notice={notice}
           onClose={() => setDetailSkill(null)}
           onInstall={() => void handleInstall(detailSkill)}
         />

--- a/apps/web/src/components/settings/SkillHubPanel.tsx
+++ b/apps/web/src/components/settings/SkillHubPanel.tsx
@@ -1,14 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { HubSkillSummary, InstallHubSkillResponse } from '@molio/contracts';
-import { useSkillHub } from '../../hooks/useSkillHub';
+import { useSkillHub, type HubSort } from '../../hooks/useSkillHub';
 import { useI18n } from '../../i18n';
+import { HubSkillDetailModal, formatDownloads } from './HubSkillDetailModal';
 
-/** Compact download count like the hub site (2249 → 2249, 120000 → 12.0万 / 12.0k). */
-function formatDownloads(n: number, zh: boolean): string {
-  if (n < 10000) return String(n);
-  const v = (n / 10000).toFixed(1);
-  return zh ? `${v}万` : `${v}w`;
-}
+/** Sort options mirror skillhub.cn: default ranking / downloads / newest updates. */
+const HUB_SORTS: HubSort[] = ['default', 'downloads', 'updated'];
 
 function HubCard({
   skill,
@@ -16,6 +13,7 @@ function HubCard({
   busy,
   zh,
   onInstall,
+  onOpenDetail,
 }: {
   skill: HubSkillSummary;
   /** This card's install is in flight (shows the busy label). */
@@ -26,11 +24,24 @@ function HubCard({
   busy: boolean;
   zh: boolean;
   onInstall: () => void;
+  onOpenDetail: () => void;
 }) {
   const { t } = useI18n();
 
   return (
-    <div className="hub-card" data-testid={`hub-card-${skill.slug}`}>
+    <div
+      className="hub-card"
+      data-testid={`hub-card-${skill.slug}`}
+      onClick={onOpenDetail}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpenDetail();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
       <div className="hub-card__head">
         <span className="hub-card__name" title={skill.name}>
           {skill.name}
@@ -57,7 +68,11 @@ function HubCard({
         <button
           className={`rt-btn rt-btn--sm${skill.installed ? ' rt-btn--ghost' : ''}`}
           data-testid={`hub-install-${skill.slug}`}
-          onClick={onInstall}
+          // Direct installs must not open the detail modal (card is clickable).
+          onClick={(e) => {
+            e.stopPropagation();
+            onInstall();
+          }}
           disabled={busy}
           title={skill.installed ? t('hub.update') : undefined}
         >
@@ -86,6 +101,8 @@ export function SkillHubPanel({ onInstalled }: { onInstalled: (res: InstallHubSk
     setKeyword,
     category,
     setCategory,
+    sort,
+    setSort,
     hasMore,
     installingSlug,
     refresh,
@@ -104,6 +121,9 @@ export function SkillHubPanel({ onInstalled }: { onInstalled: (res: InstallHubSk
     return () => clearTimeout(timer);
   }, [notice]);
 
+  // Detail modal: opened by clicking a card; the modal fetches its own data.
+  const [detailSkill, setDetailSkill] = useState<HubSkillSummary | null>(null);
+
   const handleInstall = useCallback(
     async (skill: HubSkillSummary) => {
       // One install at a time (buttons are disabled too — this guards the
@@ -117,6 +137,9 @@ export function SkillHubPanel({ onInstalled }: { onInstalled: (res: InstallHubSk
           kind: 'success',
           text: res.updated ? t('hub.updatedTip') : t('hub.installedTip'),
         });
+        // An install from the detail modal closes it — the success banner
+        // behind is the feedback, and the card grid already flipped state.
+        setDetailSkill((cur) => (cur && cur.slug === skill.slug ? null : cur));
         onInstalled(res);
       } catch (err) {
         setNotice({ kind: 'error', text: (err as Error).message });
@@ -148,6 +171,19 @@ export function SkillHubPanel({ onInstalled }: { onInstalled: (res: InstallHubSk
             </option>
           ))}
         </select>
+        <div className="hub-sort" data-testid="hub-sort" role="group" aria-label={t('hub.sort.default')}>
+          {HUB_SORTS.map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={`sk-seg__item${sort === key ? ' sk-seg__item--active' : ''}`}
+              data-testid={`hub-sort-${key}`}
+              onClick={() => setSort(key)}
+            >
+              {t(`hub.sort.${key}`)}
+            </button>
+          ))}
+        </div>
       </div>
 
       {notice && (
@@ -189,6 +225,7 @@ export function SkillHubPanel({ onInstalled }: { onInstalled: (res: InstallHubSk
                 busy={installingSlug !== null}
                 zh={zh}
                 onInstall={() => void handleInstall(skill)}
+                onOpenDetail={() => setDetailSkill(skill)}
               />
             ))}
           </div>
@@ -214,6 +251,15 @@ export function SkillHubPanel({ onInstalled }: { onInstalled: (res: InstallHubSk
           {t('hub.source')}
         </a>
       </p>
+
+      {detailSkill && (
+        <HubSkillDetailModal
+          skill={detailSkill}
+          busy={installingSlug !== null}
+          onClose={() => setDetailSkill(null)}
+          onInstall={() => void handleInstall(detailSkill)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/hooks/useSkillHub.ts
+++ b/apps/web/src/hooks/useSkillHub.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { HubCategory, HubSkillSummary, InstallHubSkillResponse } from '@molio/contracts';
+import type { HubCategory, HubSkillsQuery, HubSkillSummary, InstallHubSkillResponse } from '@molio/contracts';
 import { api } from '../api/client';
 
 /**
@@ -11,6 +11,8 @@ import { api } from '../api/client';
  */
 export const HUB_PAGE_SIZE = 20;
 
+export type HubSort = NonNullable<HubSkillsQuery['sort']>;
+
 export function useSkillHub() {
   const [skills, setSkills] = useState<HubSkillSummary[]>([]);
   const [total, setTotal] = useState(0);
@@ -20,6 +22,7 @@ export function useSkillHub() {
   const [categories, setCategories] = useState<HubCategory[]>([]);
   const [keyword, setKeyword] = useState('');
   const [category, setCategory] = useState('');
+  const [sort, setSort] = useState<HubSort>('default');
   const [hasMore, setHasMore] = useState(false);
   const [installingSlug, setInstallingSlug] = useState<string | null>(null);
 
@@ -40,7 +43,7 @@ export function useSkillHub() {
         setLoadingMore(true);
       }
       try {
-        const data = await api.listHubSkills({ page, pageSize: HUB_PAGE_SIZE, keyword, category });
+        const data = await api.listHubSkills({ page, pageSize: HUB_PAGE_SIZE, keyword, category, sort });
         if (seqRef.current !== seq) return; // superseded by a newer query
         pageRef.current = data.page;
         setTotal(data.total);
@@ -55,10 +58,12 @@ export function useSkillHub() {
         }
       }
     },
-    [keyword, category],
+    // A sort change recreates `load`, and the effect below re-fires page 1 —
+    // same debounced reset path as keyword/category changes.
+    [keyword, category, sort],
   );
 
-  // Initial load + debounced re-query on keyword/category changes.
+  // Initial load + debounced re-query on keyword/category/sort changes.
   useEffect(() => {
     const timer = setTimeout(() => {
       void load(1, true);
@@ -147,6 +152,8 @@ export function useSkillHub() {
     setKeyword,
     category,
     setCategory,
+    sort,
+    setSort,
     hasMore,
     installingSlug,
     refresh,

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -353,6 +353,15 @@ const en: Record<string, string> = {
   'hub.verified': 'Verified',
   'hub.version': 'v{version}',
   'hub.downloads': '{count} downloads',
+  'hub.sort.default': 'Default',
+  'hub.sort.downloads': 'Downloads',
+  'hub.sort.updated': 'Recently updated',
+  'hub.detail.close': 'Close',
+  'hub.detail.loading': 'Loading details…',
+  'hub.detail.stars': '{n} stars',
+  'hub.detail.updatedAt': 'Updated {date}',
+  'hub.detail.security': 'Security',
+  'hub.detail.noReadme': 'No instructions available',
 
   // ── UpdateNotification ──
   'update.ready': 'Update ready',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -353,6 +353,15 @@ const zh: Record<string, string> = {
   'hub.verified': '官方认证',
   'hub.version': 'v{version}',
   'hub.downloads': '{count} 次下载',
+  'hub.sort.default': '默认排序',
+  'hub.sort.downloads': '下载量',
+  'hub.sort.updated': '最近更新',
+  'hub.detail.close': '关闭',
+  'hub.detail.loading': '加载详情…',
+  'hub.detail.stars': '收藏 {n}',
+  'hub.detail.updatedAt': '更新于 {date}',
+  'hub.detail.security': '安全检测',
+  'hub.detail.noReadme': '暂无使用说明',
 
   // ── UpdateNotification ──
   'update.ready': '更新就绪',

--- a/apps/web/src/styles/settings.css
+++ b/apps/web/src/styles/settings.css
@@ -1207,6 +1207,16 @@
   color: var(--text-faint);
 }
 
+/* Install feedback surfaced INSIDE the detail modal: the panel's own banner
+   renders behind the fixed overlay (invisible), so a failed modal install
+   would otherwise give zero feedback. Direct-child selectors only — the
+   detail fetch's own `.rt-error` retry banner lives inside the body. */
+.hub-detail-modal > .hub-notice,
+.hub-detail-modal > .rt-error {
+  flex: none;
+  margin: 0 24px 12px;
+}
+
 .hub-detail-footer {
   flex: none;
   display: flex;

--- a/apps/web/src/styles/settings.css
+++ b/apps/web/src/styles/settings.css
@@ -946,6 +946,8 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   transition: border-color 120ms ease;
+  /* The whole card is clickable (opens the detail modal). */
+  cursor: pointer;
 }
 
 .hub-card:hover {
@@ -1040,4 +1042,176 @@
 
 .hub-shell .sk-note a:hover {
   text-decoration: underline;
+}
+
+/* Sort segmented control in the toolbar. Reuses .sk-seg__item for the items;
+   this is the container — same look as .sk-seg but WITHOUT the page-level
+   margin that the 我的技能/技能商店 switch needs. */
+.hub-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  flex-shrink: 0;
+}
+
+/* ───────────────────────────────────────────────────────────
+   Skill detail modal (.hub-detail-*) — mirrors the kb-modal
+   pattern (knowledge.css): fixed overlay + scrolling body.
+   ─────────────────────────────────────────────────────────── */
+
+.hub-detail-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 25, 22, 0.35);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hub-detail-modal {
+  background: var(--bg-panel);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  width: min(640px, calc(100vw - 48px));
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.hub-detail-header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 18px 24px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.hub-detail-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hub-detail-close {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hub-detail-close:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+/* The modal is capped at 80vh with overflow:hidden — the body must be the
+   scroll container (same reasoning as .kb-modal-body): min-height:0 lets the
+   flex item shrink below its content height so overflow-y can kick in. */
+.hub-detail-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hub-detail-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+.hub-detail-meta__author {
+  max-width: 200px;
+  font-weight: 500;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hub-detail-security {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.hub-detail-security__item {
+  padding: 1px 8px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--green);
+  background: var(--green-bg);
+  border: 1px solid var(--green-border);
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+
+.hub-detail-desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+/* SKILL.md readme rendered by the shared doocs/md engine (#output). The theme
+   CSS supplies the typography; we only frame it and tame oversized content. */
+.hub-detail-readme {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 14px 18px;
+  overflow-x: auto;
+}
+
+.hub-detail-readme .md-preview {
+  font-size: 13px;
+}
+
+.hub-detail-readme .md-preview img {
+  max-width: 100%;
+}
+
+.hub-detail-noreadme {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-faint);
+}
+
+.hub-detail-footer {
+  flex: none;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 24px;
+  border-top: 1px solid var(--border);
 }

--- a/apps/web/vendor/doocs-md/src/utils/markdownHelpers.ts
+++ b/apps/web/vendor/doocs-md/src/utils/markdownHelpers.ts
@@ -7,45 +7,68 @@ const MERMAID_PLACEHOLDER_REGEX = /<!--mermaid-start-->[\s\S]*?<!--mermaid-end--
 const PROTECTED_SPAN_REGEX = /<span data-md-protected="(\d+)"><\/span>/g
 
 /**
+ * [MOLIO] Rendering profile switch for UNTRUSTED content (e.g. a remote hub
+ * SKILL.md readme). The local-content affordances double as XSS vectors for
+ * attacker-authored input, so the strict profile drops them:
+ *  - no `onerror` allowlist — a remote `<img src=x onerror=…>` would run script;
+ *  - no mermaid/infographic protect-and-restore — restored content bypasses
+ *    sanitization entirely, which is only acceptable for locally-authored docs.
+ * Cost: mermaid diagrams from untrusted input may lose foreignObject content
+ * (the very thing DOMPurify strips) — a broken diagram, not a compromise.
+ */
+export interface SanitizeOptions {
+  untrusted?: boolean
+}
+
+/**
  * DOMPurify v3.1.7+ 会强制移除 foreignObject 内容
  * https://github.com/kkomelin/isomorphic-dompurify/pull/290
  * https://github.com/cure53/DOMPurify/issues/1152
  * 使用占位符方案：在 sanitize 前保护特定内容，sanitize 后还原
  * 注意：HTML 注释会被 DOMPurify 移除，所以使用 span 元素作为占位符
  */
-function sanitizeHtml(html: string): string {
+function sanitizeHtml(html: string, opts?: SanitizeOptions): string {
+  const untrusted = opts?.untrusted === true
   const protectedContents: string[] = []
 
-  // 保护 infographic-diagram（使用注释标记定界，避免嵌套 div 问题）
-  html = html.replace(
-    INFOGRAPHIC_PLACEHOLDER_REGEX,
-    (match) => {
-      protectedContents.push(match)
-      return `<span data-md-protected="${protectedContents.length - 1}"></span>`
-    },
-  )
+  if (!untrusted) {
+    // 保护 infographic-diagram（使用注释标记定界，避免嵌套 div 问题）
+    html = html.replace(
+      INFOGRAPHIC_PLACEHOLDER_REGEX,
+      (match) => {
+        protectedContents.push(match)
+        return `<span data-md-protected="${protectedContents.length - 1}"></span>`
+      },
+    )
 
-  // 保护 mermaid-diagram（使用注释标记定界，避免嵌套 div 问题）
-  html = html.replace(
-    MERMAID_PLACEHOLDER_REGEX,
-    (match) => {
-      protectedContents.push(match)
-      return `<span data-md-protected="${protectedContents.length - 1}"></span>`
-    },
-  )
+    // 保护 mermaid-diagram（使用注释标记定界，避免嵌套 div 问题）
+    html = html.replace(
+      MERMAID_PLACEHOLDER_REGEX,
+      (match) => {
+        protectedContents.push(match)
+        return `<span data-md-protected="${protectedContents.length - 1}"></span>`
+      },
+    )
+  }
 
   // XSS 处理
-  // Allow onerror only for our benign broken-image fallback (set by renderer-impl.ts)
-  html = DOMPurify.sanitize(html, {
-    ADD_TAGS: [`mp-common-profile`],
-    ADD_ATTR: [`onerror`],
-  })
+  // Allow onerror only for our benign broken-image fallback (set by
+  // renderer-impl.ts) — LOCAL content only; for untrusted input the allowlist
+  // would let a raw `<img onerror=…>` through.
+  html = DOMPurify.sanitize(html, untrusted
+    ? {}
+    : {
+        ADD_TAGS: [`mp-common-profile`],
+        ADD_ATTR: [`onerror`],
+      })
 
-  // 还原被保护的内容
-  html = html.replace(
-    PROTECTED_SPAN_REGEX,
-    (_, i) => protectedContents[Number(i)],
-  )
+  if (!untrusted) {
+    // 还原被保护的内容
+    html = html.replace(
+      PROTECTED_SPAN_REGEX,
+      (_, i) => protectedContents[Number(i)],
+    )
+  }
 
   return html
 }
@@ -54,16 +77,17 @@ function sanitizeHtml(html: string): string {
  * 渲染 Markdown 内容
  * @param raw - 原始 markdown 字符串
  * @param renderer - 渲染器 API
+ * @param opts - [MOLIO] 传 { untrusted: true } 渲染远端不可信内容（严格净化档）
  * @returns 渲染结果，包含 HTML 和阅读时间
  */
-export function renderMarkdown(raw: string, renderer: RendererAPI) {
+export function renderMarkdown(raw: string, renderer: RendererAPI, opts?: SanitizeOptions) {
   // 解析 front-matter 和正文
   const { markdownContent, readingTime }
     = renderer.parseFrontMatterAndContent(raw)
 
   // marked -> html
   let html = renderer.renderMarkdownToHtml(markdownContent)
-  html = sanitizeHtml(html)
+  html = sanitizeHtml(html, opts)
   return { html, readingTime }
 }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -109,6 +109,9 @@ export type {
   HubCategoriesResponse,
   InstallHubSkillRequest,
   InstallHubSkillResponse,
+  HubSkillDetailQuery,
+  HubSkillDetail,
+  HubSkillDetailResponse,
 } from './skill.js';
 
 // SKILL.md generate/parse primitives (runtime values, shared daemon ↔ web).

--- a/packages/contracts/src/skill.ts
+++ b/packages/contracts/src/skill.ts
@@ -11,7 +11,9 @@
  *    Hidden from the settings UI and always effective (app-owned). Synced whole-dir
  *    to `<vault>/.claude/skills/<id>/` (plain dir name, no `molio--` prefix).
  *  - `library`: user-created/imported single-file skills. Shown + configurable.
- *    Synced to `<vault>/.claude/skills/molio--<id>/SKILL.md`.
+ *    Synced to `<vault>/.claude/skills/molio--<dirName>/SKILL.md` where dirName
+ *    is the slugified display name (readable; same-name collisions get a stable
+ *    id-derived suffix).
  *  - core (`core: true`): the writing trio — Molio's core job. NOT shown, NOT
  *    configurable, always enabled; synced like a library skill.
  *

--- a/packages/contracts/src/skill.ts
+++ b/packages/contracts/src/skill.ts
@@ -141,6 +141,12 @@ export interface HubSkillsQuery {
   pageSize?: number;
   keyword?: string;
   category?: string;
+  /**
+   * Catalog sort order. 'default' (or omitted) keeps the hub's own ranking
+   * (score desc); 'downloads' = most downloaded first; 'updated' = most
+   * recently updated first. Unknown values fall back to 'default'.
+   */
+  sort?: 'default' | 'downloads' | 'updated';
 }
 
 export interface HubSkillsListResponse {
@@ -171,4 +177,47 @@ export interface InstallHubSkillResponse {
   updated: boolean;
   /** The version actually installed (read from the downloaded package). */
   version: string;
+}
+
+export interface HubSkillDetailQuery {
+  slug: string;
+  /** Hub namespace handle — slugs are not globally unique on the hub. */
+  namespace?: string;
+}
+
+/** One hub skill's detail page data, aggregated by the daemon proxy. */
+export interface HubSkillDetail {
+  slug: string;
+  name: string;
+  /** Chinese summary when the hub has one, else the original. */
+  description: string;
+  category: string;
+  /** Upstream project page (clawhub / github / …). May be ''. */
+  sourceUrl: string;
+  iconUrl: string;
+  createdAt: number; // epoch ms
+  updatedAt: number; // epoch ms
+  verified: boolean;
+  requiresApiKey: boolean;
+  /** Author display name. */
+  ownerName: string;
+  namespace?: string;
+  latestVersion: string;
+  /** Latest version's changelog when the hub provides one. */
+  changelog?: string;
+  stats: { downloads: number; installs: number; stars: number; versions: number };
+  /**
+   * SKILL.md body with the YAML frontmatter stripped; '' when the hub has
+   * none / the fetch failed (never blocks the rest of the detail).
+   */
+  readme: string;
+  /** Hub security-scan verdicts (keen/sanbu statusText); keys omitted when absent. */
+  security?: { keen?: string; sanbu?: string };
+  /** Annotated by the daemon from hub_skill_installs (same rules as the list). */
+  installed?: boolean;
+  installedVersion?: string;
+}
+
+export interface HubSkillDetailResponse {
+  detail: HubSkillDetail;
 }


### PR DESCRIPTION
## Summary

技能管理优化的第一项：同步进 `<vault>/.claude/skills/` 的 library/core 技能目录从 `molio--<uuid>` 改为 `molio--<显示名slug>`，runtime 技能列表与目录本身都变成可读的。

- **slug 规则**（`slugifySkillName`，paths.ts）：NFKC 归一 + 保留中英文字母/数字、其余转 `-`、小写、64 码点上限；纯 emoji 名回退 `skill-<id前缀>`
- **重名确定性消歧**（`planSyncTargets`，sync.ts）：按 createdAt 排序，最早者保留纯名，后来者加 `-<id前缀>`——跨 reconcile 稳定，不用随机数（否则孤儿清理会抖动）
- **零迁移代码**：旧 `molio--<uuid>` 目录对名称化 reconcile 就是孤儿，自动收敛；技能改名同理（旧 slug 目录删、新 slug 目录建）
- `isValidSkillId` 泛化为 `isValidSkillPathSegment`：id 与目录名在同一处守卫，路径注入防线不变
- 红线不变：库存储层 `~/.molio/skills/<id>/` 仍按 id；只动 `molio--*` 目录，用户自己的技能绝不碰

## Test plan

- [x] daemon 全量测试 1132 通过（0 失败）
- [x] skills 子集 173 通过（slugify/planSyncTargets 专项 + 旧 uuid 迁移收敛 + 改名收敛）
- [x] 全仓 typecheck 绿
- [ ] CI affected E2E（skills.spec.ts）