### PR TITLE
fix(daemon): Gemini CLI 0.57 启动横幅误报为错误 — stderr 分类降级为 raw

### DIFF
--- a/apps/daemon/src/core/runtimes/stderr.ts
+++ b/apps/daemon/src/core/runtimes/stderr.ts
@@ -22,6 +22,16 @@ import type { AgentEvent } from '@molio/contracts';
  *    reply that follows — the customer-visible symptom behind this filter.
  *    Persist it as `raw` instead: still lands in events.jsonl for diagnosis,
  *    ignored by the frontend.
+ *
+ * 3. Gemini CLI (observed on 0.57.0) prints headless startup banners to
+ *    stderr on EVERY run: the YOLO approval notice ("YOLO mode is enabled…",
+ *    emitted twice because Molio passes both --yolo and --skip-trust), the
+ *    ripgrep fallback note, and one "Skill … is overriding the built-in
+ *    skill." line per shadowed builtin skill. The run itself succeeds — the
+ *    reply arrives via stdout stream-json — but surfacing these banners as
+ *    `error` events shows a red banner and makes the run look failed.
+ *    Same treatment as the Claude marker: demote known banner lines to
+ *    `raw`, keep anything else as an `error` event.
  */
 export function classifyStderrChunk(agentId: string, text: string): AgentEvent[] {
   const trimmed = text.trim();
@@ -33,6 +43,27 @@ export function classifyStderrChunk(agentId: string, text: string): AgentEvent[]
     trimmed.includes('Reading additional input from stdin')
   )) {
     return [];
+  }
+
+  // Gemini CLI headless startup banners — demote known informational lines
+  // to `raw`, keep any genuine error lines in the same chunk as an `error`
+  // event.
+  if (agentId === 'gemini') {
+    const events: AgentEvent[] = [];
+    const errorLines: string[] = [];
+    for (const rawLine of trimmed.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      if (isGeminiInfoLine(line)) {
+        events.push({ type: 'raw', line });
+      } else {
+        errorLines.push(line);
+      }
+    }
+    if (errorLines.length > 0) {
+      events.push({ type: 'error', message: errorLines.join('\n') });
+    }
+    return events;
   }
 
   // Claude Code print-mode diagnostics — demote marker lines to `raw`, keep
@@ -56,4 +87,20 @@ export function classifyStderrChunk(agentId: string, text: string): AgentEvent[]
   }
 
   return [{ type: 'error', message: trimmed }];
+}
+
+/**
+ * Gemini CLI stderr lines that are pure startup diagnostics (observed on
+ * 0.57.0 headless runs). Deliberately NOT matched:
+ * "Approval mode overridden to \"default\" because the current folder is not
+ * trusted." — that one signals yolo being silently disabled, which genuinely
+ * breaks a headless run (tool calls can't be auto-approved), so it must keep
+ * surfacing as an error.
+ */
+function isGeminiInfoLine(line: string): boolean {
+  return (
+    line.startsWith('YOLO mode is enabled') ||
+    line.startsWith('Ripgrep is not available') ||
+    /is overriding the built-in skill\.?$/.test(line)
+  );
 }

--- a/apps/daemon/test/runtimes/stderr-classify.test.ts
+++ b/apps/daemon/test/runtimes/stderr-classify.test.ts
@@ -72,6 +72,81 @@ describe('classifyStderrChunk — claude diagnostics', () => {
   });
 });
 
+/**
+ * Error-driven test: Gemini CLI 0.57.0 headless startup banners must not be
+ * surfaced as UI errors.
+ *
+ * Customer report: after installing Gemini CLI 0.57.0 and picking it as the
+ * default agent, every run showed a red error banner quoting
+ *   YOLO mode is enabled. All tool calls will be automatically approved.
+ *   Ripgrep is not available. Falling back to GrepTool.
+ *   Skill "skill-creator" from "..." is overriding the built-in skill.
+ * even though the run itself completed successfully (reply + usage + turn_end
+ * all present in events.jsonl).
+ *
+ * Root cause: Gemini CLI 0.57.0 prints these informational startup banners to
+ * stderr on every headless run (the YOLO notice twice — once per --yolo and
+ * once per --skip-trust). classifyStderrChunk had no gemini rule, so the
+ * whole chunk became one `error` event; the frontend shows a red banner and
+ * flips streaming:false, making a successful run look failed.
+ *
+ * Fix: gemini branch demotes the known banner lines to `raw` events while
+ * keeping genuine error lines as `error` events.
+ */
+const GEMINI_STARTUP_CHUNK = [
+  'YOLO mode is enabled. All tool calls will be automatically approved.',
+  'YOLO mode is enabled. All tool calls will be automatically approved.',
+  'Ripgrep is not available. Falling back to GrepTool.',
+  'Skill "skill-creator" from "C:\\Users\\dluty\\.agents\\skills\\skill-creator\\SKILL.md" is overriding the built-in skill.',
+].join('\n');
+
+describe('classifyStderrChunk — gemini startup banners', () => {
+  it('reproduces the customer report: 0.57.0 startup chunk emits no error event', () => {
+    const events = classifyStderrChunk('gemini', GEMINI_STARTUP_CHUNK + '\n');
+    assert.ok(events.length > 0, 'banners should still be persisted as raw');
+    for (const ev of events) {
+      assert.notEqual(ev.type, 'error', `must not emit error for: ${JSON.stringify(ev)}`);
+    }
+    assert.equal(events.filter((e) => e.type === 'raw').length, 4);
+  });
+
+  it('demotes each banner line individually', () => {
+    assert.deepEqual(
+      classifyStderrChunk('gemini', 'YOLO mode is enabled. All tool calls will be automatically approved.\n'),
+      [{ type: 'raw', line: 'YOLO mode is enabled. All tool calls will be automatically approved.' }],
+    );
+    assert.deepEqual(
+      classifyStderrChunk('gemini', 'Ripgrep is not available. Falling back to GrepTool.\n'),
+      [{ type: 'raw', line: 'Ripgrep is not available. Falling back to GrepTool.' }],
+    );
+    assert.deepEqual(
+      classifyStderrChunk('gemini', 'Skill "x" from "C:\\a\\b" is overriding the built-in skill.\n'),
+      [{ type: 'raw', line: 'Skill "x" from "C:\\a\\b" is overriding the built-in skill.' }],
+    );
+  });
+
+  it('keeps genuine error lines in a mixed chunk as an error event', () => {
+    const chunk = `Ripgrep is not available. Falling back to GrepTool.\nAPI key not found. Please run gemini auth.\n`;
+    const events = classifyStderrChunk('gemini', chunk);
+    const raws = events.filter((e) => e.type === 'raw');
+    const errors = events.filter((e) => e.type === 'error');
+    assert.equal(raws.length, 1);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0]!.type === 'error' && errors[0]!.message, 'API key not found. Please run gemini auth.');
+  });
+
+  it('trust-degradation warning stays an error (yolo silently disabled)', () => {
+    const line = 'Approval mode overridden to "default" because the current folder is not trusted.';
+    const events = classifyStderrChunk('gemini', line + '\n');
+    assert.deepEqual(events, [{ type: 'error', message: line }]);
+  });
+
+  it('plain gemini stderr without known banners stays an error event', () => {
+    const events = classifyStderrChunk('gemini', 'Something actually broke\n');
+    assert.deepEqual(events, [{ type: 'error', message: 'Something actually broke' }]);
+  });
+});
+
 describe('classifyStderrChunk — existing behavior preserved', () => {
   it('codex informational stderr is still dropped', () => {
     assert.deepEqual(classifyStderrChunk('codex', 'Reading prompt from stdin...\n'), []);


### PR DESCRIPTION
Gemini CLI 0.57.0 每次 headless 运行都往 stderr 打印启动横幅
（YOLO 提示×2、Ripgrep 回退、Skill 覆盖提示）。classifyStderrChunk 无 gemini 规则，整个 chunk 被当作一条 error 事件上抛：前端弹红色
横幅并把消息置为 streaming:false，让一次成功的运行看起来像失败
（events.jsonl 里 reply/usage/turn_end 齐全）。

新增 gemini 分支：按行匹配已知横幅降级为 raw（仍落 events.jsonl
供诊断），真实错误行保留为 error。刻意不匹配 "Approval mode
overridden ... not trusted" —— 那意味着 yolo 被静默禁用，会真卡死 headless 运行，必须继续上抛。

复现报文取自真实运行日志（~/.molio/runs/9a3f5692）。