### PR TITLE
fix(web): 思考块流式结束后自动折叠

### DIFF
--- a/apps/web/e2e/helpers/mock-sse.ts
+++ b/apps/web/e2e/helpers/mock-sse.ts
@@ -31,6 +31,18 @@ export const SCRIPTS = {
     { type: 'usage', usage: { input_tokens: 110, output_tokens: 25 }, costUsd: 0.006 },
   ],
 
+  /** Reply with a long thinking block — multiple deltas so the streaming-expanded state is observable */
+  withLongThinking: [
+    { type: 'status', label: 'running' },
+    { type: 'thinking_start' },
+    { type: 'thinking_delta', delta: 'Let me analyze this...' },
+    { type: 'thinking_delta', delta: 'Considering the options...' },
+    { type: 'thinking_delta', delta: 'Weighing trade-offs...' },
+    { type: 'text_delta', delta: 'Based on my analysis, here is the answer.' },
+    { type: 'turn_end', stopReason: 'end_turn' },
+    { type: 'usage', usage: { input_tokens: 200, output_tokens: 30 }, costUsd: 0.01 },
+  ],
+
   /** Reply with thinking block */
   withThinking: [
     { type: 'status', label: 'running' },

--- a/apps/web/e2e/run-progress.spec.ts
+++ b/apps/web/e2e/run-progress.spec.ts
@@ -5,7 +5,7 @@
  * Run progress visibility:
  *   - RunStatusBar 在 tool_use 时出现，完成后消失
  *   - RunStatusBar 各阶段显示正确（thinking / tool / generating）
- *   - ThinkingBlock 流式时自动展开
+ *   - ThinkingBlock 流式时自动展开，流式结束后自动收回
  *   - ToolCard 运行 ≥5s 后自动展开输出，快速工具保持折叠
  *   - ToolCard 显示耗时
  */
@@ -98,14 +98,31 @@ test.describe('Chat — Run progress visibility', () => {
 
   test('ThinkingBlock auto-expands during streaming', async ({ page }) => {
     await unmockAll(page);
-    await mockChatRun(page, { script: SCRIPTS.withThinking, frameDelay: 150 });
+    // 多个 thinking_delta 拉长思考阶段，让「流式中展开」可被稳定观测
+    await mockChatRun(page, { script: SCRIPTS.withLongThinking, frameDelay: 300 });
     await gotoHome(page);
     await sendMessage(page, 'think please');
 
-    // 思考过程应自动展开，内容可见
+    // 思考阶段应自动展开，内容可见
     const content = page.locator('[data-testid="thinking-block"] .thinking-content');
-    await expect(content).toBeVisible({ timeout: 5_000 });
+    await expect(content).toBeVisible({ timeout: 10_000 });
     await expect(content).toContainText('Let me analyze');
+  });
+
+  test('ThinkingBlock auto-collapses after streaming ends', async ({ page }) => {
+    await unmockAll(page);
+    await mockChatRun(page, { script: SCRIPTS.withLongThinking, frameDelay: 200 });
+    await gotoHome(page);
+    await sendMessage(page, 'think please');
+
+    // 思考中自动展开，内容可见
+    const content = page.locator('[data-testid="thinking-block"] .thinking-content');
+    await expect(content).toBeVisible({ timeout: 10_000 });
+    await expect(content).toContainText('Let me analyze');
+
+    // 正文开始输出（streaming 结束）后，思考块应自动收回
+    await expect(page.locator('[data-testid="assistant-prose"]')).toContainText('here is the answer', { timeout: 10_000 });
+    await expect(content).toHaveCount(0, { timeout: 5_000 });
   });
 
   // ── P1: Tool 智能展开 ──

--- a/apps/web/src/components/ThinkingBlock.tsx
+++ b/apps/web/src/components/ThinkingBlock.tsx
@@ -19,9 +19,10 @@ export function ThinkingBlock({ content, streaming }: Props) {
     }
   }, [streaming]);
 
-  // 流式结束 → 重置 manual ref，下次流式重新自动展开
+  // 流式结束 → 自动收回（除非用户手动展开过），并重置 manual ref 供下次流式重新展开
   useEffect(() => {
     if (!streaming) {
+      if (!manualRef.current) setExpanded(false);
       manualRef.current = false;
     }
   }, [streaming]);


### PR DESCRIPTION
## 背景

ThinkingBlock 当前策略是「**流式时自动展开，但结束后从不自动折叠**」：

- 每轮思考块在流式阶段被自动展开
- 思考结束（正文开始输出）后只重置 manual ref，`expanded` 一直为 true
- 于是本会话内跑过的每一轮思考块都永久停在展开态，多轮累积后「全部摊开、很乱」

## 改动

**[`ThinkingBlock.tsx`](apps/web/src/components/ThinkingBlock.tsx)** — 流式结束 effect 里新增自动收回：

```tsx
useEffect(() => {
  if (!streaming) {
    if (!manualRef.current) setExpanded(false);   // 新增：流式结束自动收回
    manualRef.current = false;
  }
}, [streaming]);
```

行为变化：
- 思考中 → 展开（原行为保留，看进度）
- 正文开始输出（streaming 结束）→ **自动收回**，给正文腾空间
- 用户手动展开/折叠过的块不受自动逻辑干扰

## 测试

- 新增 E2E「ThinkingBlock auto-collapses after streaming ends」断言流式结束后自动收回
- 原「auto-expands」测试用多 thinking_delta 的长思考脚本（`SCRIPTS.withLongThinking`）拉长可观测窗口，避免 150ms 瞬态窗口的轮询竞态
- `run-progress.spec.ts` 全量 9 个测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)