### PR TITLE
fix(daemon): SSE 实时流双次投递同帧 — 修复对话回复重复

### DIFF
--- a/apps/daemon/src/sse.ts
+++ b/apps/daemon/src/sse.ts
@@ -123,9 +123,21 @@ export function createSSEStream(
         // Leave the whole gap to pull(), which replays it in order from the
         // run buffer once the consumer drains.
         if (lastId > lastDeliveredId + 1) return;
+        // Advance lastDeliveredId BEFORE enqueueing. controller.enqueue() is
+        // re-entrant: when the consumer has a pending read() (a live renderer
+        // almost always does), Node fulfills that read from the chunk, sees
+        // desiredSize > 0, and SYNCHRONOUSLY calls pull() — while this callback
+        // is still mid-flight. Advancing first makes that re-entrant pull() see
+        // lastDeliveredId === getLastEventId() and skip, instead of replaying
+        // the very event we're delivering and sending the same frame twice (the
+        // v0.3.42 "duplicated assistant reply" bug). If enqueue throws, the
+        // stream is dead; the event is still in run.events and a reconnect
+        // (client ?after=<its last RECEIVED seq>) replays it — the daemon's
+        // lastDeliveredId on a dead stream never feeds a reconnect, so the
+        // advance cannot cause data loss here.
+        lastDeliveredId = lastId;
         try {
           safeEnqueue(controller, frameFor(lastId, event));
-          lastDeliveredId = lastId;
         } catch {
           // Diagnostic: emitEvent fan-out reached this listener but enqueue failed —
           // the stream is dead. This is the smoking gun for assumption 2.

--- a/apps/daemon/test/routes/sse-double-delivery.test.ts
+++ b/apps/daemon/test/routes/sse-double-delivery.test.ts
@@ -1,0 +1,124 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AgentEvent } from '@molio/contracts';
+import type { RunManager } from '../../src/core/RunManager.js';
+import type { BufferedEvent } from '../../src/types.js';
+
+/**
+ * Regression test: the live SSE stream could deliver the SAME event frame
+ * TWICE to a single consumer during a burst.
+ *
+ * Root cause: controller.enqueue() is re-entrant in Node's ReadableStream.
+ * When the consumer has a pending read() (a live renderer almost always
+ * does), enqueue() fulfills that read from the chunk, sees desiredSize > 0,
+ * and SYNCHRONOUSLY invokes pull(). At that instant the live callback has NOT
+ * yet run `lastDeliveredId = lastId` (it runs AFTER safeEnqueue), so pull()
+ * observes a stale lastDeliveredId, decides the event currently being
+ * delivered was "missed", and replays it from the run buffer — the same
+ * frame delivered twice. The frontend appends text_delta content per frame
+ * with no seq-dedup (useChatCore.updateWithEvent), so a burst whose
+ * text_delta got doubled rendered the assistant reply duplicated (the
+ * "hello" → duplicated greeting report on v0.3.42).
+ *
+ * Introduced by PR #192 (commit 5c5ae37, SSE backpressure). The suite's
+ * existing stall test only asserted the SECOND stream's content after a
+ * reconnect — it never counted how many times the FIRST stream delivered
+ * each frame, so this slipped through.
+ *
+ * Reproduced 5/5 with this pattern: an active (always-reading) consumer +
+ * events emitted ~1ms apart. Env hooks (ping/stall) are NOT set here on
+ * purpose — an active consumer never stalls, and shorter pings would only
+ * add noise frames.
+ */
+const { createSSEStream } = await import('../../src/sse.js');
+
+class MockRunManager {
+  private bufferedEvents: Map<string, BufferedEvent[]> = new Map();
+  private eventListeners: Map<string, Set<(ev: AgentEvent) => void>> = new Map();
+  private lastEventIds: Map<string, number> = new Map();
+
+  /** Emit a live event AND buffer it (mirrors RunManager.emitEvent) so a
+   * reconnecting client can replay it. */
+  emitLiveEvent(runId: string, event: AgentEvent): void {
+    const id = (this.lastEventIds.get(runId) ?? 0) + 1;
+    this.lastEventIds.set(runId, id);
+    const list = this.bufferedEvents.get(runId) ?? [];
+    list.push({ id, event: String(event.type), data: event, timestamp: Date.now() });
+    this.bufferedEvents.set(runId, list);
+    const listeners = this.eventListeners.get(runId);
+    if (listeners) for (const l of listeners) l(event);
+  }
+
+  listenerCount(runId: string): number {
+    return this.eventListeners.get(runId)?.size ?? 0;
+  }
+
+  getBufferedEvents(runId: string, afterId: number = 0): BufferedEvent[] | null {
+    const events = this.bufferedEvents.get(runId);
+    if (!events) return null;
+    return events.filter((e) => e.id > afterId);
+  }
+
+  isTerminal(runId: string): boolean {
+    return false;
+  }
+
+  onEvent(runId: string, callback: (event: AgentEvent) => void): (() => void) | null {
+    if (!this.eventListeners.has(runId)) this.eventListeners.set(runId, new Set());
+    this.eventListeners.get(runId)!.add(callback);
+    return () => { this.eventListeners.get(runId)?.delete(callback); };
+  }
+
+  getLastEventId(runId: string): number {
+    return this.lastEventIds.get(runId) ?? 0;
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('SSE live stream (burst, active consumer)', () => {
+  it('should deliver each event exactly once — no double-delivery on burst', async () => {
+    const mock = new MockRunManager();
+    const runId = 'burst-1';
+    const { stream, cleanup } = createSSEStream(mock as unknown as RunManager, runId, 0);
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+
+    // Active consumer: always has a pending read(), like a live renderer.
+    const frames: string[] = [];
+    const consumer = (async () => {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        frames.push(decoder.decode(value));
+      }
+    })();
+
+    // Burst of events ~1ms apart — the hello reply on v0.3.42 arrived this
+    // way (7 events in ~3.5s, closely spaced).
+    const deltas = ['A', 'B', 'C', 'D', 'E'];
+    for (const d of deltas) {
+      mock.emitLiveEvent(runId, { type: 'text_delta', delta: d });
+      await sleep(1);
+    }
+
+    // Let any pending pull/replay settle, then stop the stream cleanly.
+    await sleep(50);
+    cleanup();
+    try { await reader.cancel(); } catch { /* already cancelled */ }
+    await consumer;
+
+    // Extract event-frame seqs (ping frames carry no `id:` line).
+    const seqs = frames
+      .map((f) => f.match(/^id: (\d+)/)?.[1])
+      .filter((s): s is string => s !== undefined)
+      .map(Number);
+
+    // 5 events → exactly 5 frames, seqs 1..5 each exactly once.
+    assert.deepEqual(
+      seqs.slice().sort((a, b) => a - b),
+      [1, 2, 3, 4, 5],
+      `expected each event frame exactly once, got seqs=${JSON.stringify(seqs)}`,
+    );
+  });
+});


### PR DESCRIPTION
## 背景

v0.3.42 上发一条 "hello"，回复整体重复一遍（"……你想做什么？你好！👋……你想做什么？"）。排查确认：**不是模型重复生成、不是数据库、不是前端渲染**，而是 daemon 的 SSE 实时流把**同一个事件帧推了两次**。

## 根因

`controller.enqueue()` 在 Node 的 ReadableStream 里是**可重入的**：当消费者挂着一个 `read()`（实时消费者几乎总是如此）时，enqueue 会先满足该 read，发现 `desiredSize > 0`，然后**同步调用 `pull()`**。

旧代码（`apps/daemon/src/sse.ts` live 回调）在 `safeEnqueue` **之后**才推进 `lastDeliveredId`：

```ts
safeEnqueue(controller, frameFor(lastId, event)); // ① 此处重入 pull()
lastDeliveredId = lastId;                          // ② 之后才推进
```

事件突发时，① 中同步插入的 `pull()` 读到**旧** `lastDeliveredId`（还差一个），判定当前事件"漏发"，从 run 缓冲区补发了一遍；回到 ①，enqueue 本身又推了一次 → 同一帧两次投递。埋点抓到的现场：

```
[TRACE live] lastId=2 lastDeliveredId=1 ready=true       ← live 回调进入，尺子还是 1
[TRACE pull] REPLAY lastDeliveredId=1 getLastEventId=2    ← enqueue 里重入的 pull()，判定漏发
[TRACE pull] ENQUEUE seq=2                                 ← 补发一次
[TRACE live] ENQUEUE seq=2                                 ← live 回调自己又推一次
```

前端 `updateWithEvent` 对 `text_delta` 直接 `content + delta`（无 seq 去重），收到两帧就 append 两次 → 回复文本重复。`status`/`activity`/`thinking_delta` 同样被翻倍，但幂等或不可见。

## 修复

把 `lastDeliveredId = lastId` 从 `safeEnqueue` **之后**挪到**之前**。重入的 `pull()` 读到 `lastDeliveredId === getLastEventId()`，命中"无漏发"守卫直接跳过，不会再补发刚发出的同一事件。

四个边界场景语义均不变：

| 场景 | 说明 |
|---|---|
| 消费者停滞（被节流） | `consumerReady` 检查在最前，停滞时走不到赋值，补发逻辑保留 |
| 有真实缺口 | 缺口守卫 `lastId > lastDeliveredId + 1` 在赋值**之前**判断，用旧值，语义不变 |
| enqueue 抛异常（流死） | 重连补发用客户端 `?after=<已收到seq>`，daemon 死流上的 `lastDeliveredId` 不参与重连，不丢数据 |
| 重连 Phase 1 回放 | 在 `start()` 内执行，`kStarted=false`，enqueue 不触发 pull，无重入风险 |

## 测试

新增 `apps/daemon/test/routes/sse-double-delivery.test.ts`：突发事件 + 即时消费者，断言每个 seq 恰好投递一次。

- bug 代码上：`seqs=[1,2,2,3,3,4,4,5,5]`（红灯，复现）
- 修复后：`seqs=[1,2,3,4,5]`（绿灯）
- 现有 SSE 测试（stall/resume/watchdog/sse）全过
- daemon routes 全套 162 个测试全过
- daemon 全量 1121 个测试：1115 过，仅 1 个失败为**历史遗留**的 esm-compat（`skill-installer.ts` 的 `__dirname`，干净 main 上同样失败，与本改动无关）
- daemon typecheck 零错误

## 引入版本

commit `5c5ae37`（PR #192，SSE 背压防内存泄漏），v0.3.40 / v0.3.41 / v0.3.42 均受影响。这是间歇性竞态（enqueue 撞上挂起 read 才触发），非必然失败，故 v0.3.40/41 期间未被发现；hello 短回复尾部紧簇 + 单块 text_delta 恰好踩中，整段问候翻倍才被看见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)