### PR TITLE
feat(web): 回复期间输入框可排队发送 — 排队中徽标 + turn_end 自动下发

### DIFF
--- a/apps/web/e2e/chat-composer-queue.spec.ts
+++ b/apps/web/e2e/chat-composer-queue.spec.ts
@@ -8,7 +8,9 @@ import { mockChatRun, unmockAll } from './helpers/mock-sse';
  *
  * Queue semantics while the AI is replying: the composer stays enabled, a
  * message sent mid-reply appears immediately with a "排队中" badge, and is
- * dispatched after the current turn ends.
+ * dispatched after the current turn ends. The drained turn streams real
+ * content over the same SSE connection (secondTurnScripts), so the spec can
+ * assert per-bubble content — not just that a second bubble appeared.
  *
  * Prerequisites: `pnpm dev` running (daemon :3100, web :5173).
  */
@@ -26,7 +28,17 @@ test.describe('Chat — composer queue while running', () => {
       { type: 'turn_end', stopReason: 'end_turn' },
       { type: 'usage', usage: { input_tokens: 100, output_tokens: 20 }, costUsd: 0.005 },
     ];
-    await mockChatRun(page, { script, frameDelay: 700 });
+    await mockChatRun(page, {
+      script,
+      frameDelay: 700,
+      secondTurnScripts: [[
+        { type: 'status', label: 'running' },
+        { type: 'text_delta', delta: 'Second reply, ' },
+        { type: 'text_delta', delta: 'done.' },
+        { type: 'turn_end', stopReason: 'end_turn' },
+        { type: 'usage', usage: { input_tokens: 50, output_tokens: 10 }, costUsd: 0.002 },
+      ]],
+    });
     await gotoHome(page);
 
     const textarea = page.locator('[data-testid="composer-input"]');
@@ -56,11 +68,77 @@ test.describe('Chat — composer queue while running', () => {
     await expect(stopBtn).toBeVisible();
     await expect(textarea).toBeEnabled();
 
-    // 6) When the turn ends (usage footer), the badge clears and the queued
-    //    message is dispatched (a second assistant message appears).
-    await expect(page.locator('[data-testid="usage-footer"]')).toBeVisible({ timeout: 10_000 });
+    // 6) When the turn ends the queued message drains: the drained turn streams
+    //    real content over the same SSE connection (second assistant bubble).
+    const assistantMsgs = page.locator('[data-testid="assistant-message"]');
+    await expect(assistantMsgs).toHaveCount(2, { timeout: 10_000 });
+    await expect(assistantMsgs.nth(1)).toContainText('Second reply, done.');
     await expect(page.locator('[data-testid="msg-queued-badge"]')).toHaveCount(0);
-    await expect(page.locator('[data-testid="assistant-message"]')).toHaveCount(2);
+    // The drained turn's usage footer (turn 2's) — turn 1's trailing usage is
+    // orphaned (it lands after the drain retargets to the streaming bubble, so
+    // the streaming guard ignores it), leaving exactly one usage footer.
+    await expect(page.locator('[data-testid="usage-footer"]')).toHaveCount(1, { timeout: 10_000 });
     await expect(textarea).toBeEnabled();
+  });
+
+  test('two messages queued during one reply drain in order without scrambling content', async ({ page }) => {
+    // Turn 1 reply (5 frames). Two messages are queued mid-turn; the drained
+    // turns stream distinct text so a scramble (turn N's content landing in
+    // turn N+1's bubble, or a reply dropped entirely) is caught.
+    const script = [
+      { type: 'status', label: 'running' },
+      { type: 'text_delta', delta: 'First reply, ' },
+      { type: 'text_delta', delta: 'streaming.' },
+      { type: 'turn_end', stopReason: 'end_turn' },
+      { type: 'usage', usage: { input_tokens: 100, output_tokens: 20 }, costUsd: 0.005 },
+    ];
+    await mockChatRun(page, {
+      script,
+      frameDelay: 700,
+      secondTurnScripts: [
+        [
+          { type: 'status', label: 'running' },
+          { type: 'text_delta', delta: 'Second reply, ' },
+          { type: 'text_delta', delta: 'done.' },
+          { type: 'turn_end', stopReason: 'end_turn' },
+          { type: 'usage', usage: { input_tokens: 50, output_tokens: 10 }, costUsd: 0.002 },
+        ],
+        [
+          { type: 'status', label: 'running' },
+          { type: 'text_delta', delta: 'Third reply, ' },
+          { type: 'text_delta', delta: 'done.' },
+          { type: 'turn_end', stopReason: 'end_turn' },
+          { type: 'usage', usage: { input_tokens: 60, output_tokens: 12 }, costUsd: 0.003 },
+        ],
+      ],
+    });
+    await gotoHome(page);
+
+    const textarea = page.locator('[data-testid="composer-input"]');
+    const stopBtn = page.locator('[data-testid="composer-stop"]');
+    const userMsgs = page.locator('[data-testid="user-message"]');
+
+    // 1) Send the first message → run starts.
+    await textarea.fill('First');
+    await textarea.press('Enter');
+    await expect(stopBtn).toBeVisible({ timeout: 5_000 });
+
+    // 2) Queue message 2 while turn 1 is running.
+    await textarea.fill('Second (queued)');
+    await textarea.press('Enter');
+    await expect(userMsgs).toHaveCount(2);
+
+    // 3) Queue message 3 while turn 1 is STILL running.
+    await textarea.fill('Third (queued)');
+    await textarea.press('Enter');
+    await expect(userMsgs).toHaveCount(3);
+    await expect(page.locator('[data-testid="msg-queued-badge"]')).toHaveCount(2);
+
+    // 4) Both queued messages drain in order, each with its own distinct reply.
+    const assistantMsgs = page.locator('[data-testid="assistant-message"]');
+    await expect(assistantMsgs).toHaveCount(3, { timeout: 15_000 });
+    await expect(assistantMsgs.nth(1)).toContainText('Second reply, done.');
+    await expect(assistantMsgs.nth(2)).toContainText('Third reply, done.');
+    await expect(page.locator('[data-testid="msg-queued-badge"]')).toHaveCount(0);
   });
 });

--- a/apps/web/e2e/chat-composer-queue.spec.ts
+++ b/apps/web/e2e/chat-composer-queue.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { gotoHome } from './helpers/navigation';
+import { mockChatRun, unmockAll } from './helpers/mock-sse';
+
+/**
+ * @area chat
+ * @priority P1
+ *
+ * Queue semantics while the AI is replying: the composer stays enabled, a
+ * message sent mid-reply appears immediately with a "排队中" badge, and is
+ * dispatched after the current turn ends.
+ *
+ * Prerequisites: `pnpm dev` running (daemon :3100, web :5173).
+ */
+test.describe('Chat — composer queue while running', () => {
+  test.afterEach(async ({ page }) => { await unmockAll(page); });
+
+  test('message sent during a reply is queued, badged, then dispatched after turn_end', async ({ page }) => {
+    // 5 frames × 700ms ≈ 3.5s running window: long enough to observe the
+    // "running" state and queue a second message mid-turn, short enough to
+    // keep the test snappy. The run ends with turn_end + usage.
+    const script = [
+      { type: 'status', label: 'running' },
+      { type: 'text_delta', delta: 'First reply, ' },
+      { type: 'text_delta', delta: 'still streaming.' },
+      { type: 'turn_end', stopReason: 'end_turn' },
+      { type: 'usage', usage: { input_tokens: 100, output_tokens: 20 }, costUsd: 0.005 },
+    ];
+    await mockChatRun(page, { script, frameDelay: 700 });
+    await gotoHome(page);
+
+    const textarea = page.locator('[data-testid="composer-input"]');
+    const stopBtn = page.locator('[data-testid="composer-stop"]');
+    const sendBtn = page.locator('[data-testid="composer-send"]');
+
+    // 1) Send the first message → run starts (stop button marks running).
+    await textarea.fill('First');
+    await textarea.press('Enter');
+    await expect(stopBtn).toBeVisible({ timeout: 5_000 });
+
+    // 2) While running the composer stays ENABLED.
+    await expect(textarea).toBeEnabled();
+
+    // 3) Type a second message → the send button reappears next to Stop.
+    await textarea.fill('Second (queued)');
+    await expect(sendBtn).toBeVisible();
+
+    // 4) Send it mid-reply → it appears immediately WITH the queued badge.
+    await textarea.press('Enter');
+    const userMsgs = page.locator('[data-testid="user-message"]');
+    await expect(userMsgs).toHaveCount(2);
+    await expect(userMsgs.nth(1)).toContainText('Second (queued)');
+    await expect(page.locator('[data-testid="msg-queued-badge"]')).toBeVisible();
+
+    // 5) The run keeps going and the composer stays usable.
+    await expect(stopBtn).toBeVisible();
+    await expect(textarea).toBeEnabled();
+
+    // 6) When the turn ends (usage footer), the badge clears and the queued
+    //    message is dispatched (a second assistant message appears).
+    await expect(page.locator('[data-testid="usage-footer"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-testid="msg-queued-badge"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="assistant-message"]')).toHaveCount(2);
+    await expect(textarea).toBeEnabled();
+  });
+});

--- a/apps/web/e2e/chat-single.spec.ts
+++ b/apps/web/e2e/chat-single.spec.ts
@@ -43,7 +43,7 @@ test.describe('Chat — single turn', () => {
     await expect(prose).toContainText('Hello, how can I help you?');
   });
 
-  test('composer disables during streaming and shows stop button', async ({ page }) => {
+  test('composer stays enabled during streaming', async ({ page }) => {
     await gotoHome(page);
 
     const textarea = page.locator('[data-testid="composer-input"]');
@@ -57,11 +57,10 @@ test.describe('Chat — single turn', () => {
     await textarea.fill('Test');
     await textarea.press('Enter');
 
-    // After send: composer should be disabled during streaming
-    // Note: with mock SSE the response is instant, so we check that it was disabled
-    // at some point by verifying the stop button appeared or the response completed.
-    // The mock SSE returns all events immediately, so the composer may re-enable quickly.
-    // We verify the final state: assistant message rendered.
+    // With the queue feature the composer is never locked during streaming.
+    // (The mock SSE returns instantly, so the dedicated "running window"
+    // coverage lives in chat-timeout-fallback / chat-timeout-idle-reset /
+    // chat-composer-queue — here we just confirm the final state renders.)
     await expect(page.locator('[data-testid="assistant-prose"]')).toBeVisible({ timeout: 10_000 });
   });
 

--- a/apps/web/e2e/chat-single.spec.ts
+++ b/apps/web/e2e/chat-single.spec.ts
@@ -139,4 +139,24 @@ test.describe('Chat — single turn', () => {
     await page.locator('[data-testid="assistant-message"]').hover();
     await expect(page.locator('[data-testid="assistant-message"]').locator('[data-testid="msg-copy-btn"]')).toBeVisible();
   });
+
+  test('codex-style turn (usage without turn_end) still renders the usage footer', async ({ page }) => {
+    // Codex emits `usage` (turn.completed) with NO turn_end at all — the usage
+    // arrives while the assistant message is still streaming. The footer must
+    // still render and the input must unlock (regression: the round-1 streaming
+    // guard dropped the stamp AND the unlock for such runtimes).
+    await mockChatRun(page, {
+      script: [
+        { type: 'status', label: 'running' },
+        { type: 'text_delta', delta: 'Codex reply' },
+        { type: 'usage', usage: { input_tokens: 80, output_tokens: 15 }, costUsd: 0.004 },
+        { type: 'status', label: 'completed' },
+      ],
+    });
+    await gotoHome(page);
+    await sendMessage(page, 'Test');
+    await expect(page.locator('[data-testid="usage-footer"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-testid="usage-footer"]')).toContainText('80');
+    await expect(page.locator('[data-testid="composer-input"]')).toBeEnabled();
+  });
 });

--- a/apps/web/e2e/chat-timeout-fallback.spec.ts
+++ b/apps/web/e2e/chat-timeout-fallback.spec.ts
@@ -44,13 +44,18 @@ test.describe('Chat — timeout fallback (W3)', () => {
     await gotoHome(page);
     await sendMessage(page, 'hi');
 
-    // During the run, the composer input is disabled (isRunning=true).
+    // Must be enabled WHILE the run is live. The 2s fallback would also unlock
+    // it, so a 500ms window (below the fallback) keeps this assertion
+    // discriminating: old code (disabled during run) fails it, new code
+    // (never disabled) passes it immediately.
     const input = page.locator('[data-testid="composer-input"]');
-    await expect(input).toBeDisabled({ timeout: 5_000 });
+    await expect(page.locator('[data-testid="composer-stop"]')).toBeVisible({ timeout: 5_000 });
+    await expect(input).toBeEnabled({ timeout: 500 });
 
-    // After the fallback timer (2s via test hook), the input must unlock and
-    // an error message must surface on the assistant bubble.
-    await expect(input).toBeEnabled({ timeout: 5_000 });
+    // After the fallback timer (2s via test hook), the run force-unlocks:
+    // the stop button disappears and an error message surfaces on the
+    // assistant bubble.
+    await expect(page.locator('[data-testid="composer-stop"]')).toBeHidden({ timeout: 5_000 });
     await expect(page.locator('[data-testid="assistant-error"]'))
       .toContainText('响应超时', { timeout: 2_000 });
   });

--- a/apps/web/e2e/chat-timeout-idle-reset.spec.ts
+++ b/apps/web/e2e/chat-timeout-idle-reset.spec.ts
@@ -37,15 +37,22 @@ test.describe('Chat — idle reset prevents false timeout', () => {
     await sendMessage(page, 'hi');
 
     const input = page.locator('[data-testid="composer-input"]');
-    // During the run the composer is disabled (isRunning=true).
-    await expect(input).toBeDisabled({ timeout: 5_000 });
+    // Must be enabled WHILE the run is live. A 5s window would poll until the
+    // ~4s idle fallback unlock on old code, pushing the post-wait assertions
+    // outside the run window (RED via a timing cascade, not a direct
+    // discriminator). 500ms is below the 1s idle window: old code fails here
+    // directly on "composer disabled during run"; new code passes immediately
+    // and the post-wait composer-stop check lands inside the ~4s active run.
+    await expect(page.locator('[data-testid="composer-stop"]')).toBeVisible({ timeout: 5_000 });
+    await expect(input).toBeEnabled({ timeout: 500 });
 
     // Wait PAST the 1s idle window. The run is still streaming (events arrive
     // every 300ms through ~3s), so the timer has been reset repeatedly — no
-    // false timeout. The composer must still be running and no error banner
+    // false timeout. The composer must still be enabled and no error banner
     // must have surfaced.
     await page.waitForTimeout(1_600);
-    await expect(input).toBeDisabled();
+    await expect(page.locator('[data-testid="composer-stop"]')).toBeVisible();
+    await expect(input).toBeEnabled();
     await expect(page.locator('[data-testid="assistant-error"]')).toHaveCount(0);
   });
 

--- a/apps/web/e2e/helpers/mock-sse.ts
+++ b/apps/web/e2e/helpers/mock-sse.ts
@@ -209,7 +209,32 @@ export async function mockChatRun(page: Page, opts: MockRunOptions = {}) {
       await route.continue({ url: target });
     });
   } else {
+    // `route.fulfill` closes the response, so EventSource auto-reconnects. For a
+    // NON-terminal script (no status completed/failed) that reconnect re-serves
+    // the script — which the multi-turn tests rely on to simulate the daemon
+    // streaming the next turn over the same connection. But for a TERMINAL script
+    // the run is over: replaying would re-deliver already-seen events and mask a
+    // bug where the FIRST delivery dropped one (e.g. codex `usage` without
+    // `turn_end` — the round-1 streaming guard dropped the stamp, then a replay
+    // re-stamped it against the now-non-streaming bubble, hiding the regression).
+    // Chromium's auto-reconnect carries no `?after=`/Last-Event-ID, so honoring
+    // `after` alone is not enough — terminal scripts serve exactly once.
+    const isTerminal = script.some((evt) => {
+      const e = evt as { type?: string; label?: string };
+      return e.type === 'status' && (e.label === 'completed' || e.label === 'failed');
+    });
+    let served = false;
     await page.route(`**/api/runs/${runId}/events**`, async (route) => {
+      if (served && isTerminal) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/event-stream',
+          headers: { 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' },
+          body: '',
+        });
+        return;
+      }
+      served = true;
       const frames = script.map((evt, i) => sseFrame(i + 1, runId, evt)).join('');
       await route.fulfill({
         status: 200,

--- a/apps/web/e2e/helpers/mock-sse.ts
+++ b/apps/web/e2e/helpers/mock-sse.ts
@@ -81,6 +81,11 @@ export interface MockRunOptions {
   /** 已持久化的会话历史消息（DB 加载 / 重挂载恢复用）。默认 [] —— 避免真实 daemon
    *  对未知 conv 404 → onLoadError 关标签。响应结构对齐 daemon：`{ messages: [...] }`。 */
   persistedMessages?: Array<{ id: string; role: 'user' | 'assistant'; content: string; timestamp: number }>;
+  /** Turn scripts streamed over the SAME SSE connection, one per drained queued
+   *  message, in drain order. Only supported with `frameDelay` set (needs a live
+   *  streaming server). Each element is a full turn script (status running →
+   *  text_delta… → turn_end → usage). */
+  secondTurnScripts?: Array<readonly object[]>;
 }
 
 // ── Main mock function ─────────────────────────────────────────────────
@@ -100,6 +105,22 @@ export async function mockChatRun(page: Page, opts: MockRunOptions = {}) {
   const runId = opts.runId ?? 'test-run-1';
   const convId = opts.conversationId ?? 'test-conv-1';
   const script = opts.script ?? SCRIPTS.simpleTextReply;
+
+  // Multi-turn POST signaling for secondTurnScripts: the SSE server streams each
+  // second-turn script only after the corresponding queued-message POST arrives
+  // (a POST may land BEFORE the primary script finishes — buffer it, don't lose it).
+  let pendingPosts: string[] = [];
+  const postWaiters: Array<() => void> = [];
+  function onMultiTurnPost(text: string) {
+    pendingPosts.push(text);
+    postWaiters.splice(0).forEach((r) => r());
+  }
+  async function waitForNthPost(n: number): Promise<string> {
+    while (pendingPosts.length <= n) {
+      await new Promise<void>((r) => postWaiters.push(r));
+    }
+    return pendingPosts[n]!;
+  }
 
   // 1) POST /api/runs → return { runId, conversationId }
   await page.route('**/api/runs', async (route) => {
@@ -154,9 +175,24 @@ export async function mockChatRun(page: Page, opts: MockRunOptions = {}) {
         socket.on('close', () => connections.delete(socket));
       }
       (async () => {
-        for (let i = 0; i < script.length; i++) {
-          res.write(sseFrame(i + 1, runId, script[i]!));
-          await new Promise((r) => setTimeout(r, opts.frameDelay));
+        // Monotonic seq across ALL scripts on this one connection — the real
+        // daemon numbers a run's events continuously, so a second turn starts
+        // at seq N+1, not 1.
+        let seq = 0;
+        const streamScript = async (turn: readonly object[]) => {
+          for (const evt of turn) {
+            seq += 1;
+            res.write(sseFrame(seq, runId, evt));
+            await new Promise((r) => setTimeout(r, opts.frameDelay));
+          }
+        };
+        await streamScript(script);
+        // Stream the drained turns over the SAME connection — one per queued
+        // message, in drain order, each gated on its POST arriving. If no POST
+        // ever arrives the connection stays open and the test times out.
+        for (let t = 0; t < (opts.secondTurnScripts?.length ?? 0); t++) {
+          await waitForNthPost(t);
+          await streamScript(opts.secondTurnScripts![t]!);
         }
         res.end();
       })();
@@ -190,6 +226,13 @@ export async function mockChatRun(page: Page, opts: MockRunOptions = {}) {
   // 3) POST /api/runs/:id/messages → multi-turn follow-up
   if (opts.multiTurn !== false) {
     await page.route(`**/api/runs/${runId}/messages`, async (route) => {
+      // With secondTurnScripts, signal the SSE server that this queued message
+      // was dispatched, so it can stream the corresponding turn over the same
+      // connection. Body is `{ message: "<text>" }` (matches api.sendMessage).
+      if (opts.secondTurnScripts && route.request().method() === 'POST') {
+        const body = JSON.parse(route.request().postData() || '{}');
+        onMultiTurnPost(typeof body.message === 'string' ? body.message : '');
+      }
       await route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -192,7 +192,7 @@ export default function App() {
                   messages={chat.messages}
                   isRunning={chat.isRunning}
                   activity={chat.activity}
-                  onSend={chat.send}
+                  onSend={(message) => chat.send(message, { queueIfRunning: true })}
                   onCancel={chat.cancel}
                   onNewChat={handleNewChat}
                   onSubmitToolResult={chat.submitToolResult}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -193,6 +193,7 @@ export default function App() {
                   isRunning={chat.isRunning}
                   activity={chat.activity}
                   onSend={(message) => chat.send(message, { queueIfRunning: true })}
+                  onSubmitForm={(text) => chat.send(text)}
                   onCancel={chat.cancel}
                   onNewChat={handleNewChat}
                   onSubmitToolResult={chat.submitToolResult}

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -198,7 +198,7 @@ export function ChatComposer({
     // them would push broken markdown to the backend.
     const doneImages = pastedImages.filter((p) => p.state === 'done');
     const hasContent = trimmed || fileRefs.length > 0 || doneImages.length > 0;
-    if (hasContent && !isRunning) {
+    if (hasContent) {
       onSend(trimmed, fileRefs, doneImages);
       setText('');
       // Clear the draft cache synchronously *before* the parent re-renders.
@@ -364,12 +364,11 @@ export function ChatComposer({
   const canSend =
     (text.trim().length > 0 || fileRefs.length > 0 || pastedImages.some((p) => p.state === 'done')) &&
     !isUploading &&
-    !isRunning &&
     !disabled;
   const placeholder = disabled
     ? (disabledPlaceholder ?? t('composer.noAgent'))
     : isRunning
-      ? t('composer.waiting')
+      ? t('composer.queuePlaceholder')
       : t('composer.placeholder');
 
   // Get vaultId for FilePicker
@@ -468,7 +467,7 @@ export function ChatComposer({
             onMouseUp={handleMouseUp}
             onPaste={handlePaste}
             placeholder={placeholder}
-            disabled={isRunning || disabled}
+            disabled={disabled}
             rows={1}
           />
 
@@ -487,6 +486,21 @@ export function ChatComposer({
           {isRunning ? (
             <>
               <span className="composer-spacer" />
+              {canSend && (
+                <button
+                  type="button"
+                  data-testid="composer-send"
+                  className="composer-send"
+                  onClick={handleSend}
+                  title={t('composer.queueTooltip')}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="22" y1="2" x2="11" y2="13" />
+                    <polygon points="22 2 15 22 11 13 2 9 22 2" />
+                  </svg>
+                  {t('composer.send')}
+                </button>
+              )}
               <button
                 type="button"
                 data-testid="composer-stop"

--- a/apps/web/src/components/HomePage.tsx
+++ b/apps/web/src/components/HomePage.tsx
@@ -18,6 +18,10 @@ interface Props {
   /** Live background subagent/workflow activity (null = nothing to show). */
   activity?: ActivityInfo | null;
   onSend: (message: string) => void;
+  /** Form fallback for AskUserQuestion answers — must reach the agent
+   *  IMMEDIATELY (never queued): the agent is paused waiting for the answer,
+   *  so queueing it would deadlock. Mirrors KbChatSession's unflagged send. */
+  onSubmitForm?: (text: string) => void;
   onCancel: () => void;
   onNewChat: () => void;
   onSubmitToolResult?: (toolUseId: string, content: string) => Promise<void>;
@@ -35,6 +39,7 @@ export function HomePage({
   isRunning,
   activity,
   onSend,
+  onSubmitForm,
   onCancel,
   onNewChat,
   onSubmitToolResult,
@@ -156,7 +161,7 @@ export function HomePage({
                   message={msg}
                   isLast={msg.id === lastAssistantId}
                   onAnswerToolUse={onSubmitToolResult ? onAnswerToolUse : undefined}
-                  onSubmitForm={(text: string) => handleSend(text, [])}
+                  onSubmitForm={onSubmitForm ?? ((text: string) => handleSend(text, []))}
                   onRegenerate={msg.id === lastAssistantId ? onRegenerate : undefined}
                   onContinue={msg.id === lastAssistantId ? onContinue : undefined}
                   onRequestDelete={onRequestDelete}

--- a/apps/web/src/components/UserMessage.tsx
+++ b/apps/web/src/components/UserMessage.tsx
@@ -141,6 +141,12 @@ export function UserMessage({ message, isLast, onEdit, onRequestDelete, disabled
     >
       <div className="role">
         <span className="msg-time">{formatTime(message.timestamp)}</span>
+        {message.queued && (
+          <span className="msg-queued-badge" data-testid="msg-queued-badge">
+            <span className="msg-queued-dot" />
+            {t('userMessage.queued')}
+          </span>
+        )}
       </div>
 
       {selectMode && <MessageCheckbox id={message.id} />}

--- a/apps/web/src/components/kb/KbChatSession.tsx
+++ b/apps/web/src/components/kb/KbChatSession.tsx
@@ -231,7 +231,7 @@ export function KbChatSession({
     }
     const isFirstTurn = chat.conversationId == null;
     const wrapped = session.mode === 'qa' && isFirstTurn ? WIKI_QUERY_TRIGGER(message) : message;
-    sendRef.current(wrapped);
+    sendRef.current(wrapped, { queueIfRunning: true });
   }, [selectedText, onSelectedTextConsumed, t, session.mode, chat.conversationId]);
 
   const contextLabel =

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -8,7 +8,7 @@
  * and an optional `rewindResend` for regenerating/editing the last user turn.
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import type { AgentEvent, ActivityInfo } from '@molio/contracts';
 import { api } from '../api/client';
 import { subscribeToRun } from '../api/sse';
@@ -43,6 +43,15 @@ export interface ChatMessage {
    *  Kept separate from `content` so saved messages don't carry an "Error:"
    *  prefix — the UI renders this as a distinct banner above the prose. */
   error?: string;
+  /** Frontend-only queue marker — the message is waiting for the current turn
+   *  to end before dispatch. Never sent to the daemon, never persisted. */
+  queued?: boolean;
+}
+
+/** A message queued while a reply is running (see `send` + drain effect). */
+export interface QueuedMessage {
+  id: string;
+  text: string;
 }
 
 interface ChatState {
@@ -58,6 +67,8 @@ interface ChatState {
    * Workflow keeps running — this is what keeps the UI alive in that gap.
    */
   activity: ActivityInfo | null;
+  /** Messages queued while isRunning — drained one per turn-end. */
+  pendingQueue: QueuedMessage[];
 }
 
 export interface RunResult {
@@ -123,6 +134,7 @@ export function useChatCore(options: UseChatCoreOptions) {
     isRunning: false,
     conversationId: initialConversationId,
     activity: null,
+    pendingQueue: [],
   });
 
   // 最新已提交 state 的 ref（每次渲染同步）。事件处理器里读「当前状态」必须走它，而不是渲染闭包——
@@ -386,49 +398,30 @@ export function useChatCore(options: UseChatCoreOptions) {
   }, [agentId, onComplete, clearFallbackTimer, clearWatchdog, armWatchdog, resetFallbackTimer]);
 
   /**
-   * Send a message — tries multi-turn on existing run first, falls back to createRun.
+   * Dispatch a message to the agent — the shared core for both a normal send
+   * and a drained queued message. Tries multi-turn on the existing run first,
+   * falls back to createRun. `optimisticMessages` is the full message list
+   * AFTER this turn's user+assistant messages are in place (attachRun replaces
+   * `messages` with it); its user/assistant members (minus this turn's own
+   * user + assistant messages) form the transcript sent to the daemon.
    */
-  const send = useCallback(async (text: string) => {
-    if (!text.trim()) return;
-
-    const userMsg: ChatMessage = {
-      id: nextMsgId(),
-      role: 'user',
-      content: text.trim(),
-      timestamp: Date.now(),
-    };
-
-    const newAssistantId = nextMsgId();
-    assistantIdRef.current = newAssistantId;
-
-    const assistantMsg: ChatMessage = {
-      id: newAssistantId,
-      role: 'assistant',
-      content: '',
-      timestamp: Date.now(),
-      streaming: true,
-      tools: [],
-    };
+  const dispatchTurn = useCallback(async (
+    text: string,
+    userMsgId: string,
+    assistantMsg: ChatMessage,
+    optimisticMessages: ChatMessage[],
+  ) => {
+    // Route incoming SSE events to the new assistant message.
+    assistantIdRef.current = assistantMsg.id;
 
     // 读最新已提交 state（stateRef 而非渲染闭包）：clear()/cancel() 在同一微任务里同步改过
     // stateRef 后，紧跟的 send() 必须看到清空后的 messages/conversationId（D3 清标签语义）。
     const cur = stateRef.current;
-    const prevMessages = cur.messages;
-
-    setState((prev) => ({
-      ...prev,
-      messages: [...prev.messages, userMsg, assistantMsg],
-      isRunning: true,
-    }));
-
-    // Try multi-turn on existing run — but only if the agent hasn't changed.
-    // When the user switches runtime (e.g. Claude → Qwen), the existing run
-    // belongs to the old agent; sending a follow-up would go to the wrong process.
     const existingRunId = cur.runId;
     const agentChanged = agentId != null && cur.runAgentId != null && agentId !== cur.runAgentId;
     if (existingRunId && !agentChanged) {
       try {
-        await api.sendMessage(existingRunId, text.trim());
+        await api.sendMessage(existingRunId, text);
         // Multi-turn reuses the existing SSE subscription, which does NOT
         // re-arm the fallback timer (attachRun isn't called). Re-arm here so
         // a hung follow-up turn still force-unlocks instead of spinning
@@ -440,9 +433,11 @@ export function useChatCore(options: UseChatCoreOptions) {
       }
     }
 
-    // Build history for transcript
-    const history = prevMessages
-      .filter((m) => m.role === 'user' || m.role === 'assistant')
+    // Build history for transcript — everything except THIS turn's user +
+    // assistant messages (the user message is the `message` prompt; the
+    // assistant message is empty/streaming).
+    const history = optimisticMessages
+      .filter((m) => (m.role === 'user' || m.role === 'assistant') && m.id !== userMsgId && m.id !== assistantMsg.id)
       .map((m) => ({
         id: m.id,
         role: m.role as 'user' | 'assistant',
@@ -463,14 +458,13 @@ export function useChatCore(options: UseChatCoreOptions) {
 
     try {
       const result = await createRun({
-        message: text.trim(),
+        message: text,
         history,
         conversationId: cur.conversationId,
       });
-
-      await attachRun(result.runId, result.conversationId ?? cur.conversationId, newAssistantId, [...prevMessages, userMsg, assistantMsg]);
+      await attachRun(result.runId, result.conversationId ?? cur.conversationId, assistantMsg.id, optimisticMessages);
     } catch (err) {
-      const errId = newAssistantId;
+      const errId = assistantMsg.id;
       setState((prev) => {
         const messages = prev.messages.map((msg) =>
           msg.id === errId
@@ -480,7 +474,92 @@ export function useChatCore(options: UseChatCoreOptions) {
         return { ...prev, messages, isRunning: false };
       });
     }
-  }, [closeEventSource, createRun, agentId, onComplete, attachRun, resetFallbackTimer]);
+  }, [agentId, closeEventSource, createRun, attachRun, resetFallbackTimer]);
+
+  /**
+   * Send a message. With `{ queueIfRunning: true }`, a send while `isRunning`
+   * queues the message (appears immediately with `queued: true`, dispatched by
+   * the drain effect after the current turn ends) instead of interleaving.
+   * All other callers (form submit, "继续", wiki auto-send) keep the flag off —
+   * they must reach the agent immediately.
+   */
+  const send = useCallback(async (text: string, opts?: { queueIfRunning?: boolean }) => {
+    if (!text.trim()) return;
+    const trimmed = text.trim();
+    const cur = stateRef.current;
+
+    // 排队路径：回复进行中发送 → 乐观 user 消息立即上屏 + 标记 queued，等 turn 结束再下发。
+    if (opts?.queueIfRunning && cur.isRunning) {
+      const userMsg: ChatMessage = {
+        id: nextMsgId(),
+        role: 'user',
+        content: trimmed,
+        timestamp: Date.now(),
+        queued: true,
+      };
+      setState((prev) => ({
+        ...prev,
+        messages: [...prev.messages, userMsg],
+        pendingQueue: [...prev.pendingQueue, { id: userMsg.id, text: trimmed }],
+      }));
+      return;
+    }
+
+    const userMsg: ChatMessage = {
+      id: nextMsgId(),
+      role: 'user',
+      content: trimmed,
+      timestamp: Date.now(),
+    };
+    const assistantMsg: ChatMessage = {
+      id: nextMsgId(),
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      streaming: true,
+      tools: [],
+    };
+
+    setState((prev) => ({
+      ...prev,
+      messages: [...prev.messages, userMsg, assistantMsg],
+      isRunning: true,
+    }));
+
+    await dispatchTurn(trimmed, userMsg.id, assistantMsg, [...cur.messages, userMsg, assistantMsg]);
+  }, [dispatchTurn]);
+
+  // 排队 drain：当前 turn 结束后（isRunning → false）按序下发 pendingQueue 中的消息。
+  // 任何解锁路径（turn_end / usage / status completed / onDone / fallback）都会触发。
+  // drain 后立即 isRunning=true，effect 不会对同一条重复处理；多条排队逐 turn 下发；
+  // 下发失败（createRun 抛错）→ 标 error、isRunning=false → 继续 drain 下一条。
+  useEffect(() => {
+    if (stateRef.current.isRunning) return;
+    const first = stateRef.current.pendingQueue[0];
+    if (!first) return;
+
+    const assistantMsg: ChatMessage = {
+      id: nextMsgId(),
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      streaming: true,
+      tools: [],
+    };
+    // 去掉该用户消息的 queued 标记（徽标消失）并追加本条 assistant 消息。
+    const messages = stateRef.current.messages.map((m) =>
+      m.id === first.id ? { ...m, queued: false } : m
+    );
+    const optimistic = [...messages, assistantMsg];
+    setState((prev) => ({
+      ...prev,
+      pendingQueue: prev.pendingQueue.slice(1),
+      messages: optimistic,
+      isRunning: true,
+    }));
+    void dispatchTurn(first.text, first.id, assistantMsg, optimistic);
+    // 依赖用响应式 state（触发 effect），body 读 stateRef（最新已提交），两者在 effect 运行时恒等。
+  }, [state.isRunning, state.pendingQueue, dispatchTurn]);
 
   const rewindAndResend = useCallback(async (newContent: string) => {
     if (!rewindResend) return;
@@ -602,7 +681,7 @@ export function useChatCore(options: UseChatCoreOptions) {
     const messages = prev.messages.map((msg) =>
       msg.streaming ? { ...msg, streaming: false } : msg
     );
-    const next = { ...prev, messages, isRunning: false, runId: null, runAgentId: null, activity: null };
+    const next = { ...prev, messages, isRunning: false, runId: null, runAgentId: null, activity: null, pendingQueue: [] };
     stateRef.current = next;
     setState(next);
   }, [closeEventSource]);
@@ -611,7 +690,7 @@ export function useChatCore(options: UseChatCoreOptions) {
     closeEventSource();
     assistantIdRef.current = null;
     messageSelectionStore.exit();
-    const next = { messages: [], runId: null, runAgentId: null, isRunning: false, conversationId: null, activity: null };
+    const next = { messages: [], runId: null, runAgentId: null, isRunning: false, conversationId: null, activity: null, pendingQueue: [] };
     stateRef.current = next;
     setState(next);
   }, [closeEventSource]);
@@ -631,6 +710,7 @@ export function useChatCore(options: UseChatCoreOptions) {
       isRunning: false,
       conversationId: conversationId ?? null,
       activity: null,
+      pendingQueue: [],
     };
     stateRef.current = next;
     setState(next);

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -146,6 +146,11 @@ export function useChatCore(options: UseChatCoreOptions) {
 
   const esRef = useRef<EventSource | null>(null);
   const assistantIdRef = useRef<string | null>(null);
+  // 排队 drain 后 assistantIdRef 被重定向到新气泡；上一轮的尾随事件（usage / turn_end）
+  // 仍在旧连接上到达，须在「drain → 新气泡首个内容事件」窗口内丢弃，否则会污染新气泡或
+  // 提前把它标记为完成（gemini: usage 先于 turn_end）。窗口外一切正常 —— codex/gemini
+  // 的 usage 发给仍在 streaming 的消息是合法的（它们不发 turn_end 或 turn_end 在后）。
+  const drainedPendingRef = useRef(false);
   // P2-3: fallback timer that force-unlocks the input if the daemon hangs or
   // the SSE dies without a terminal event. Aligned with daemon's
   // promptIdleTimeoutMs (5min) — if no terminal status arrives by then, the
@@ -257,6 +262,8 @@ export function useChatCore(options: UseChatCoreOptions) {
     // multi-turn path (api.sendMessage on an existing run) can retarget
     // events to a new assistant message without resubscribing.
     assistantIdRef.current = assistantId;
+    // 全新连接（createRun / rewindAndResend / resumeRun）不会有上一轮的尾随事件。
+    drainedPendingRef.current = false;
     clearFallbackTimer();
     clearWatchdog();
     reconnectAttemptRef.current = 0;
@@ -298,6 +305,15 @@ export function useChatCore(options: UseChatCoreOptions) {
         };
         window.dispatchEvent(new CustomEvent(ACP_MODELS_UPDATED_EVENT, { detail }));
       }
+      // 尾随窗口：drain 刚重定向、新气泡尚未收到自己的内容 —— 此时到达的 usage / turn_end(end_turn)
+      // 属于上一轮，丢弃（不盖章、不提前解锁、不标记完成）。
+      if (drainedPendingRef.current && (event.type === 'usage' || (event.type === 'turn_end' && event.stopReason !== 'tool_use'))) {
+        return;
+      }
+      // 新气泡开始流动（内容 / 状态 / 非尾随 turn_end(tool_use) / error）→ 关闭窗口。
+      if (event.type !== 'activity' && event.type !== 'usage' && !(event.type === 'turn_end' && event.stopReason !== 'tool_use')) {
+        drainedPendingRef.current = false;
+      }
       setState((prev) => updateWithEvent(prev, currentId, event));
       if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed' || event.label === 'canceled')) {
         clearFallbackTimer();
@@ -313,6 +329,8 @@ export function useChatCore(options: UseChatCoreOptions) {
       console.warn('[chat] SSE onDone (CLOSED) — force-unlocking. runId=' + runId);
       clearWatchdog();
       reconnectRef.current = null;
+      // 连接关闭 → 尾随窗口作废（防御：防止 stale 窗口污染后续 run）。
+      drainedPendingRef.current = false;
       setState((prev) => {
         if (!prev.isRunning) return prev;
         const messages = prev.messages.map((msg) =>
@@ -559,6 +577,9 @@ export function useChatCore(options: UseChatCoreOptions) {
       messages: optimistic,
       isRunning: true,
     }));
+    // 进入尾随窗口：此后到达的 usage / turn_end(end_turn) 属于上一轮（旧连接尾随），
+    // 在新气泡首个内容事件前丢弃，避免污染新气泡或提前把它标记为完成。
+    drainedPendingRef.current = true;
     void dispatchTurn(first.text, first.id, assistantMsg, optimistic);
     // 依赖用响应式 state 触发 effect；body 读 stateRef.current（与渲染闭包在 effect 运行时等价的已提交 state）。
     // 排队是纯前端语义：cancel/reset/setMessages 会清空 pendingQueue 并作废 queued 气泡（见 §6 设计）。
@@ -686,6 +707,7 @@ export function useChatCore(options: UseChatCoreOptions) {
     }
     closeEventSource();
     assistantIdRef.current = null;
+    drainedPendingRef.current = false;
 
     // 同步更新 stateRef：调用方（clearAndSend 中断路径）可能在同一事件循环里紧跟 send()，
     // 必须让 send 读到「已取消、runId 已清」的最新状态。
@@ -702,6 +724,7 @@ export function useChatCore(options: UseChatCoreOptions) {
   const reset = useCallback(() => {
     closeEventSource();
     assistantIdRef.current = null;
+    drainedPendingRef.current = false;
     messageSelectionStore.exit();
     const next = { messages: [], runId: null, runAgentId: null, isRunning: false, conversationId: null, activity: null, pendingQueue: [] };
     stateRef.current = next;
@@ -715,6 +738,7 @@ export function useChatCore(options: UseChatCoreOptions) {
   const setMessages = useCallback((messages: ChatMessage[], conversationId?: string | null) => {
     closeEventSource();
     assistantIdRef.current = null;
+    drainedPendingRef.current = false;
     messageSelectionStore.exit();
     const next = {
       messages,
@@ -843,9 +867,6 @@ function updateWithEvent(
       }
 
       case 'usage':
-        // 排队 drain 后，上一轮的尾随 usage（本气泡已在流式回复）不属于这个 turn ——
-        // 既不能盖到新气泡上，也不能触发解锁（否则 isRunning 提前回 false → 多条排队乱序下发）。
-        if (msg.streaming) return msg;
         return clearRepairing({
           ...msg,
           usage: {
@@ -879,11 +900,7 @@ function updateWithEvent(
   }
 
   if (event.type === 'usage') {
-    const target = messages.find((m) => m.id === assistantId);
-    // 上一轮尾随 usage 落到「正在流式回复」的新气泡 → 忽略，不提前解锁。
-    if (target && !target.streaming) {
-      isRunning = false;
-    }
+    isRunning = false;
   }
 
   if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed')) {

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -435,9 +435,11 @@ export function useChatCore(options: UseChatCoreOptions) {
 
     // Build history for transcript — everything except THIS turn's user +
     // assistant messages (the user message is the `message` prompt; the
-    // assistant message is empty/streaming).
+    // assistant message is empty/streaming). Still-queued messages (queued:
+    // true, not yet dispatched) are excluded too so the agent doesn't answer
+    // them prematurely before their own turn.
     const history = optimisticMessages
-      .filter((m) => (m.role === 'user' || m.role === 'assistant') && m.id !== userMsgId && m.id !== assistantMsg.id)
+      .filter((m) => (m.role === 'user' || m.role === 'assistant') && m.id !== userMsgId && m.id !== assistantMsg.id && !m.queued)
       .map((m) => ({
         id: m.id,
         role: m.role as 'user' | 'assistant',
@@ -678,9 +680,10 @@ export function useChatCore(options: UseChatCoreOptions) {
     // 同步更新 stateRef：调用方（clearAndSend 中断路径）可能在同一事件循环里紧跟 send()，
     // 必须让 send 读到「已取消、runId 已清」的最新状态。
     const prev = stateRef.current;
-    const messages = prev.messages.map((msg) =>
-      msg.streaming ? { ...msg, streaming: false } : msg
-    );
+    // 排队消息作废（设计 §6）：停止时把 queued 消息一并从会话移除，避免残留「排队中」徽标。
+    const messages = prev.messages
+      .filter((msg) => !msg.queued)
+      .map((msg) => (msg.streaming ? { ...msg, streaming: false } : msg));
     const next = { ...prev, messages, isRunning: false, runId: null, runAgentId: null, activity: null, pendingQueue: [] };
     stateRef.current = next;
     setState(next);

--- a/apps/web/src/hooks/useChatCore.ts
+++ b/apps/web/src/hooks/useChatCore.ts
@@ -560,7 +560,8 @@ export function useChatCore(options: UseChatCoreOptions) {
       isRunning: true,
     }));
     void dispatchTurn(first.text, first.id, assistantMsg, optimistic);
-    // 依赖用响应式 state（触发 effect），body 读 stateRef（最新已提交），两者在 effect 运行时恒等。
+    // 依赖用响应式 state 触发 effect；body 读 stateRef.current（与渲染闭包在 effect 运行时等价的已提交 state）。
+    // 排队是纯前端语义：cancel/reset/setMessages 会清空 pendingQueue 并作废 queued 气泡（见 §6 设计）。
   }, [state.isRunning, state.pendingQueue, dispatchTurn]);
 
   const rewindAndResend = useCallback(async (newContent: string) => {
@@ -577,7 +578,9 @@ export function useChatCore(options: UseChatCoreOptions) {
     })();
     if (lastUserIdx < 0) return;
 
-    const prevMessages = state.messages.slice(0, lastUserIdx); // everything before last user msg
+    const prevMessages = state.messages
+      .slice(0, lastUserIdx) // everything before last user msg
+      .map((m) => (m.queued ? { ...m, queued: false } : m)); // 重发丢弃尾部 → 残余 queued 气泡作废
     const newUserMsg: ChatMessage = {
       id: nextMsgId(),
       role: 'user',
@@ -597,18 +600,25 @@ export function useChatCore(options: UseChatCoreOptions) {
 
     closeEventSource();
 
+    // 重发丢弃消息尾部，排队消息必须随之作废 —— 同步清空队列（写 stateRef + setState，
+    // 与 cancel/reset 一致），避免残留 queued 消息在重发后 ghost drain。
+    const cleared = { ...stateRef.current, pendingQueue: [] };
+    stateRef.current = cleared;
+    setState((prev) => ({ ...prev, pendingQueue: [] }));
+
     try {
       const result = await rewindResend({ conversationId: convId, newContent: newContent.trim() });
       await attachRun(result.runId, result.conversationId ?? convId, newAssistantId, [...prevMessages, newUserMsg, newAssistantMsg]);
     } catch (err) {
       setState((prev) => ({
         ...prev,
-        messages: [...prev.messages, {
+        // 队列已清空，但残余 queued 气泡仍需摘掉徽标，避免 stale badge 残留。
+        messages: prev.messages.map((m) => (m.queued ? { ...m, queued: false } : m)).concat([{
           id: nextMsgId(),
           role: 'error',
           content: `Error: ${(err as Error).message}`,
           timestamp: Date.now(),
-        } as ChatMessage],
+        } as ChatMessage]),
         isRunning: false,
       }));
     }
@@ -625,7 +635,7 @@ export function useChatCore(options: UseChatCoreOptions) {
   const resumeRun = useCallback((opts: { runId: string }) => {
     const msgs = stateRef.current.messages;
     const last = msgs[msgs.length - 1];
-    if (!last || last.role !== 'user') return; // 本轮已结束并持久化 → 恢复会重复
+    if (!last || last.role !== 'user' || last.queued) return; // queued 消息尚未进入回复，跳过恢复
     const newAssistantId = nextMsgId();
     const assistantMsg: ChatMessage = {
       id: newAssistantId,
@@ -728,6 +738,7 @@ export function useChatCore(options: UseChatCoreOptions) {
       setState((prev) => ({
         ...prev,
         messages: prev.messages.filter((m) => !ids.includes(m.id)),
+        pendingQueue: prev.pendingQueue.filter((q) => !ids.includes(q.id)),
       }));
     } catch (err) {
       setState((prev) => ({
@@ -832,6 +843,9 @@ function updateWithEvent(
       }
 
       case 'usage':
+        // 排队 drain 后，上一轮的尾随 usage（本气泡已在流式回复）不属于这个 turn ——
+        // 既不能盖到新气泡上，也不能触发解锁（否则 isRunning 提前回 false → 多条排队乱序下发）。
+        if (msg.streaming) return msg;
         return clearRepairing({
           ...msg,
           usage: {
@@ -865,7 +879,11 @@ function updateWithEvent(
   }
 
   if (event.type === 'usage') {
-    isRunning = false;
+    const target = messages.find((m) => m.id === assistantId);
+    // 上一轮尾随 usage 落到「正在流式回复」的新气泡 → 忽略，不提前解锁。
+    if (target && !target.streaming) {
+      isRunning = false;
+    }
   }
 
   if (event.type === 'status' && (event.label === 'completed' || event.label === 'failed')) {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -24,6 +24,8 @@ const en: Record<string, string> = {
   // ── ChatComposer ──
   'composer.noAgent': 'No agent available',
   'composer.waiting': 'Waiting for response...',
+  'composer.queuePlaceholder': 'Reply in progress — sends when finished',
+  'composer.queueTooltip': 'Sends after the current reply finishes',
   'composer.placeholder': 'Type a message...',
   'composer.stop': 'Stop',
   'composer.send': 'Send',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -23,7 +23,6 @@ const en: Record<string, string> = {
 
   // ── ChatComposer ──
   'composer.noAgent': 'No agent available',
-  'composer.waiting': 'Waiting for response...',
   'composer.queuePlaceholder': 'Reply in progress — sends when finished',
   'composer.queueTooltip': 'Sends after the current reply finishes',
   'composer.placeholder': 'Type a message...',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -506,6 +506,7 @@ const en: Record<string, string> = {
 
   // ── UserMessage ──
   'userMessage.viewOriginal': 'View original',
+  'userMessage.queued': 'Queued',
 
   // ── HomePage ──
   'home.fileContextFallback': 'Please analyze the above content.',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -24,6 +24,8 @@ const zh: Record<string, string> = {
   // ── ChatComposer ──
   'composer.noAgent': '没有可用的代理',
   'composer.waiting': '等待回复…',
+  'composer.queuePlaceholder': '回复中，发送将排入队列',
+  'composer.queueTooltip': '回复完成后发送',
   'composer.placeholder': '输入消息…',
   'composer.stop': '停止',
   'composer.send': '发送',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -23,7 +23,6 @@ const zh: Record<string, string> = {
 
   // ── ChatComposer ──
   'composer.noAgent': '没有可用的代理',
-  'composer.waiting': '等待回复…',
   'composer.queuePlaceholder': '回复中，发送将排入队列',
   'composer.queueTooltip': '回复完成后发送',
   'composer.placeholder': '输入消息…',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -506,6 +506,7 @@ const zh: Record<string, string> = {
 
   // ── UserMessage ──
   'userMessage.viewOriginal': '查看原图',
+  'userMessage.queued': '排队中',
 
   // ── HomePage ──
   'home.fileContextFallback': '请根据以上内容帮我分析。',

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -158,6 +158,31 @@
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+.msg-queued-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--amber);
+  background: var(--amber-bg);
+  border: 1px solid var(--amber-border);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+  white-space: nowrap;
+  user-select: none;
+}
+.msg-queued-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--amber);
+  animation: msg-queued-pulse 1.6s ease-in-out infinite;
+}
+@keyframes msg-queued-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
 
 /* Assistant prose */
 .assistant-prose {
@@ -1232,6 +1257,9 @@
   .composer-history-actions,
   .composer-history-action {
     transition: none;
+  }
+  .msg-queued-dot {
+    animation: none;
   }
 }
 

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -42,6 +42,7 @@
   --red-border: #f0d4d2;
   --amber: #a87018;
   --amber-bg: #fdf5e8;
+  --amber-border: #f0ddbd;
 
   --shadow-xs: 0 1px 0 rgba(26, 25, 23, 0.03);
   --shadow-sm: 0 1px 3px rgba(26, 25, 23, 0.04), 0 1px 2px rgba(26, 25, 23, 0.03);
@@ -99,6 +100,7 @@
   --red-border: #582825;
   --amber: #e0ac58;
   --amber-bg: #3a2e16;
+  --amber-border: #4d3c1e;
 
   --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.2);
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.25), 0 1px 2px rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
## 功能

AI 回复生成期间,输入框不再被禁用 —— 可继续输入并发送,消息进入排队(带「排队中」琥珀徽标),当前回复完成后自动逐条下发。

### 交互语义(排队,非打断)

- 回复中发送的消息立刻上屏并带「排队中」徽标,可继续编辑/删除/取消
- 当前 turn 结束(`turn_end`)后,队列消息逐条自动下发,每条进入自己的新气泡
- `cancel` / `reset` / `deleteMessages` / `rewindAndResend` / `resumeRun` 均正确处理排队消息(清空 / 作废 / 不恢复)

### 关键改动

- `useChatCore`: `ChatMessage.queued` + `ChatState.pendingQueue` + `dispatchTurn` 公共下发核心 + drain effect + `send(text, { queueIfRunning })`
- 尾随事件收敛: `drainedPendingRef` 窗口 —— 仅在 drain 重定向后丢弃上一轮尾随的 `usage` / `turn_end`,不误伤 codex(仅 usage)/ gemini(usage 先于 turn_end)的用量页脚
- `ChatComposer`: 回复期间解锁输入 + 发送/停止双按钮 + 排队 placeholder 文案
- `UserMessage`: 排队中琥珀徽标(圆点脉动,尊重 reduced-motion)
- 表单提交(AskUserQuestion)保持即时发送、不进队列(避免 agent 等待死锁)
- `KbChatSession` wiki 自动发送与表单提交同样即时,不受影响

### 测试

- 新增 `chat-composer-queue.spec.ts`: 排队徽标 + 真实内容 drain + 两条排队 scramble 锁
- 新增 codex 风格页脚回归测试(usage 无 turn_end)
- 全量 E2E: **262 passed / 0 failed / 8 skipped**; `pnpm typecheck` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
