### PR TITLE
fix(ci): CI install 走 npmjs.org 而非 npmmirror — 规避 app-builder-bin 下载超时

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          # CI runners are outside China — use the official npm registry instead of
+          # npmmirror.com to avoid CDN routing issues (e.g. app-builder-bin timeouts).
+          npm_config_registry: https://registry.npmjs.org
 
       - name: Build all packages
         run: pnpm build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          # CI runners are outside China — use the official npm registry instead of
+          # npmmirror.com to avoid CDN routing issues (e.g. app-builder-bin timeouts).
+          npm_config_registry: https://registry.npmjs.org
 
       - name: Build all packages
         run: pnpm build

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,6 +27,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          # CI runners are outside China — use the official npm registry instead of
+          # npmmirror.com to avoid CDN routing issues (e.g. app-builder-bin timeouts).
+          npm_config_registry: https://registry.npmjs.org
 
       - name: Build all packages
         run: pnpm build
@@ -78,6 +82,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          # CI runners are outside China — use the official npm registry instead of
+          # npmmirror.com to avoid CDN routing issues (e.g. app-builder-bin timeouts).
+          npm_config_registry: https://registry.npmjs.org
 
       - name: Build all packages
         run: pnpm build


### PR DESCRIPTION
## 问题

PR check 在 `pnpm install` 时挂掉：
```
GET https://registry.npmmirror.com/app-builder-bin/...tgz error (23)
TimeoutError: The operation was aborted due to timeout
```

根因：根 `.npmrc` 把 `registry` 全局锁成 `https://registry.npmmirror.com`。但 CI runner 在境外，官方 `npmjs.org` 更快更稳；走 npmmirror 反而对 `app-builder-bin`（electron-builder 的大二进制包）有 CDN 路由问题而导致超时。

## 修复

给以下 workflow 的 `pnpm install` 步骤加 `npm_config_registry: https://registry.npmjs.org` 覆盖（对齐 `release.yml` 已有做法）：
- `pr-check.yml`（build-and-test + e2e-affected 两处）
- `e2e.yml`
- `cloud.yml`

`.npmrc` 里的 npmmirror **保留**（供国内 Docker 构建 / 本地用），仅 CI 环境切官方源。