### PR TITLE
fix(web): 登录弹窗遮罩点击不再关闭 — 仅右上角 × 可关闭

### DIFF
--- a/apps/landing-page/auth.js
+++ b/apps/landing-page/auth.js
@@ -196,7 +196,8 @@
     document.body.appendChild(el);
     modal = el;
 
-    el.addEventListener('click', function (e) { if (e.target === el) cancelLogin(); });
+    // 关闭只认右上角 ×：点遮罩（卡片外暗区）不关闭。验证码步骤用户常在等邮件时
+    // 误点弹窗外，遮罩关闭会丢掉已输入的邮箱/验证码，体验恶劣——勿恢复遮罩关闭。
     el.querySelector('#auth-close').addEventListener('click', cancelLogin);
 
     var emailInput = el.querySelector('#auth-email');

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -81,6 +81,25 @@ test.describe('Account panel (always available)', () => {
     await expect(page.locator(ACCOUNT_MODAL)).not.toBeVisible();
   });
 
+  // Regression (2026-08-31): 遮罩（卡片外暗区）点击曾直接关闭面板——用户在验证码
+  // 步骤等邮件时误点弹窗外，已输入的邮箱/验证码全部丢失。现在只认右上角 ×。
+  test('clicking the overlay backdrop does not close the account modal', async ({
+    page,
+  }) => {
+    await gotoHome(page);
+    await openAccount(page);
+    // overlay 全屏铺满、模态卡居中：左上角坐标必落在遮罩自身区域
+    await page
+      .locator('.kb-overlay:has(.account-modal)')
+      .click({ position: { x: 12, y: 12 } });
+    await expect(page.locator(ACCOUNT_MODAL)).toBeVisible();
+    // 表单状态未丢：邮箱输入框仍在（验证码步骤同理，共用同一遮罩）
+    await expect(page.locator('[data-testid="account-email-input"]')).toBeVisible();
+    // × 仍是有效关闭入口
+    await page.locator('[data-testid="account-modal-close"]').click();
+    await expect(page.locator(ACCOUNT_MODAL)).not.toBeVisible();
+  });
+
   // Regression (2026-08-17): base.css 的全局 input{width:100%} 曾把协议勾选框
   // 撑满整行——勾选框居中、协议文案被挤出模态框右边界不可见。
   test('terms row: checkbox stays compact and links fit inside the modal', async ({

--- a/apps/web/src/components/account/AccountModal.tsx
+++ b/apps/web/src/components/account/AccountModal.tsx
@@ -264,11 +264,10 @@ export function AccountModal({ show, onClose, onLoggedIn, elevated = false }: Ac
     );
   }
 
+  // 关闭只认右上角 ×：点遮罩（卡片外暗区）不关闭。验证码步骤用户常在等邮件时
+  // 误点弹窗外，遮罩关闭会丢掉已输入的邮箱/验证码——勿恢复遮罩关闭。
   return (
-    <div
-      className={`kb-overlay show${elevated ? ' kb-overlay-elevated' : ''}`}
-      onClick={(e) => e.target === e.currentTarget && onClose()}
-    >
+    <div className={`kb-overlay show${elevated ? ' kb-overlay-elevated' : ''}`}>
       <div className="kb-modal account-modal">
         {/* 无标题栏：关闭按钮悬浮右上角，面板空间全留给内容 */}
         <button


### PR DESCRIPTION
## Summary

- **问题**：验证码登录是「邮箱 → 验证码」两步表单，用户在等邮件期间误点弹窗外（遮罩暗区），整个面板被关闭，已输入的邮箱/验证码全部丢失。官网 molio.cn 登录弹窗与应用内账号面板两处都有此行为。
- **修复**：两处一并移除遮罩点击关闭，关闭只认右上角 ×：
  - `apps/landing-page/auth.js`（官网登录弹窗，删掉 `e.target === el → cancelLogin()` 监听）
  - `apps/web/src/components/account/AccountModal.tsx`（应用内账号面板，删掉 overlay `onClick`）
  - 均留下「勿恢复遮罩关闭」注释说明原因
- **E2E 回归**：`auth.spec.ts` 新增「点击遮罩不关闭面板、× 仍可关闭」用例（放在 always-available 块，不受云端配置门禁影响）

## Test plan

- [x] `pnpm typecheck`（contracts 先 build）全绿
- [x] 新增回归用例在隔离环境（独立端口 + 独立 USERPROFILE，不碰用户本机登录态）两次跑通
- [x] auth.spec 全套 9 用例：8 绿；剩余 1 条失败为本机已知的 Vite dev 请求风暴 flake（卡在「加载中…」，单独跑/分块跑均通过），与本改动无关
- [ ] **注意**：官网 molio.cn 侧的修复需手动部署 landing-page 后才生效