### PR TITLE
fix(kb): 「+」新建文件夹统一在根目录创建 + 树空白区右键新建

### DIFF
--- a/apps/web/e2e/kb-create-at-root.spec.ts
+++ b/apps/web/e2e/kb-create-at-root.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * @area kb
+ * @priority P1
+ *
+ * Toolbar "+" and blank-area right-click both create at the vault ROOT —
+ * regardless of which file is currently selected (fix for "新建文件夹在根目录
+ * 创建失败").
+ *
+ * Regression: before the fix, "+ → 新建文件夹" silently targeted the SELECTED
+ * file's parent dir (createParentDir), so with sub/note.md selected the dialog
+ * said "在 sub 下新建文件夹" and the folder landed inside sub/ — invisible at
+ * root. The blank-area right-click entry did not exist at all.
+ *
+ * Prerequisites: `pnpm dev` running (daemon :3100, web :5173).
+ */
+import { test, expect } from '@playwright/test';
+import { createTempVault, cleanupTempVault, type TempVault } from './helpers/cleanup';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const WEB = 'http://localhost:5173';
+
+let vault: TempVault;
+
+test.describe('KB root-level folder creation', () => {
+  test.beforeAll(async () => {
+    vault = await createTempVault('e2e-kb-create-at-root');
+    // Remove the seed test.md so the tree only has the structure we build here.
+    fs.unlinkSync(path.join(vault.path, 'test.md'));
+    // sub/note.md — a file inside a subfolder, used to simulate a selected file
+    // whose parent is NOT the vault root.
+    fs.mkdirSync(path.join(vault.path, 'sub'), { recursive: true });
+    fs.writeFileSync(path.join(vault.path, 'sub', 'note.md'), '# note\n');
+  });
+
+  test.afterAll(async () => {
+    if (vault) await cleanupTempVault(vault);
+  });
+
+  test('toolbar "+ → 新建文件夹" creates at root even when a subfolder file is selected', async ({ page }) => {
+    await page.goto(`${WEB}/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.kb-file-panel')).toBeVisible({ timeout: 5_000 });
+
+    // Select a file inside a subfolder (the pre-bug trigger state).
+    const subLabel = page.locator('.kb-tree-group-label').filter({ hasText: 'sub' });
+    const noteFile = page.locator('.kb-tree-item').filter({ hasText: 'note.md' });
+    if (!(await noteFile.isVisible().catch(() => false))) {
+      await subLabel.click(); // expand sub
+    }
+    await expect(noteFile).toBeVisible({ timeout: 5_000 });
+    await noteFile.click();
+    await page.waitForTimeout(300);
+
+    // Open "+ → 新建文件夹".
+    await page.locator('[data-testid="kb-btn-create"]').click();
+    await expect(page.locator('[data-testid="kb-create-dropdown"]')).toBeVisible({ timeout: 5_000 });
+    await page.locator('[data-testid="kb-create-folder"]').click();
+    const dialog = page.locator('.kb-modal');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // The dialog must target the ROOT — no "在 sub 下新建文件夹" title.
+    const title = (await dialog.locator('.kb-modal-header h2').textContent())?.trim();
+    expect(title).toBe('新建文件夹');
+
+    const folderName = `__root_${Date.now() % 100000}__`;
+    await dialog.locator('input').fill(folderName);
+    await dialog.locator('.kb-btn-primary').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // Created at the vault root (visible as a top-level tree group).
+    await expect(
+      page.locator('.kb-tree-group-label').filter({ hasText: folderName }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // And on disk: at the vault root, NOT inside sub/.
+    expect(fs.existsSync(path.join(vault.path, folderName))).toBe(true);
+    expect(fs.existsSync(path.join(vault.path, 'sub', folderName))).toBe(false);
+  });
+
+  test('right-click tree blank area → "新建文件夹" creates at root', async ({ page }) => {
+    await page.goto(`${WEB}/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.kb-file-panel')).toBeVisible({ timeout: 5_000 });
+
+    // Right-click on the tree's blank area (bottom-left of the scroll region,
+    // away from any node).
+    const box = await page.locator('.kb-tree-scroll').boundingBox();
+    expect(box).not.toBeNull();
+    await page.mouse.click(box!.x + 30, box!.y + box!.height - 8, { button: 'right' });
+
+    // Root-level context menu appears.
+    await expect(page.locator('.ctx-menu')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('[data-testid="kb-ctx-new-folder-root"]')).toBeVisible();
+    await page.locator('[data-testid="kb-ctx-new-folder-root"]').click();
+
+    // Dialog targets the root.
+    const dialog = page.locator('.kb-modal');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    const title = (await dialog.locator('.kb-modal-header h2').textContent())?.trim();
+    expect(title).toBe('新建文件夹');
+
+    const folderName = `__blank_${Date.now() % 100000}__`;
+    await dialog.locator('input').fill(folderName);
+    await dialog.locator('.kb-btn-primary').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // Created at the vault root.
+    await expect(
+      page.locator('.kb-tree-group-label').filter({ hasText: folderName }),
+    ).toBeVisible({ timeout: 5_000 });
+    expect(fs.existsSync(path.join(vault.path, folderName))).toBe(true);
+  });
+});

--- a/apps/web/src/components/kb/KbFilePanel.tsx
+++ b/apps/web/src/components/kb/KbFilePanel.tsx
@@ -30,6 +30,9 @@ interface KbFilePanelProps {
   onAddToWiki?: (path: string, isDirectory: boolean) => void;
   /** Context menu handler — fired on right-click of any tree node */
   onContextMenu?: (node: TreeNode, e: React.MouseEvent) => void;
+  /** Context menu handler — fired on right-click of the tree's blank area.
+   *  Node right-clicks stopPropagation, so this only fires on empty space. */
+  onBlankContextMenu?: (e: React.MouseEvent) => void;
   /** Path of node being renamed (null = none) */
   renamingPath?: string | null;
   /** Confirm rename: (oldPath, newName) */
@@ -63,6 +66,7 @@ export const KbFilePanel = forwardRef<KbFilePanelHandle, KbFilePanelProps>(funct
   onVaultClick,
   onAddToWiki,
   onContextMenu,
+  onBlankContextMenu,
   renamingPath,
   onRenameComplete,
   onRenameCancel,
@@ -100,11 +104,12 @@ export const KbFilePanel = forwardRef<KbFilePanelHandle, KbFilePanelProps>(funct
     setCreateMenuOpen(next);
   };
 
-  /** Parent dir for create actions — the selected file's directory (or root). */
-  const createParentDir = () =>
-    selectedFile && selectedFile.includes('/')
-      ? selectedFile.slice(0, selectedFile.lastIndexOf('/'))
-      : undefined;
+  /** Blank-area right-click on the tree opens the root create menu. Node
+   *  right-clicks stopPropagation in KbFileTree, so this only fires on empty space. */
+  const handleTreeBlankContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    onBlankContextMenu?.(e);
+  }, [onBlankContextMenu]);
 
   // Bumped each time the user hits "locate" — KbFileTree scrolls the active
   // file into view when this token changes (see TreeNodeItem effect).
@@ -359,7 +364,7 @@ export const KbFilePanel = forwardRef<KbFilePanelHandle, KbFilePanelProps>(funct
                 className="kb-create-item"
                 role="menuitem"
                 data-testid="kb-create-note"
-                onClick={() => { setCreateMenuOpen(false); setCreateMenuPos(null); onNewFile(createParentDir()); }}
+                onClick={() => { setCreateMenuOpen(false); setCreateMenuPos(null); onNewFile(); }}
               >
                 {/* file-plus */}
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -375,7 +380,7 @@ export const KbFilePanel = forwardRef<KbFilePanelHandle, KbFilePanelProps>(funct
                 className="kb-create-item"
                 role="menuitem"
                 data-testid="kb-create-folder"
-                onClick={() => { setCreateMenuOpen(false); setCreateMenuPos(null); onNewFolder(createParentDir()); }}
+                onClick={() => { setCreateMenuOpen(false); setCreateMenuPos(null); onNewFolder(); }}
               >
                 {/* folder-plus */}
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -504,7 +509,7 @@ export const KbFilePanel = forwardRef<KbFilePanelHandle, KbFilePanelProps>(funct
       )}
 
       {/* File tree */}
-      <div className="kb-tree-scroll">
+      <div className="kb-tree-scroll" onContextMenu={handleTreeBlankContextMenu}>
         <KbFileTree
           nodes={sortedTree}
           selectedFile={selectedFile}

--- a/apps/web/src/components/kb/KnowledgeBasePage.tsx
+++ b/apps/web/src/components/kb/KnowledgeBasePage.tsx
@@ -186,7 +186,7 @@ export function KnowledgeBasePage({ agentId, chatPanelRef }: KnowledgeBasePagePr
   }, [location.state, kb.vaults, kb.activeVault?.id, navigate]);
 
   // Context menu state
-  const [ctxMenu, setCtxMenu] = useState<{ node: TreeNode; x: number; y: number } | null>(null);
+  const [ctxMenu, setCtxMenu] = useState<{ node: TreeNode | null; x: number; y: number } | null>(null);
 
   // Inline rename state
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
@@ -624,6 +624,11 @@ export function KnowledgeBasePage({ agentId, chatPanelRef }: KnowledgeBasePagePr
     setCtxMenu({ node, x: e.clientX, y: e.clientY });
   }, []);
 
+  /** Right-click on the tree's blank area → root-level create menu. */
+  const handleBlankContextMenu = useCallback((e: React.MouseEvent) => {
+    setCtxMenu({ node: null, x: e.clientX, y: e.clientY });
+  }, []);
+
   const handleCloseCtxMenu = useCallback(() => {
     setCtxMenu(null);
   }, []);
@@ -652,6 +657,23 @@ export function KnowledgeBasePage({ agentId, chatPanelRef }: KnowledgeBasePagePr
   const getContextMenuItems = useCallback((): MenuItem[] => {
     if (!ctxMenu) return [];
     const { node } = ctxMenu;
+
+    // Right-click on the tree's blank area → create at the vault root.
+    if (node === null) {
+      return [
+        {
+          label: '新建文件',
+          testid: 'kb-ctx-new-file-root',
+          onClick: () => handleNewFile(),
+        },
+        {
+          label: '新建文件夹',
+          testid: 'kb-ctx-new-folder-root',
+          onClick: () => handleNewFolder(),
+        },
+      ];
+    }
+
     const items: MenuItem[] = [];
 
     if (node.type === 'file') {
@@ -970,6 +992,7 @@ export function KnowledgeBasePage({ agentId, chatPanelRef }: KnowledgeBasePagePr
         onVaultClick={() => kb.setShowVaultSwitcher(true)}
         onAddToWiki={hasVault ? handleIngestFile : undefined}
         onContextMenu={handleContextMenu}
+        onBlankContextMenu={handleBlankContextMenu}
         renamingPath={renamingPath}
         onRenameComplete={handleRenameComplete}
         onRenameCancel={handleRenameCancel}

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -401,7 +401,7 @@ const zh: Record<string, string> = {
   'kb.locateFile': '在目录中定位',
   'kb.locateFileNeedFile': '请先打开一个文件',
   'kb.newNote': '新建笔记',
-  'kb.newFolder': '新建子文件夹',
+  'kb.newFolder': '新建文件夹',
   'kb.create': '新建',
   'kb.newWindow': '新窗口',
   'kb.collapseAll': '折叠全部',


### PR DESCRIPTION
## 问题

知识库根目录下通过工具条「+」→「新建文件夹」创建文件夹失败——输入名称确认后无反应，文件夹没有出现在根目录。

## 根因

`createParentDir()`（#205 引入）让「+」下的新建操作目标变为**当前选中文件的父目录**，而非 vault 根目录。知识库 Tab 持久化会自动恢复选中 `raw/xxx.txt`，于是「新建文件夹」实际创建到了 `raw/` 下，根目录看不到。

## 修复

1. **工具条「+」统一在根目录新建**：移除 `createParentDir()`，「新建文件」「新建文件夹」始终作用于 vault 根目录，与用户直觉一致。
2. **树空白区右键新建**：目录树空白处右键 → 「新建文件 / 新建文件夹」（根目录），与右键文件夹弹「新建子文件夹」（文件夹内）逻辑一致、对称。
3. **文案**：「+」菜单项「新建子文件夹」→「新建文件夹」。

## 测试

- 新增 `apps/web/e2e/kb-create-at-root.spec.ts`（P1 / area: kb）：
  - 工具条「+」→「新建文件夹」：选中子文件夹内文件时，弹窗标题为「新建文件夹」（不再有「在 sub 下」），文件夹创建在 vault 根、**不在** sub/ 下。
  - 树空白区右键 → 「新建文件夹」：创建在 vault 根。
- 相关 E2E 全绿：kb-folder-ops、kb-folder-root-drop、multi-window、publish-flow、kb-create-at-root（15 tests）。

## 验证流程

修复前：先写回归测试复现失败 → 确认测试失败；修复后：恢复测试确认通过。revert 修复 → 新 spec 失败；恢复修复 → 新 spec 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)