### PR TITLE
fix(kb): 知识库公式不再显示为原始 LaTeX —— 本地加载 MathJax 渲染为 SVG

### DIFF
--- a/apps/web/e2e/markdown-render.spec.ts
+++ b/apps/web/e2e/markdown-render.spec.ts
@@ -44,6 +44,22 @@ References
 \\[2\\] AI Maker：https://example.com/2
 `;
 
+// LaTeX formulas in every supported syntax. Molio loads MathJax v3 locally
+// (see src/utils/mathjaxLoader.ts) so the doocs/md KaTeX extension typesets
+// these to real SVG; without MathJax they would render as raw LaTeX source.
+const FORMULA_TEST_MD = `# Formula Test
+
+Inline formula $E = mc^2$ here.
+
+$$
+\\int_0^1 x^2 \\, dx = \\frac{1}{3}
+$$
+
+\\[ a^2 + b^2 = c^2 \\]
+
+\\( x + y = z \\) inline latex.
+`;
+
 const RENDER_TEST_MD = `# Test Markdown Rendering
 
 ## Table
@@ -115,6 +131,7 @@ test.describe('Markdown Rendering', () => {
     testVaultPath = mkdtempSync(join(tmpdir(), 'molio-e2e-render-'));
     writeFileSync(join(testVaultPath, 'render-test.md'), RENDER_TEST_MD);
     writeFileSync(join(testVaultPath, 'citation-test.md'), CITATION_TEST_MD);
+    writeFileSync(join(testVaultPath, 'formula-test.md'), FORMULA_TEST_MD);
 
     // Register the vault via the daemon API
     const res = await fetch(`${DAEMON_API}/knowledge/vaults`, {
@@ -217,11 +234,12 @@ test.describe('Markdown Rendering', () => {
   });
 
   test('escaped-bracket citation markers do not crash MathJax renderer', async ({ page }) => {
-    // Reproduces the WeChat-clipping crash: `\\[1\\]` citation markers must
-    // NOT be treated as LaTeX block math. MathJax is not loaded in Molio, so
-    // any `\\[ ... \\]` / `$ ... $` token reaching the KaTeX renderer crashes
-    // ("Cannot read properties of undefined (reading 'texReset')"). The guard
-    // must fall back to raw text instead.
+    // WeChat clippings use `\\[1\\]` as escaped-bracket citation markers. They
+    // collide with the LaTeX block rule and (before the #113 guard) crashed the
+    // renderer with "Cannot read properties of undefined (reading 'texReset')"
+    // when MathJax was missing. Now MathJax is loaded locally, but the citation
+    // guard (isCitationLike in katex.ts) must still keep them as literal `[N]`
+    // text — NOT typeset as display math.
     await openRenderTestFile(page, 'citation-test.md');
 
     // Must NOT render the MdRenderer error fallback
@@ -232,5 +250,27 @@ test.describe('Markdown Rendering', () => {
     const output = page.locator('#output');
     await expect(output).toContainText('[1]');
     await expect(output).toContainText('[2]');
+
+    // Regression: even with MathJax loaded, citation markers must NOT be turned
+    // into math — no SVG anywhere in this (formula-free) document.
+    await expect(page.locator('#output svg')).toHaveCount(0, { timeout: 5_000 });
+  });
+
+  test('renders LaTeX formulas as MathJax SVG', async ({ page }) => {
+    // Formulas must render as real math (SVG), not raw LaTeX source. Covers all
+    // four doocs/md syntaxes: `$...$`, `$$...$$`, `\\[ ... \\]`, `\\( ... \\)`.
+    await openRenderTestFile(page, 'formula-test.md');
+
+    // Inline formulas render inside span.katex-inline, block inside section.katex-block
+    const inlineSvg = page.locator('#output .katex-inline svg');
+    const blockSvg = page.locator('#output .katex-block svg');
+    await expect(inlineSvg).toHaveCount(2, { timeout: 10_000 });
+    await expect(blockSvg).toHaveCount(2, { timeout: 10_000 });
+
+    // The raw LaTeX source must NOT leak as visible text (only inside
+    // data-math-raw attributes).
+    const outputText = await page.locator('#output').innerText();
+    expect(outputText).not.toContain('$E = mc^2$');
+    expect(outputText).not.toContain('\\frac');
   });
 });

--- a/apps/web/e2e/markdown-render.spec.ts
+++ b/apps/web/e2e/markdown-render.spec.ts
@@ -272,5 +272,13 @@ test.describe('Markdown Rendering', () => {
     const outputText = await page.locator('#output').innerText();
     expect(outputText).not.toContain('$E = mc^2$');
     expect(outputText).not.toContain('\\frac');
+
+    // Regression: MathJax SVG must contain `<use>` glyph references. Without
+    // them (DOMPurify strips `<use>` by default — see sanitizeHtml ADD_TAGS
+    // `use` in vendor/doocs-md/src/utils/markdownHelpers.ts) the formula
+    // renders as a blank box even though the `<svg>` element exists.
+    await expect(page.locator('#output .katex-inline svg use').first()).toBeVisible({ timeout: 10_000 });
+    expect(await page.locator('#output .katex-inline svg use').count()).toBeGreaterThan(0);
+    expect(await page.locator('#output .katex-block svg use').count()).toBeGreaterThan(0);
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "highlight.js": "^11.11.1",
     "isomorphic-dompurify": "^3.15.0",
     "marked": "^18.0.4",
+    "mathjax": "3.2.2",
     "pdfjs-dist": "6.2.108",
     "qrcode": "^1.5.4",
     "react": "^19.0.0",

--- a/apps/web/src/components/kb/MdRenderer.tsx
+++ b/apps/web/src/components/kb/MdRenderer.tsx
@@ -15,6 +15,7 @@ import { useEffect, useRef, useMemo, useState, memo } from 'react';
 import { initRenderer } from '@molio/doocs-md/src/renderer/renderer-impl';
 import { renderMarkdown, postProcessHtml } from '@molio/doocs-md/src/utils/markdownHelpers';
 import { applyTheme } from '@molio/doocs-md/src/theme/themeApplicator';
+import { mathJaxReady, ensureMathJax } from '../../utils/mathjaxLoader';
 import type { IOpts } from '@molio/doocs-md/shared/types/common';
 import type { ThemeConfig } from './MdStylePanel';
 
@@ -99,25 +100,47 @@ export const MdRenderer = memo(function MdRenderer({
     finalOptions.themeMode,
   ]);
 
-  // Render markdown content
+  // Render markdown content. Formulas are typeset by the doocs/md KaTeX
+  // extension through the global window.MathJax, which Molio loads lazily as a
+  // local asset. If MathJax isn't ready yet, render immediately with the
+  // extension's raw-LaTeX fallback (so content never waits), then re-render
+  // once MathJax is ready so formulas upgrade to real SVG. If the asset fails
+  // to load, the fallback render stays — no crash, no blank page.
   useEffect(() => {
     if (!content) {
       setRenderedHtml('');
       return;
     }
 
-    try {
-      const { html, readingTime } = renderMarkdown(
-        content,
-        renderer,
-        untrusted ? { untrusted: true } : undefined,
-      );
-      const finalHtml = postProcessHtml(html, readingTime, renderer);
-      setRenderedHtml(finalHtml);
-    } catch (error) {
-      console.error('Markdown rendering error:', error);
-      setRenderedHtml(`<p>Error rendering content: ${String(error)}</p>`);
+    let cancelled = false;
+
+    const doRender = () => {
+      try {
+        const { html, readingTime } = renderMarkdown(
+          content,
+          renderer,
+          untrusted ? { untrusted: true } : undefined,
+        );
+        const finalHtml = postProcessHtml(html, readingTime, renderer);
+        if (!cancelled) setRenderedHtml(finalHtml);
+      } catch (error) {
+        console.error('Markdown rendering error:', error);
+        if (!cancelled) setRenderedHtml(`<p>Error rendering content: ${String(error)}</p>`);
+      }
+    };
+
+    doRender();
+    if (!mathJaxReady()) {
+      ensureMathJax()
+        .then(doRender)
+        .catch((err) => {
+          console.error('MathJax unavailable; formulas render as raw LaTeX:', err);
+        });
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [content, renderer, untrusted]);
 
   // Apply theme CSS when themeConfig changes.

--- a/apps/web/src/utils/mathjaxLoader.ts
+++ b/apps/web/src/utils/mathjaxLoader.ts
@@ -1,0 +1,82 @@
+/**
+ * Lazy MathJax v3 loader for the doocs/md KaTeX extension.
+ *
+ * The vendored doocs/md `katex.ts` extension renders formulas via the global
+ * `window.MathJax` object (`tex2svg` / `texReset`). Molio never loaded MathJax,
+ * so every `$...$` / `$$...$$` / `\(...\)` / `\[...\]` formula fell through to
+ * a raw-LaTeX fallback and displayed as source text.
+ *
+ * Here we load the self-contained `tex-svg-full.js` combined component as a
+ * local Vite asset — no CDN, so it works offline and behind restrictive
+ * networks (see memory: network-env-github-access). MdRenderer gates rendering
+ * on `mathJaxReady()` and re-renders once `ensureMathJax()` resolves, so
+ * formulas upgrade from raw text to real SVG without a crash.
+ *
+ * Loaded at most once; concurrent callers share a single promise.
+ */
+
+import texSvgFullUrl from 'mathjax/es5/tex-svg-full.js?url';
+
+let readyPromise: Promise<void> | null = null;
+
+/** True once `window.MathJax.tex2svg` / `texReset` are available. */
+export function mathJaxReady(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof (window as unknown as { MathJax?: { tex2svg?: unknown; texReset?: unknown } }).MathJax?.tex2svg ===
+      'function' &&
+    typeof (window as unknown as { MathJax?: { texReset?: unknown } }).MathJax?.texReset === 'function'
+  );
+}
+
+/**
+ * Ensure MathJax is loaded and ready. Resolves once `tex2svg` / `texReset` are
+ * callable; rejects only if the local asset fails to load. On failure the
+ * cached promise is cleared so a later render retries.
+ */
+export function ensureMathJax(): Promise<void> {
+  if (mathJaxReady()) return Promise.resolve();
+  if (!readyPromise) {
+    readyPromise = injectMathJax().catch((err: unknown) => {
+      readyPromise = null; // allow a later retry
+      throw err;
+    });
+  }
+  return readyPromise;
+}
+
+function injectMathJax(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Configure BEFORE the component script runs (MathJax v3 merges this into
+    // its startup). Safety measures:
+    //  - `startup.typeset: false` — never auto-scan the app DOM for math, so
+    //    unrelated content (e.g. chat messages containing `\(...\)` text) is
+    //    not silently typeset. We only ever call `tex2svg` explicitly.
+    //  - `enableMenu` / `enableAssistiveMml` off — avoid the lazy jsdelivr
+    //    loads (speech-rule-engine, mathmaps) that those features trigger;
+    //    core SVG typesetting is fully self-contained.
+    (window as unknown as { MathJax: object }).MathJax = {
+      startup: { typeset: false },
+      options: { enableMenu: false, enableAssistiveMml: false },
+    };
+
+    const script = document.createElement('script');
+    script.src = texSvgFullUrl;
+    script.async = true;
+    script.onload = () => {
+      // `tex2svg` / `texReset` are wired at the end of the bundle, but wait for
+      // the startup promise to settle before declaring readiness.
+      Promise.resolve((window as unknown as { MathJax?: { startup?: { promise?: Promise<unknown> } } }).MathJax?.startup?.promise)
+        .then(() => {
+          if (!mathJaxReady()) {
+            reject(new Error('MathJax loaded but tex2svg/texReset unavailable'));
+            return;
+          }
+          resolve();
+        })
+        .catch((err: unknown) => reject(err instanceof Error ? err : new Error(String(err))));
+    };
+    script.onerror = () => reject(new Error('Failed to load local MathJax asset'));
+    document.head.appendChild(script);
+  });
+}

--- a/apps/web/vendor/doocs-md/src/extensions/katex.ts
+++ b/apps/web/vendor/doocs-md/src/extensions/katex.ts
@@ -14,53 +14,78 @@ const blockRule = /^\s{0,3}(\${1,2})[ \t]*\n([\s\S]+?)\n\s{0,3}\1[ \t]*(?:\n|$)/
 const inlineLatexRule = /^\\\(([^\\]*(?:\\.[^\\]*)*?)\\\)/
 const blockLatexRule = /^\\\[([^\\]*(?:\\.[^\\]*)*?)\\\]/
 
+/**
+ * [MOLIO] Raw-text fallback used when MathJax is unavailable or a typeset
+ * throws. Renders as standard markdown would: strip the backslash before
+ * brackets / parens so `\[1\]` → `[1]` and `\(x\)` → `(x)` (these are escaped
+ * brackets in CommonMark, which is how WeChat clippings use them as citation
+ * markers). `$...$` / `$$...$$` are kept literal.
+ */
+function fallbackHtml(token: any, display: boolean): string {
+  const raw = escapeHtml((token.raw ?? token.text).replace(/\\([()\[\]])/g, `$1`))
+  return display
+    ? `<section class="katex-block" data-math-display="true" data-math-raw="${raw}">${raw}</section>`
+    : `<span class="katex-inline" data-math-display="false" data-math-raw="${raw}">${raw}</span>`
+}
+
+/**
+ * [MOLIO] WeChat clippings use `\[N\]` / `\[12-15\]` as citation markers
+ * (escaped brackets in CommonMark), which collide with the LaTeX block/inline
+ * rules. Only treat `\[ ... \]` / `\( ... \)` as math when the content is not a
+ * bare citation — i.e. contains something beyond digits, commas, spaces and
+ * dashes. This keeps citation markers rendering as literal `[1]` even once
+ * MathJax is loaded (see katex.ts guard history / #113).
+ */
+function isCitationLike(text: string): boolean {
+  return /^[\d,\s–-]*$/.test(text)
+}
+
 function createRenderer(defaultDisplay: boolean, withStyle: boolean = true) {
   return (token: any) => {
     const display = token.displayMode ?? defaultDisplay
 
     // [MOLIO] Guard: MathJax is loaded lazily and may be absent (not yet
-    // loaded, offline, CDN failure, SSR/test env). Without this guard any
+    // loaded, offline, asset failure, SSR/test env). Without this guard any
     // `\[ ... \]` / `$ ... $` token reaching the renderer crashes with
-    // "Cannot read properties of undefined (reading 'texReset')". WeChat
-    // clippings use `\[1\]` citation markers which collide with the LaTeX
-    // block rule, so this path is hit by ordinary articles, not just math.
-    // Fall back to raw text so the document still renders.
+    // "Cannot read properties of undefined (reading 'texReset')". Fall back to
+    // raw text so the document still renders.
     // @ts-expect-error MathJax is a global variable
     const mathjax = window.MathJax
     if (!mathjax?.texReset || !mathjax?.tex2svg) {
-      // Render as standard markdown would: strip the backslash before brackets
-      // / parens so `\[1\]` → `[1]` and `\(x\)` → `(x)` (these are escaped
-      // brackets in CommonMark, which is how WeChat clippings use them as
-      // citation markers). `$...$` / `$$...$$` are kept literal.
-      const raw = escapeHtml((token.raw ?? token.text).replace(/\\([()\[\]])/g, `$1`))
-      return display
-        ? `<section class="katex-block" data-math-display="true" data-math-raw="${raw}">${raw}</section>`
-        : `<span class="katex-inline" data-math-display="false" data-math-raw="${raw}">${raw}</span>`
+      return fallbackHtml(token, display)
     }
 
-    mathjax.texReset()
-    const mjxContainer = mathjax.tex2svg(token.text, { display })
-    const svg = mjxContainer.firstChild
-    const width = svg.style[`min-width`] || svg.getAttribute(`width`)
-    svg.removeAttribute(`width`)
+    try {
+      mathjax.texReset()
+      const mjxContainer = mathjax.tex2svg(token.text, { display })
+      const svg = mjxContainer.firstChild
+      const width = svg.style[`min-width`] || svg.getAttribute(`width`)
+      svg.removeAttribute(`width`)
 
-    // 行内公式对齐 https://groups.google.com/g/mathjax-users/c/zThKffrrCvE?pli=1
-    // 直接覆盖 style 会覆盖 MathJax 的样式，需要手动设置
-    // svg.style = `max-width: 300vw !important; display: initial; flex-shrink: 0;`
+      // 行内公式对齐 https://groups.google.com/g/mathjax-users/c/zThKffrrCvE?pli=1
+      // 直接覆盖 style 会覆盖 MathJax 的样式，需要手动设置
+      // svg.style = `max-width: 300vw !important; display: initial; flex-shrink: 0;`
 
-    if (withStyle) {
-      svg.style.display = `initial`
-      svg.style.setProperty(`max-width`, `300vw`, `important`)
-      svg.style.flexShrink = `0`
-      svg.style.width = width
+      if (withStyle) {
+        svg.style.display = `initial`
+        svg.style.setProperty(`max-width`, `300vw`, `important`)
+        svg.style.flexShrink = `0`
+        svg.style.width = width
+      }
+
+      if (!display) {
+        // 新主题系统：使用 class 而非内联样式
+        return `<span class="katex-inline" data-math-display="false" data-math-raw="${escapeHtml(token.raw ?? token.text)}">${svg.outerHTML}</span>`
+      }
+
+      return `<section class="katex-block" data-math-display="true" data-math-raw="${escapeHtml(token.raw ?? token.text)}">${svg.outerHTML}</section>`
     }
-
-    if (!display) {
-      // 新主题系统：使用 class 而非内联样式
-      return `<span class="katex-inline" data-math-display="false" data-math-raw="${escapeHtml(token.raw ?? token.text)}">${svg.outerHTML}</span>`
+    catch (error) {
+      // [MOLIO] Invalid / unsupported TeX (or a MathJax hiccup) must not take
+      // down the whole document — fall back to raw text for this one token.
+      console.error(`[MOLIO] MathJax typeset failed, falling back to raw text:`, error)
+      return fallbackHtml(token, display)
     }
-
-    return `<section class="katex-block" data-math-display="true" data-math-raw="${escapeHtml(token.raw ?? token.text)}">${svg.outerHTML}</section>`
   }
 }
 
@@ -136,6 +161,8 @@ function inlineLatexKatex(_options: MarkedKatexOptions | undefined, renderer: an
     tokenizer(src: string) {
       const match = src.match(inlineLatexRule)
       if (match) {
+        // [MOLIO] Skip citation-like content so it renders as literal text
+        if (isCitationLike(match[1])) return undefined
         return {
           type: `inlineLatexKatex`,
           raw: match[0],
@@ -159,6 +186,9 @@ function blockLatexKatex(_options: MarkedKatexOptions | undefined, renderer: any
     tokenizer(src: string) {
       const match = src.match(blockLatexRule)
       if (match) {
+        // [MOLIO] Skip citation-like content (e.g. `\[1\]`, `\[12-15\]`) so it
+        // renders as literal `[1]` instead of being typeset as display math.
+        if (isCitationLike(match[1])) return undefined
         return {
           type: `blockLatexKatex`,
           raw: match[0],

--- a/apps/web/vendor/doocs-md/src/utils/markdownHelpers.ts
+++ b/apps/web/vendor/doocs-md/src/utils/markdownHelpers.ts
@@ -55,10 +55,14 @@ function sanitizeHtml(html: string, opts?: SanitizeOptions): string {
   // Allow onerror only for our benign broken-image fallback (set by
   // renderer-impl.ts) — LOCAL content only; for untrusted input the allowlist
   // would let a raw `<img onerror=…>` through.
+  // [MOLIO] ADD_TAGS `use`: MathJax 公式的 SVG 用 `<use xlink:href="#MJX-…">` 引用
+  // `<defs>` 里的字形路径，而 DOMPurify 默认会把 `<use>` 整个剥掉，导致所有公式
+  // 渲染成空白（只有 defs 路径、没有 use 引用）。加回 `use` 即可恢复（xlink:href
+  // 指向文档内片段，DOMPurify 仍会校验其值）。
   html = DOMPurify.sanitize(html, untrusted
     ? {}
     : {
-        ADD_TAGS: [`mp-common-profile`],
+        ADD_TAGS: [`mp-common-profile`, `use`],
         ADD_ATTR: [`onerror`],
       })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,13 +147,16 @@ importers:
         version: 0.26.0(graphology-types@0.24.8)
       highlight.js:
         specifier: ^11.11.1
-        version: 11.11.1
+        version: 11.11.2
       isomorphic-dompurify:
         specifier: ^3.15.0
         version: 3.15.0
       marked:
         specifier: ^18.0.4
         version: 18.0.4
+      mathjax:
+        specifier: 3.2.2
+        version: 3.2.2
       pdfjs-dist:
         specifier: 6.2.108
         version: 6.2.108
@@ -2092,8 +2095,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  highlight.js@11.11.1:
-    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+  highlight.js@11.11.2:
+    resolution: {integrity: sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==}
     engines: {node: '>=12.0.0'}
 
   hono@4.12.23:
@@ -2420,6 +2423,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mathjax@3.2.2:
+    resolution: {integrity: sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -5507,7 +5513,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  highlight.js@11.11.1: {}
+  highlight.js@11.11.2: {}
 
   hono@4.12.23: {}
 
@@ -5824,6 +5830,8 @@ snapshots:
     optional: true
 
   math-intrinsics@1.1.0: {}
+
+  mathjax@3.2.2: {}
 
   mdn-data@2.27.1: {}
 


### PR DESCRIPTION
## 问题

知识库页面打开含公式的 `.md` 文件时，`$E=mc^2$` / `$$...$$` / `\[...\]` / `\(...\)` 都以原始 LaTeX 源码显示，未渲染成数学图形。

**根因**：doocs/md 的 `katex.ts` 扩展名带 katex，但实际依赖全局 `window.MathJax`（`tex2svg`/`texReset`）。Molio 从未加载 MathJax，所有公式都命中 #113 加的降级分支，以 LaTeX 源码输出。`katex.ts:29` 的守卫注释与 E2E 里都写明"MathJax is not loaded in Molio"。

## 修复方案（本地、无 CDN，离线/内网可用）

1. **`apps/web/src/utils/mathjaxLoader.ts`（新增）**：懒加载 `mathjax/es5/tex-svg-full.js` 作为本地 Vite 资产（`?url`），`startup.typeset: false` 防止 MathJax 自动扫描整页 DOM，关闭 menu/a11y 避免 jsdelivr 懒加载；共享就绪 promise，失败自动清缓存重试。
2. **`MdRenderer.tsx`**：就绪门控——先立即渲染（内容不等待），MathJax 就绪后自动重渲染升级为 SVG；渲染包 try/catch，加载失败不崩、不空白。
3. **`katex.ts`**：
   - `isCitationLike` 守卫：微信剪藏 `\[N\]` / `\[12-15\]` 引用角标保持字面 `[1]`，**保住 #113 的行为**（MathJax 加载后不被误当公式居中排版）
   - `tex2svg` 包 try/catch：单个非法 TeX 只回落到该 token 的 raw 文本，不拖垮整篇文档
4. **`package.json`**：钉 `mathjax@3.2.2`（`^3` 会被 pnpm `blockExoticSubdeps` 拦截——3.0.0 声明了 git 依赖 `mathjax-full: git://...`）

## 测试

错误驱动测试（CLAUDE.md 规则）：
- `markdown-render.spec.ts` 新增 **"renders LaTeX formulas as MathJax SVG"**：断言 4 种公式语法渲染出 SVG、raw 源码不泄漏为可见文本
- 强化 **引用角标回归**：含角标文档断言 `#output svg` 数量为 0

本地验证全绿：
- markdown-render 8/8 ✓
- publish-flow 2/2 ✓
- KB 回归批次（knowledge / kb-status-bar / kb-outline / kb-doc-context-menu / bootstrap）19/19 ✓
- web typecheck ✓、生产构建 ✓（mathjax 资产正确 emit）

## 影响面与权衡

- MathJax 懒加载约 2.3MB，仅首次打开含公式文档时加载
- 复制/发布含公式文档：HTML 槽位公式以 SVG 粘贴（改进方向），Markdown 槽位公式被 turndown 丢弃（后续可优化还原）
- 聊天路径的 `markdown.ts` 不受影响（不经过 doocs/md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)