### PR TITLE
fix(web): 修复桌面端付费资源提示「支付服务未开通」— PAY_BASE 补默认值

### DIFF
--- a/apps/web/e2e/resources.spec.ts
+++ b/apps/web/e2e/resources.spec.ts
@@ -7,9 +7,10 @@ import { gotoHome, clickNav } from './helpers/navigation';
  *
  * E2E tests for the resources module (list / filters / detail / not-found).
  *
- * The catalog is bundled from apps/landing-page/resources-data.js (shared
- * single source of truth with the landing page). Counts are asserted
- * relatively (all = paid + free) so adding a resource does not break tests.
+ * The catalog comes from the cloud market via daemon /api/market/listings
+ * (since #233; the old static apps/landing-page/resources-data.js bridge is
+ * retired). Counts are asserted relatively (all = paid + free) so adding a
+ * resource does not break tests.
  *
  * NOTE: the pay button is intentionally NOT clicked here — it would create
  * real orders against pay.molio.cn. The pay modal is covered manually.
@@ -72,6 +73,54 @@ test.describe('Resources page', () => {
     await expect(page.locator('.resources-shell')).toBeVisible();
     await expect(page.locator('.resources-tip-box')).toBeVisible();
     await expect(page.locator('[data-testid="resources-back"]')).toBeVisible();
+  });
+});
+
+/**
+ * 支付可用性回归（2026-08：#233 移除 resources-data.js 的 side-effect import 后，
+ * web 端 window.MOLIO_PAY_BASE 无人注入，桌面端付费资源静默降级为
+ * 「支付服务未开通，请直接联系购买」，官网正常 —— 见 resources.ts 的默认值修复）。
+ *
+ * 只断言文案形态（按钮带「微信支付」+ 侧栏为扫码说明），绝不点击购买按钮。
+ */
+test.describe('Pay base availability', () => {
+  test('paid detail page offers WeChat pay instead of contact-us fallback', async ({ page }) => {
+    // mock 一个付费条目，不依赖开发环境云端目录里是否有付费资源
+    await page.route('**/api/market/listings/pay-regression', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'pay-regression',
+          source: 'official',
+          name: '支付回归用条目',
+          icon: '💰',
+          tint: '#f5c518',
+          summary: '回归测试专用付费条目',
+          overview: [],
+          highlights: [],
+          tags: [],
+          previews: [],
+          version: '1.0.0',
+          priceCents: 100,
+          payUrl: '',
+          author: 'Molio E2E',
+          fileSize: null,
+          publishedAt: null,
+        }),
+      }),
+    );
+
+    await page.goto('/resources/pay-regression');
+    await expect(page.locator('.resources-detail-head h1')).toHaveText('支付回归用条目');
+
+    // 按钮文案含「微信支付 ¥1」（未登录带「登录后」前缀，登录与否都命中）
+    await expect(page.locator('[data-testid="resource-buy-pay-regression"]')).toContainText(
+      '微信支付 ¥1',
+    );
+    // 侧栏说明为扫码支付文案，而非「支付服务未开通，请直接联系购买」
+    await expect(page.locator('.resources-side-note')).toContainText('扫码支付成功后自动解锁下载');
+    await expect(page.locator('.resources-side-note')).not.toContainText('支付服务未开通');
   });
 });
 

--- a/apps/web/src/data/resources.ts
+++ b/apps/web/src/data/resources.ts
@@ -5,8 +5,16 @@
  */
 import type { MarketListing } from '@molio/contracts';
 
-/** 微信支付后端地址；空串表示未开通，付费资源降级为“联系购买” */
-export const PAY_BASE: string = window.MOLIO_PAY_BASE ?? '';
+/**
+ * 微信支付后端地址。默认官网支付后端（与 landing-page/resources-data.js 一致，
+ * CORS 已放行 *）；window.MOLIO_PAY_BASE 可覆盖——显式注入空串表示未开通，
+ * 付费资源降级为“联系购买”。
+ *
+ * 历史教训（2026-08）：早期靠 side-effect import resources-data.js 顺带注入该值，
+ * 社区市场重构移除 import 后桌面端静默降级为「支付服务未开通」，官网不受影响。
+ * 因此默认值必须在这里显式声明，不能依赖外部注入。
+ */
+export const PAY_BASE: string = window.MOLIO_PAY_BASE ?? 'https://pay.molio.cn';
 
 /** 官网根：预览图如为相对路径(兼容旧数据)则拼绝对 URL */
 export const SITE_BASE = 'https://molio.cn';


### PR DESCRIPTION
## 问题

桌面端购买付费资源时提示「支付服务未开通，请直接联系购买」，而官网 landing-page 购买正常（弹登录 → 出二维码）。

## 根因

两端都读 `window.MOLIO_PAY_BASE`：

- 官网：`resources-data.js` 自带 `window.MOLIO_PAY_BASE = 'https://pay.molio.cn'` → 正常
- 桌面端：早期靠 `resources.ts` side-effect import `resources-data.js` 顺带注入；#233 社区市场重构把数据桥改为云端市场 API、移除了该 import → `PAY_BASE` 变空串 → `useResourcePay` 走 `no-base` 分支 → 静默降级为「联系购买」

## 修复

- `apps/web/src/data/resources.ts`：`PAY_BASE` 默认 `https://pay.molio.cn`（与官网一致，CORS 已放行 `*`），保留 `window.MOLIO_PAY_BASE` 覆盖能力与「显式空串 = 未开通」语义，注释留历史教训
- `apps/web/e2e/resources.spec.ts`：新增 **Pay base availability** 回归用例——route mock 付费条目，断言购买按钮显示「微信支付 ¥1」、侧栏为扫码说明而非「支付服务未开通」；遵守既有纪律绝不点击购买按钮（避免真实下单）。顺带修正 #233 后已过时的目录来源注释

## 验证

- ✅ 回归用例在旧代码上失败（按钮显示「联系购买」）、修复后通过（错误驱动测试流程）
- ✅ `tsc --noEmit` 通过
- ℹ️ 单独跑 `resources.spec.ts` 时「列表渲染」用例失败为预先存在的环境问题（本地全新云端市场无条目；CI 全量运行时 `market-community.spec.ts` 先发布条目喂饱目录），未修改代码上失败更多（4 vs 1），与本改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)