### PR TITLE
fix(web): 预处理跳过 YAML frontmatter，修复 ARMS YAMLException 噪音

### DIFF
--- a/apps/web/e2e/markdown-render.spec.ts
+++ b/apps/web/e2e/markdown-render.spec.ts
@@ -44,6 +44,29 @@ References
 \\[2\\] AI Maker：https://example.com/2
 `;
 
+// Reproduces the ARMS-reported YAMLException: wiki skills mandate QUOTED
+// wikilink lists in frontmatter (`related: - "[[页面]]"`). The renderer
+// preprocessing used to rewrite [[…]] into `<a class="kb-wiki-link" href="…">`
+// INSIDE the frontmatter block, corrupting the YAML ("bad indentation of a
+// sequence entry" from js-yaml) — doocs/md's front-matter parse then failed
+// and the whole frontmatter block leaked into the rendered body. The fix
+// (preprocessKbMarkdown) keeps the frontmatter block verbatim.
+const FRONTMATTER_WIKILINK_MD = `---
+title: 李白
+type: entity
+tags:
+  - 诗人
+related:
+  - "[[杜甫]]"
+sources:
+  - "[[旧唐书]]"
+---
+
+# 李白
+
+唐代诗人，与 [[杜甫]] 并称"李杜"。
+`;
+
 const RENDER_TEST_MD = `# Test Markdown Rendering
 
 ## Table
@@ -115,6 +138,9 @@ test.describe('Markdown Rendering', () => {
     testVaultPath = mkdtempSync(join(tmpdir(), 'molio-e2e-render-'));
     writeFileSync(join(testVaultPath, 'render-test.md'), RENDER_TEST_MD);
     writeFileSync(join(testVaultPath, 'citation-test.md'), CITATION_TEST_MD);
+    writeFileSync(join(testVaultPath, 'frontmatter-wikilink.md'), FRONTMATTER_WIKILINK_MD);
+    // Link target for the body wikilink in frontmatter-wikilink.md
+    writeFileSync(join(testVaultPath, '杜甫.md'), '# 杜甫\n\n唐代诗人。\n');
 
     // Register the vault via the daemon API
     const res = await fetch(`${DAEMON_API}/knowledge/vaults`, {
@@ -214,6 +240,41 @@ test.describe('Markdown Rendering', () => {
     // Verify even rows have a background color from doocs/md theme
     const evenRow = page.locator('#output .md-table tbody tr:nth-child(even)').first();
     await expect(evenRow).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('quoted wikilinks inside frontmatter do not corrupt YAML or leak into body', async ({ page }) => {
+    // ARMS regression: preprocessing once rewrote [[…]] inside the frontmatter
+    // block into raw HTML anchors, breaking js-yaml ("bad indentation of a
+    // sequence entry") and dumping the whole frontmatter into the document.
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await openRenderTestFile(page, 'frontmatter-wikilink.md');
+
+    const output = page.locator('#output');
+
+    // Body wikilinks are still transformed into navigable anchors — and there
+    // is EXACTLY one: without the fix the leaked frontmatter renders a second
+    // anchor (from `related: - "[[杜甫]]"`), so count > 1 means regression.
+    await expect(
+      output.locator('a.kb-wiki-link[data-file-path="杜甫"]'),
+    ).toHaveCount(1, { timeout: 5_000 });
+
+    // The frontmatter block must NOT leak into the rendered body
+    await expect(output).not.toContainText('related:');
+    await expect(output).not.toContainText('sources:');
+    await expect(output).not.toContainText('type: entity');
+
+    // Frontmatter parsed successfully → property card shows the metadata
+    const fmCard = page.locator('[data-testid="kb-fm-expanded"]');
+    await expect(fmCard).toBeVisible({ timeout: 5_000 });
+    await expect(fmCard).toContainText('李白');
+
+    // No front-matter parse errors were logged (the ARMS-reported symptom)
+    const fmErrors = consoleErrors.filter((t) => /front-matter|YAMLException/i.test(t));
+    expect(fmErrors).toEqual([]);
   });
 
   test('escaped-bracket citation markers do not crash MathJax renderer', async ({ page }) => {

--- a/apps/web/src/components/kb/KbMainContent.tsx
+++ b/apps/web/src/components/kb/KbMainContent.tsx
@@ -19,7 +19,7 @@ import { ViewerErrorBoundary } from './ViewerErrorBoundary';
 import type { KbCodeMirrorViewerHandle } from './KbCodeMirrorViewer';
 import { KbFrontmatterCard } from './KbFrontmatterCard';
 import { formatFileSize } from '../../utils/format';
-import { preprocessWikiLinks, preprocessWikiEmbeds, proxyExternalImages, stripTrackingPixels } from '../../hooks/useKnowledge';
+import { preprocessKbMarkdown } from '../../hooks/useKnowledge';
 import { api } from '../../api/client';
 import { useI18n } from '../../i18n';
 import TurndownService from 'turndown';
@@ -201,7 +201,7 @@ export function KbMainContent({
   // runs for the small-.md doocs path — never for the CM source view.
   const renderedContent = useMemo(
     () => isSmallMd
-      ? preprocessWikiLinks(proxyExternalImages(preprocessWikiEmbeds(stripTrackingPixels(editedContent ?? fileContent?.content ?? ''), vaultId ?? '')), vaultId ?? '')
+      ? preprocessKbMarkdown(editedContent ?? fileContent?.content ?? '', vaultId ?? undefined)
       : '',
     [editedContent, fileContent?.content, vaultId, isSmallMd],
   );

--- a/apps/web/src/components/kb/MdTypesetEditor.tsx
+++ b/apps/web/src/components/kb/MdTypesetEditor.tsx
@@ -13,7 +13,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { MdRenderer } from './MdRenderer';
 import { MdStylePanel, defaultThemeConfig, type ThemeConfig } from './MdStylePanel';
-import { preprocessWikiLinks, preprocessWikiEmbeds, proxyExternalImages, stripTrackingPixels } from '../../hooks/useKnowledge';
+import { preprocessKbMarkdown } from '../../hooks/useKnowledge';
 
 export interface MdTypesetEditorProps {
   initialContent: string;
@@ -128,13 +128,12 @@ export function MdTypesetEditor({
 
   // Content for doocs/md themed preview (live-updating as user edits source).
   // Memoized to avoid re-running full-string regex scans on every keystroke.
-  const previewContent = useMemo(() => {
-    const stripped = stripTrackingPixels(content);
-    const withEmbeds = vaultId
-      ? proxyExternalImages(preprocessWikiEmbeds(stripped, vaultId))
-      : proxyExternalImages(stripped);
-    return preprocessWikiLinks(withEmbeds, vaultId);
-  }, [content, vaultId]);
+  // preprocessKbMarkdown keeps any leading YAML frontmatter block verbatim —
+  // rewriting [[wikilinks]] inside it would corrupt the YAML (see useKnowledge).
+  const previewContent = useMemo(
+    () => preprocessKbMarkdown(content, vaultId),
+    [content, vaultId],
+  );
 
   return (
     <div className="kb-typeset-editor">

--- a/apps/web/src/hooks/useKnowledge.ts
+++ b/apps/web/src/hooks/useKnowledge.ts
@@ -9,6 +9,7 @@ import { api } from '../api/client';
 import type { ThemeConfig } from '../components/kb/MdStylePanel';
 import { defaultThemeConfig } from '../components/kb/MdStylePanel';
 import { copyHtml } from '@molio/doocs-md/shared/utils/clipboard';
+import { FRONTMATTER_BLOCK_RE } from '@molio/doocs-md/src/renderer/renderer-impl';
 import { vaultStore, useActiveVaultId } from '../stores/vaultStore';
 
 const FILE_LOAD_RETRY_MS = 600;
@@ -123,14 +124,15 @@ export function stripTrackingPixels(markdown: string): string {
  * the block untouched. [[wikilinks]] inside frontmatter stay literal text,
  * which YAML parses fine (KbFrontmatterCard already displays them).
  *
- * The delimiter regex mirrors the `front-matter` package's own detection
- * (BOM, `---` / `= yaml =` opening, `---` / `...` closing, CRLF tolerated),
- * and is deliberately a superset: protecting a block that front-matter ends
- * up not parsing is harmless, while missing one it DOES parse reintroduces
- * the YAML corruption this guard exists to prevent.
+ * The delimiter regex is FRONTMATTER_BLOCK_RE, imported from the vendored
+ * renderer (doocs-md renderer-impl.ts) — a single source of truth shared
+ * with its parse-failure fallback, so the two can never silently drift.
+ * It mirrors the `front-matter` package's own detection (BOM, `---` /
+ * `= yaml =` opening, `---` / `...` closing, CRLF tolerated) and is
+ * deliberately a superset: protecting a block that front-matter ends up not
+ * parsing is harmless, while missing one it DOES parse reintroduces the YAML
+ * corruption this guard exists to prevent.
  */
-const FRONTMATTER_BLOCK_RE =
-  /^\uFEFF?(?:---|= yaml =)[ \t]*\r?\n[\s\S]*?\r?\n(?:---|= yaml =|\.\.\.)[ \t]*(?:\r?\n|$)/;
 
 export function preprocessKbMarkdown(markdown: string, vaultId?: string): string {
   const transform = (body: string): string => {

--- a/apps/web/src/hooks/useKnowledge.ts
+++ b/apps/web/src/hooks/useKnowledge.ts
@@ -104,6 +104,47 @@ export function stripTrackingPixels(markdown: string): string {
   );
 }
 
+/* [MOLIO] Frontmatter-safe preprocessing entry point for the doocs/md render path.
+ *
+ * The preprocessing chain below replaces [[wikilinks]] / ![[embeds]] with raw
+ * HTML anchors. It must NEVER touch a leading YAML frontmatter block: the wiki
+ * skills (wiki-build / wiki-save / wiki-ingest) mandate entries like
+ *
+ *   related:
+ *     - "[[相关页面]]"
+ *
+ * Rewriting [[…]] inside a quoted YAML scalar injects unescaped double quotes
+ * (`- "<a class="kb-wiki-link" …`), which makes the frontmatter invalid YAML —
+ * js-yaml throws "bad indentation of a sequence entry", doocs/md's front-matter
+ * parse fails, and its fallback renders the WHOLE text (frontmatter block
+ * included) as body. This was reported by ARMS as a high-volume YAMLException.
+ *
+ * So: split off the frontmatter block, transform only the body, and re-attach
+ * the block untouched. [[wikilinks]] inside frontmatter stay literal text,
+ * which YAML parses fine (KbFrontmatterCard already displays them).
+ *
+ * The delimiter regex mirrors the `front-matter` package's own detection
+ * (BOM, `---` / `= yaml =` opening, `---` / `...` closing, CRLF tolerated),
+ * and is deliberately a superset: protecting a block that front-matter ends
+ * up not parsing is harmless, while missing one it DOES parse reintroduces
+ * the YAML corruption this guard exists to prevent.
+ */
+const FRONTMATTER_BLOCK_RE =
+  /^\uFEFF?(?:---|= yaml =)[ \t]*\r?\n[\s\S]*?\r?\n(?:---|= yaml =|\.\.\.)[ \t]*(?:\r?\n|$)/;
+
+export function preprocessKbMarkdown(markdown: string, vaultId?: string): string {
+  const transform = (body: string): string => {
+    const stripped = stripTrackingPixels(body);
+    const withEmbeds = vaultId ? preprocessWikiEmbeds(stripped, vaultId) : stripped;
+    const proxied = proxyExternalImages(withEmbeds);
+    return preprocessWikiLinks(proxied, vaultId);
+  };
+
+  const match = FRONTMATTER_BLOCK_RE.exec(markdown);
+  if (!match) return transform(markdown);
+  return match[0] + transform(markdown.slice(match[0].length));
+}
+
 interface UseKnowledgeReturn {
   // Data
   vaults: Vault[];

--- a/apps/web/src/vendor.d.ts
+++ b/apps/web/src/vendor.d.ts
@@ -40,6 +40,9 @@ declare module '*/vendor/doocs-md/src/renderer/renderer-impl' {
 
   export function initRenderer(opts?: IOpts): RendererAPI;
   export const hljs: unknown;
+  /** [MOLIO] Leading YAML frontmatter block delimiter — single source of truth
+   *  shared by the renderer's parse-failure fallback and preprocessKbMarkdown. */
+  export const FRONTMATTER_BLOCK_RE: RegExp;
 }
 
 declare module '*/vendor/doocs-md/src/utils/markdownHelpers' {

--- a/apps/web/vendor/doocs-md/src/renderer/renderer-impl.ts
+++ b/apps/web/vendor/doocs-md/src/renderer/renderer-impl.ts
@@ -172,11 +172,23 @@ function parseFrontMatterAndContent(markdownText: string): ParseResult {
     }
   }
   catch (error) {
-    console.error(`Error parsing front-matter:`, error)
+    // [MOLIO] console.warn, not console.error: this is a handled fallback, not
+    // an exception. ARMS only reports consoleError as exceptions, so logging an
+    // error here flooded monitoring for every file whose frontmatter merely
+    // failed to parse (see YAMLException in preprocessKbMarkdown's comment).
+    console.warn(`Error parsing front-matter:`, error)
+    // [MOLIO] Strip the malformed frontmatter block instead of rendering it as
+    // body — otherwise the raw YAML (--- … ---) leaks into the rendered
+    // document. Delimiter regex mirrors the `front-matter` package (superset,
+    // same one as FRONTMATTER_BLOCK_RE in apps/web/src/hooks/useKnowledge.ts).
+    const withoutBlock = markdownText.replace(
+      /^\uFEFF?(?:---|= yaml =)[ \t]*\r?\n[\s\S]*?\r?\n(?:---|= yaml =|\.\.\.)[ \t]*(?:\r?\n|$)/,
+      '',
+    )
     return {
       yamlData: {},
-      markdownContent: markdownText,
-      readingTime: readingTime(markdownText),
+      markdownContent: withoutBlock,
+      readingTime: readingTime(withoutBlock),
     }
   }
 }

--- a/apps/web/vendor/doocs-md/src/renderer/renderer-impl.ts
+++ b/apps/web/vendor/doocs-md/src/renderer/renderer-impl.ts
@@ -157,6 +157,18 @@ interface ParseResult {
   readingTime: ReadTimeResults
 }
 
+// [MOLIO] Delimiter for a leading YAML frontmatter block. Mirrors the
+// `front-matter` package's own detection (BOM, `---` / `= yaml =` opening,
+// `---` / `...` closing, CRLF tolerated) and is deliberately a superset:
+// matching a block that front-matter ends up not parsing is harmless, while
+// missing one it DOES parse re-leaks raw YAML into the rendered document.
+//
+// SINGLE SOURCE OF TRUTH: also imported by apps/web/src/hooks/useKnowledge.ts
+// (preprocessKbMarkdown) so the preprocessing guard and the parse-failure
+// fallback below can never silently diverge.
+export const FRONTMATTER_BLOCK_RE
+  = /^\uFEFF?(?:---|= yaml =)[ \t]*\r?\n[\s\S]*?\r?\n(?:---|= yaml =|\.\.\.)[ \t]*(?:\r?\n|$)/
+
 function parseFrontMatterAndContent(markdownText: string): ParseResult {
   try {
     const parsed = frontMatter(markdownText)
@@ -179,12 +191,9 @@ function parseFrontMatterAndContent(markdownText: string): ParseResult {
     console.warn(`Error parsing front-matter:`, error)
     // [MOLIO] Strip the malformed frontmatter block instead of rendering it as
     // body — otherwise the raw YAML (--- … ---) leaks into the rendered
-    // document. Delimiter regex mirrors the `front-matter` package (superset,
-    // same one as FRONTMATTER_BLOCK_RE in apps/web/src/hooks/useKnowledge.ts).
-    const withoutBlock = markdownText.replace(
-      /^\uFEFF?(?:---|= yaml =)[ \t]*\r?\n[\s\S]*?\r?\n(?:---|= yaml =|\.\.\.)[ \t]*(?:\r?\n|$)/,
-      '',
-    )
+    // document. Uses the shared FRONTMATTER_BLOCK_RE above (single source of
+    // truth, also imported by apps/web/src/hooks/useKnowledge.ts).
+    const withoutBlock = markdownText.replace(FRONTMATTER_BLOCK_RE, '')
     return {
       yamlData: {},
       markdownContent: withoutBlock,


### PR DESCRIPTION
## 背景

ARMS 日志监控大量上报：

```
exception.source: console.error
exception.name: YAMLException
exception.message: bad indentation of a sequence entry at line 11, column 16:
  - "<a class="kb-wiki-link" href="/knowledge?v ...
```

## 根因

产品自身造成的系统性问题，每个按 wiki 技能规范生成的页面打开渲染视图都会触发：

1. wiki-build / wiki-save / wiki-ingest 技能要求 frontmatter 必须含带引号的 wikilink 列表：`related: - "[[相关页面]]"`
2. web 渲染管线（`KbMainContent` / `MdTypesetEditor`）对**全文**跑 `preprocessWikiLinks`，把 frontmatter 里的 `[[…]]` 也替换成 `<a class="kb-wiki-link" href="/knowledge?vault=…">` —— 双引号标量里注入未转义双引号，YAML 变非法
3. doocs-md 的 `parseFrontMatterAndContent`（front-matter 包，内部 js-yaml）抛 YAMLException，catch 里 `console.error` 被 ARMS 采集为异常
4. 兜底逻辑把**全文（含 frontmatter 块）当正文渲染**，用户看到原始 YAML 倾泻在文档顶部

异常消息里的 `href="/knowledge?v…` 格式与 `- "` 前导引号即为预处理产物的铁证（磁盘文件本身无 HTML）。

## 修复

- **useKnowledge**：新增 `preprocessKbMarkdown()` —— 分离首部 frontmatter 块，只对正文做预处理链（去追踪像素 → embeds → 图床代理 → wikilink），块原样拼回。定界正则对齐 `front-matter` 包自身的检测（BOM / `= yaml =` / `...` 收尾 / CRLF），且刻意取超集：多保护无害，漏保护会复发
- **KbMainContent / MdTypesetEditor**：渲染与排版预览统一改走该入口
- **doocs-md renderer-impl 兜底**：`console.error` → `console.warn`（已处理的降级而非异常；ARMS 只采 consoleError）；解析失败时剥除畸形块，不再倾泻进正文
- **E2E**（错误驱动）：`markdown-render.spec.ts` 新增回归测试 —— 修复前红（泄漏的 frontmatter 渲染出第二个锚点，count 2≠1）、修复后绿

## 验证

- [x] 新 E2E 修复前失败（锚点 count=2 + frontmatter 泄漏）→ 修复后通过
- [x] `markdown-render.spec.ts` 8/8 绿
- [x] `knowledge.spec.ts` 6/6 绿（P0 冒烟）
- [x] `publish-flow.spec.ts` 2/2 绿（排版模式路径）
- [x] `pnpm --filter @molio/web typecheck` 通过
- [ ] CI 全绿

## Test plan

- [ ] 打开任意 wiki 页（frontmatter 含 `related: - "[[页面]]"`）：正文 wikilink 可点击、frontmatter 不再泄漏进正文、属性卡片正常
- [ ] ARMS 观察 YAMLException 上报归零（发布后）