### PR TITLE
fix(daemon): Claude Code 的 [claude-code:*] stderr 诊断行不再当作错误 — 修复第三方 provider 回复被吞

### DIFF
--- a/apps/daemon/CLAUDE.md
+++ b/apps/daemon/CLAUDE.md
@@ -138,6 +138,7 @@ pnpm typecheck    # tsc --noEmit
 - **RunManager** 是核心单例，管理所有活跃 run 的生命周期
 - 每个 run 通过 `child_process.spawn` 启动本地 AI CLI 进程
 - stdout 输出经 stream handler 解析为 `AgentEvent`，通过 SSE 推送给前端
+- **stderr ≠ 错误**：agent CLI 会往 stderr 写信息性诊断（Claude Code 2.1.233+ 的 `[claude-code:*]` marker 行、Codex 的 "Reading prompt from stdin"），分流规则集中在 `runtimes/stderr.ts` 的 `classifyStderrChunk`（诊断行 → `raw` 事件只落日志，真错误 → `error` 事件）。新增 agent 或新诊断行时在这里加规则——**不要**把 stderr 直接升级为 `error` 事件：前端收到 error 会置 `streaming:false` 吞掉后续回复流
 - 事件缓冲区限制 2000 条，run TTL 30 分钟
 - 支持多轮对话 (transcript 构建)
 - SQLite 存储项目、会话、知识库等持久化数据

--- a/apps/daemon/src/core/RunManager.ts
+++ b/apps/daemon/src/core/RunManager.ts
@@ -10,6 +10,7 @@ import { getAgentDef, listAgentDefs } from './runtimes/registry.js';
 import { TranscriptWatcher, claudeProjectDir } from './activity/transcript-watcher.js';
 import { resolveAgentBinary, probeVersion, needsShellOnWindows } from './runtimes/launch.js';
 import { buildSpawnEnv, createStderrDecoder } from './runtimes/env.js';
+import { classifyStderrChunk } from './runtimes/stderr.js';
 import { createClaudeStreamHandler } from './streams/claude-stream.js';
 import { createCodexStreamHandler } from './streams/codex-stream.js';
 import { createJsonEventStreamHandler } from './streams/json-event-stream.js';
@@ -469,16 +470,12 @@ export class RunManager {
 
     child.stderr?.on('data', (chunk: Buffer) => {
       const text = stderrDecoder ? stderrDecoder(chunk) : chunk.toString('utf8');
-      const trimmed = text.trim();
-      // Codex CLI logs "Reading prompt from stdin..." and "Reading additional
-      // input from stdin..." to stderr as informational messages, not errors.
-      // Filter them out so they don't show up as red error bubbles in the UI.
-      const isCodexInfoStderr = def.id === 'codex' && (
-        trimmed.includes('Reading prompt from stdin') ||
-        trimmed.includes('Reading additional input from stdin')
-      );
-      if (trimmed && !isCodexInfoStderr) {
-        this.emitEvent(run, { type: 'error', message: trimmed });
+      // Classify the chunk: Codex info lines are dropped, Claude Code
+      // `[claude-code:*]` diagnostics (e.g. unrecognized_model for any
+      // third-party provider) become `raw` log events, everything else stays
+      // an `error` event. See runtimes/stderr.ts for why.
+      for (const event of classifyStderrChunk(def.id, text)) {
+        this.emitEvent(run, event);
       }
     });
 

--- a/apps/daemon/src/core/runtimes/stderr.ts
+++ b/apps/daemon/src/core/runtimes/stderr.ts
@@ -1,0 +1,59 @@
+import type { AgentEvent } from '@molio/contracts';
+
+/**
+ * Classify a stderr chunk from a stdio-jsonl agent process into the AgentEvents
+ * Molio should emit. Returns an empty array when the chunk carries nothing
+ * actionable.
+ *
+ * Why not "every stderr line is an error": agent CLIs write informational
+ * diagnostics to stderr too. Two known cases:
+ *
+ * 1. Codex CLI logs "Reading prompt from stdin..." / "Reading additional input
+ *    from stdin..." on every run — pure info, must not surface.
+ *
+ * 2. Claude Code (>= 2.1.233) writes `[claude-code:<kind>]` diagnostics to
+ *    stderr in print mode. `[claude-code:unrecognized_model]` fires on EVERY
+ *    request whose model id isn't a built-in Anthropic id — which is always
+ *    the case for third-party providers (DeepSeek, OpenRouter, ...). The
+ *    request still goes out; the line is informational (Claude Code docs tell
+ *    harnesses reading stderr to match on the `[claude-code...]` marker).
+ *    Emitting it as an `error` event shows a red banner AND flips the
+ *    assistant message to streaming:false in the UI, which discards the real
+ *    reply that follows — the customer-visible symptom behind this filter.
+ *    Persist it as `raw` instead: still lands in events.jsonl for diagnosis,
+ *    ignored by the frontend.
+ */
+export function classifyStderrChunk(agentId: string, text: string): AgentEvent[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  // Codex CLI informational stderr — drop entirely (existing behavior).
+  if (agentId === 'codex' && (
+    trimmed.includes('Reading prompt from stdin') ||
+    trimmed.includes('Reading additional input from stdin')
+  )) {
+    return [];
+  }
+
+  // Claude Code print-mode diagnostics — demote marker lines to `raw`, keep
+  // any genuine error lines in the same chunk as an `error` event.
+  if (agentId === 'claude' && trimmed.includes('[claude-code:')) {
+    const events: AgentEvent[] = [];
+    const errorLines: string[] = [];
+    for (const rawLine of trimmed.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      if (line.startsWith('[claude-code:')) {
+        events.push({ type: 'raw', line });
+      } else {
+        errorLines.push(line);
+      }
+    }
+    if (errorLines.length > 0) {
+      events.push({ type: 'error', message: errorLines.join('\n') });
+    }
+    return events;
+  }
+
+  return [{ type: 'error', message: trimmed }];
+}

--- a/apps/daemon/test/core/skill-installer.test.ts
+++ b/apps/daemon/test/core/skill-installer.test.ts
@@ -372,8 +372,18 @@ describe('skill-installer migration', () => {
     installAll(tmpVault);
 
     const installed = fs.readFileSync(path.join(wikiBuildDir, 'SKILL.md'), 'utf-8');
-    // Must now carry a version line (proves the versioned source was copied in).
-    assert.match(installed, /^version:\s*1\.\d+\.\d+$/m, 'version-less dest should be updated to versioned source');
+    // Must now carry the source's version line (proves the versioned source
+    // was copied in). Read the expected version dynamically so this test
+    // survives skill version bumps — the wiki-* five-piece moves versions
+    // together, and the old hardcoded `1.x` regex broke when it hit 2.0.0.
+    const sourceSkillMd = fs.readFileSync(
+      path.join(resolveSkillsSourceDir(), 'wiki-build', 'SKILL.md'),
+      'utf-8',
+    );
+    const sourceVersion = sourceSkillMd.match(/^version:\s*(.+)$/m)?.[1]?.trim();
+    assert.ok(sourceVersion, 'bundled wiki-build SKILL.md should declare a version');
+    const escapedVersion = sourceVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.match(installed, new RegExp(`^version:\\s*${escapedVersion}$`, 'm'), 'version-less dest should be updated to versioned source');
     // And the current body content, not the stale old body.
     assert.ok(
       installed.includes('超长源文件处理'),

--- a/apps/daemon/test/runtimes/stderr-classify.test.ts
+++ b/apps/daemon/test/runtimes/stderr-classify.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyStderrChunk } from '../../src/core/runtimes/stderr.js';
+
+/**
+ * Error-driven test: Claude Code print-mode stderr diagnostics must not be
+ * surfaced as UI errors.
+ *
+ * Customer report: configuring DeepSeek as the Claude Code provider made
+ * every run show the error
+ *   [claude-code:unrecognized_model] {"model":"deepseek-v4-pro","query_source":"sdk"}
+ * while the same setup worked fine in the user's own cmd.
+ *
+ * Root cause: Claude Code >= 2.1.233 writes `[claude-code:*]` diagnostics to
+ * stderr in print mode (`-p`). `unrecognized_model` fires on every request
+ * whose model id isn't a built-in Anthropic id — always the case for
+ * third-party providers. The request still goes out; the line is purely
+ * informational. Molio's stderr handler emitted it as an `error` event, and
+ * the frontend flips the assistant message to streaming:false on error —
+ * discarding the real reply that followed.
+ *
+ * Fix: classifyStderrChunk demotes `[claude-code:*]` lines to `raw` events
+ * (logged to events.jsonl, ignored by the UI) while keeping genuine error
+ * lines as `error` events.
+ */
+
+const CUSTOMER_LINE =
+  '[claude-code:unrecognized_model] {"model":"deepseek-v4-pro","query_source":"sdk"}';
+
+describe('classifyStderrChunk — claude diagnostics', () => {
+  it('reproduces the customer report: unrecognized_model line is NOT an error event', () => {
+    const events = classifyStderrChunk('claude', CUSTOMER_LINE + '\n');
+    assert.ok(events.length > 0, 'diagnostic should still be persisted as raw');
+    for (const ev of events) {
+      assert.notEqual(ev.type, 'error', `must not emit error for: ${CUSTOMER_LINE}`);
+    }
+    assert.deepEqual(events, [{ type: 'raw', line: CUSTOMER_LINE }]);
+  });
+
+  it('demotes any [claude-code:*] marker line, not just unrecognized_model', () => {
+    const events = classifyStderrChunk('claude', '[claude-code:some_future_kind] details\n');
+    assert.deepEqual(events, [{ type: 'raw', line: '[claude-code:some_future_kind] details' }]);
+  });
+
+  it('keeps genuine error lines in a mixed chunk as an error event', () => {
+    const chunk = `${CUSTOMER_LINE}\nAPI Error: 401 invalid api key\n`;
+    const events = classifyStderrChunk('claude', chunk);
+    const raws = events.filter((e) => e.type === 'raw');
+    const errors = events.filter((e) => e.type === 'error');
+    assert.equal(raws.length, 1);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0]!.type === 'error' && errors[0]!.message, 'API Error: 401 invalid api key');
+  });
+
+  it('does not over-filter: marker mentioned mid-line is still an error', () => {
+    const events = classifyStderrChunk('claude', 'Failed, see [claude-code:docs] for help\n');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.type, 'error');
+  });
+
+  it('plain claude stderr without the marker stays an error event', () => {
+    const events = classifyStderrChunk('claude', 'Something actually broke\n');
+    assert.deepEqual(events, [{ type: 'error', message: 'Something actually broke' }]);
+  });
+
+  it('only claude gets the diagnostic demotion — other agents keep error behavior', () => {
+    for (const agentId of ['gemini', 'qwen', 'codex', 'unknown']) {
+      const events = classifyStderrChunk(agentId, CUSTOMER_LINE + '\n');
+      assert.equal(events.length, 1, `agent ${agentId}`);
+      assert.equal(events[0]!.type, 'error', `agent ${agentId}`);
+    }
+  });
+});
+
+describe('classifyStderrChunk — existing behavior preserved', () => {
+  it('codex informational stderr is still dropped', () => {
+    assert.deepEqual(classifyStderrChunk('codex', 'Reading prompt from stdin...\n'), []);
+    assert.deepEqual(classifyStderrChunk('codex', 'Reading additional input from stdin...\n'), []);
+  });
+
+  it('codex real errors still surface', () => {
+    const events = classifyStderrChunk('codex', 'model not found\n');
+    assert.deepEqual(events, [{ type: 'error', message: 'model not found' }]);
+  });
+
+  it('empty / whitespace-only chunks produce no events', () => {
+    assert.deepEqual(classifyStderrChunk('claude', ''), []);
+    assert.deepEqual(classifyStderrChunk('claude', '  \n\t '), []);
+  });
+});


### PR DESCRIPTION
## 问题

客户配置 DeepSeek 后每次对话都报错：

\`\`\`
[claude-code:unrecognized_model] {"model":"deepseek-v4-pro","query_source":"sdk"}
\`\`\`

但同一配置在客户自己的 cmd 里 Claude Code 完全正常。

## 根因

1. Claude Code **2.1.233** 起，print 模式（\`-p\`，即 Molio 的 headless 用法）对非内置 model id（第三方 provider 必然如此）会在**发出请求时**往 stderr 写 \`[claude-code:unrecognized_model]\` 诊断行——请求照常发出，纯信息性（官方 changelog 2.1.233 原文：*written to stderr when a request goes out for a model ID Claude Code doesn't recognize*）。
2. Molio \`RunManager\` 的 stderr handler 把**任何**非空 stderr 当 \`error\` 事件推给前端（此前只过滤过 Codex 两条 info）。
3. 前端收到 \`error\` 事件会置该消息 \`streaming: false\`，而 \`text_delta\` 有 \`if (!msg.streaming) return\` 守卫——**真正到达的回复被整个吞掉**。

所以客户看到的不是"多了个红色气泡"，而是"彻底没有回复"。交互式 cmd 不打这条 print-mode 诊断行，因此客户本地正常。

> 版本门槛说明：该诊断行仅存在于 claude >= 2.1.233；客户本机装的是新版 claude（cmd 在用），Molio 一键安装固定的 2.1.179 反而不会触发。

## 修复

- 新增 \`classifyStderrChunk\`（\`apps/daemon/src/core/runtimes/stderr.ts\`）：
  - claude 的 \`[claude-code:*\` 开头行 → 降级为 \`raw\` 事件（仍写入 events.jsonl 供诊断，前端忽略 \`raw\`）
  - 同一 chunk 里的真错误行 → 保留 \`error\` 事件
  - Codex info 过滤、其他 runtime 的行为完全不变
- \`RunManager\` 的 stderr handler 改用该分类器
- \`apps/daemon/CLAUDE.md\` 补充设计约束："stderr ≠ 错误，升级为 error 前必须确认"

## 测试（错误驱动）

- 新增 \`apps/daemon/test/runtimes/stderr-classify.test.ts\`：9 个用例，含客户原始报错行的逐字复现、混合块、防过度过滤、非 claude runtime 行为回归
- 顺带修复 main 上已红的存量测试：wiki-build bump 到 2.0.0 后 \`skill-installer.test.ts\` 仍硬编码 \`1.x\` 版本正则，改为动态读源版本号

## 验证

- ✅ daemon 单测 1176 全过（含新增 9 例）、desktop 257 全过
- ✅ 全仓 typecheck 通过（contracts / web / daemon / desktop）

🤖 Generated with [Claude Code](https://claude.com/claude-code)