### PR TITLE
feat(market): 升版表单与发布对齐 + 更新入口移到 KB 页

### DIFF
--- a/apps/cloud/src/market/routes.ts
+++ b/apps/cloud/src/market/routes.ts
@@ -75,7 +75,7 @@ export function marketRoutes(deps: MarketRoutesDeps, config: CloudConfig, now: (
     const denied = guardBody(c); if (denied) return denied;
     const p = bearer(c);
     if (!p) return c.json({ error: 'invalid_token' }, 401);
-    const body = await c.req.json().catch(() => null) as { previews?: { ext: string; size: number }[]; priceCents?: number } | null;
+    const body = await c.req.json().catch(() => null) as { previews?: { ext: string; size: number }[]; priceCents?: number; name?: string; summary?: string; icon?: string; tags?: string[] } | null;
     try { return c.json(await service.update(p.sub, c.req.param('id'), body ?? {}), 200); } catch (e) { return handle(c, e); }
   });
 

--- a/apps/cloud/src/market/service.ts
+++ b/apps/cloud/src/market/service.ts
@@ -216,13 +216,25 @@ export class MarketService {
     }
     const updated = await this.deps.store.updateListing(rec.id, {
       version: bumpVersion(rec.version), previews, pendingUpdate: null,
+      publishedAt: this.now,
+      ...(pend.name !== undefined ? { name: pend.name } : {}),
+      ...(pend.summary !== undefined ? { summary: pend.summary } : {}),
+      ...(pend.icon !== undefined ? { icon: pend.icon } : {}),
+      ...(pend.tags !== undefined ? { tags: pend.tags } : {}),
     }, this.now);
     return this.toMy(updated!);
   }
 
   // ── 更新版本（发起）──
 
-  async update(userId: string, listingId: string, input: { previews?: { ext: string; size: number }[]; priceCents?: number }): Promise<MarketCreateResponse> {
+  async update(userId: string, listingId: string, input: {
+    previews?: { ext: string; size: number }[];
+    priceCents?: number;
+    name?: string;
+    summary?: string;
+    icon?: string;
+    tags?: string[];
+  }): Promise<MarketCreateResponse> {
     const rec = await this.mustFind(listingId);
     if (rec.userId !== userId) throw new MarketServiceError('not_owner', 403);
     if (rec.status !== 'active') throw new MarketServiceError('listing_not_found', 404);
@@ -230,9 +242,28 @@ export class MarketService {
     if (previews.length > MAX_PREVIEWS || previews.some((p) => !(p.ext in PREVIEW_EXT_CT) || !(p.size > 0) || p.size > MAX_PREVIEW_BYTES)) {
       throw new MarketServiceError('invalid_metadata', 400);
     }
+    // 升版元数据校验：仅校验非空提供的字段
+    if (input.name !== undefined && (typeof input.name !== 'string' || cpLen(input.name.trim()) < 1 || cpLen(input.name.trim()) > MAX_NAME_CP)) {
+      throw new MarketServiceError('invalid_metadata', 400);
+    }
+    if (input.summary !== undefined && (typeof input.summary !== 'string' || cpLen(input.summary.trim()) < 1 || cpLen(input.summary.trim()) > MAX_SUMMARY_CP)) {
+      throw new MarketServiceError('invalid_metadata', 400);
+    }
+    if (input.icon !== undefined && !(MARKET_ICONS as readonly string[]).includes(input.icon)) {
+      throw new MarketServiceError('invalid_metadata', 400);
+    }
+    if (input.tags !== undefined) {
+      if (!Array.isArray(input.tags) || input.tags.some((t) => typeof t !== 'string' || cpLen(t.trim()) < 1 || cpLen(t.trim()) > MAX_TAG_CP) || input.tags.length > MAX_TAGS) {
+        throw new MarketServiceError('invalid_metadata', 400);
+      }
+    }
     const pending: MarketPendingUpdate = {
       previews: previews.map((p, i) => ({ key: `next/${rec.id}-p${i + 1}${p.ext}` })),
     };
+    if (input.name !== undefined) pending.name = input.name.trim();
+    if (input.summary !== undefined) pending.summary = input.summary.trim();
+    if (input.icon !== undefined) pending.icon = input.icon;
+    if (input.tags !== undefined) pending.tags = [...new Set(input.tags.map((t) => t.trim()))].slice(0, MAX_TAGS);
     // §六：仅管理员可调价；非管理员传值被忽略
     const user = await this.deps.users.findActiveUserById(userId);
     const admin = user !== null && this.isAdminEmail(user.email);

--- a/apps/cloud/src/store/market-memory.ts
+++ b/apps/cloud/src/store/market-memory.ts
@@ -22,7 +22,7 @@ export class MemoryMarketStore implements MarketStore {
     id: string,
     patch: Partial<Pick<MarketListingRecord,
       'status' | 'removedReason' | 'fileSize' | 'version' | 'previews' | 'ossKey' | 'publishedAt' | 'pendingUpdate'
-      | 'priceCents' | 'payUrl'>>,
+      | 'priceCents' | 'payUrl' | 'name' | 'summary' | 'icon' | 'tags'>>,
     now: number,
   ): Promise<MarketListingRecord | null> {
     const r = this.listings.get(id);

--- a/apps/cloud/src/store/market-pg.ts
+++ b/apps/cloud/src/store/market-pg.ts
@@ -60,7 +60,7 @@ export class PgMarketStore implements MarketStore {
     id: string,
     patch: Partial<Pick<MarketListingRecord,
       'status' | 'removedReason' | 'fileSize' | 'version' | 'previews' | 'ossKey' | 'publishedAt' | 'pendingUpdate'
-      | 'priceCents' | 'payUrl'>>,
+      | 'priceCents' | 'payUrl' | 'name' | 'summary' | 'icon' | 'tags'>>,
     now: number,
   ): Promise<MarketListingRecord | null> {
     // 动态 SET 拼接：字段白名单固定，参数化防注入
@@ -73,6 +73,10 @@ export class PgMarketStore implements MarketStore {
     if (patch.version !== undefined) add('version', patch.version);
     if (patch.priceCents !== undefined) add('price_cents', patch.priceCents);
     if (patch.payUrl !== undefined) add('pay_url', patch.payUrl);
+    if (patch.name !== undefined) add('name', patch.name);
+    if (patch.summary !== undefined) add('summary', patch.summary);
+    if (patch.icon !== undefined) add('icon', patch.icon);
+    if (patch.tags !== undefined) add('tags', JSON.stringify(patch.tags));
     if (patch.previews !== undefined) add('previews', JSON.stringify(patch.previews));
     if (patch.ossKey !== undefined) add('oss_key', patch.ossKey);
     if (patch.pendingUpdate !== undefined) {

--- a/apps/cloud/src/store/market-types.ts
+++ b/apps/cloud/src/store/market-types.ts
@@ -6,6 +6,10 @@ import type { MarketListingSource, MarketListingStatus } from '@molio/contracts'
 /** 更新流程暂存声明（confirm 消费后清空） */
 export interface MarketPendingUpdate {
   previews: { key: string }[]; // 新效果图暂存键；空数组 = 沿用旧图
+  name?: string;
+  summary?: string;
+  icon?: string;
+  tags?: string[];
 }
 
 export interface MarketListingRecord {
@@ -38,9 +42,10 @@ export interface MarketListingRecord {
 export interface MarketStore {
   insertListing(rec: MarketListingRecord): Promise<void>;
   findListingById(id: string): Promise<MarketListingRecord | null>;
-  /** 部分字段更新；不存在返回 null。status/removedReason/fileSize/version/previews/ossKey/publishedAt/pendingUpdate/updatedAt 可改 */
+  /** 部分字段更新；不存在返回 null */
   updateListing(id: string, patch: Partial<Pick<MarketListingRecord,
     'status' | 'removedReason' | 'fileSize' | 'version' | 'previews' | 'ossKey' | 'publishedAt' | 'pendingUpdate'
+    | 'priceCents' | 'payUrl' | 'name' | 'summary' | 'icon' | 'tags'
   >>, now: number): Promise<MarketListingRecord | null>;
   /** active 列表，published_at DESC */
   listActiveListings(limit: number): Promise<MarketListingRecord[]>;

--- a/apps/cloud/test/market-service.test.ts
+++ b/apps/cloud/test/market-service.test.ts
@@ -224,3 +224,66 @@ test('pricing(§九)：公开返回价目，file=zip 全量 key；未知 id 404'
   assert.equal(p.status, 'active');
   await assert.rejects(svc.pricing('nope'), (e: unknown) => (e as MarketServiceError).code === 'listing_not_found');
 });
+
+test('更新版本：修改名称/摘要/标签 → confirm 后生效', async () => {
+  const { svc, users, objects } = makeService();
+  const u = await users.createActiveUser({ id: 'u1', email: 'a@x.com', nickname: 'n', now: 1 });
+  const c = await svc.create(u.id, VALID);
+  objects.set(c.uploads[0]!.key, 1); objects.set(c.uploads[1]!.key, 1);
+  await svc.confirm(u.id, c.listingId);
+  // 升版：改名称、摘要、标签
+  const up = await svc.update(u.id, c.listingId, {
+    previews: [],
+    name: '新名字',
+    summary: '新简介',
+    tags: ['新标签'],
+  });
+  objects.set(up.uploads[0]!.key, 2);
+  const after = await svc.confirm(u.id, c.listingId);
+  assert.equal(after.version, 'v1.1');
+  assert.equal(after.name, '新名字');
+  assert.equal(after.summary, '新简介');
+  assert.deepEqual(after.tags, ['新标签']);
+  // 图标未传，保持原值
+  assert.equal(after.icon, VALID.icon);
+});
+
+test('更新版本：只改部分字段 → 未传字段保持原值', async () => {
+  const { svc, users, objects } = makeService();
+  const u = await users.createActiveUser({ id: 'u1', email: 'a@x.com', nickname: 'n', now: 1 });
+  const c = await svc.create(u.id, VALID);
+  objects.set(c.uploads[0]!.key, 1); objects.set(c.uploads[1]!.key, 1);
+  await svc.confirm(u.id, c.listingId);
+  // 只改名称，不动摘要和标签
+  const up = await svc.update(u.id, c.listingId, {
+    previews: [],
+    name: '仅改名',
+  });
+  objects.set(up.uploads[0]!.key, 2);
+  const after = await svc.confirm(u.id, c.listingId);
+  assert.equal(after.name, '仅改名');
+  assert.equal(after.summary, VALID.summary); // 未传 → 保持原值
+  assert.deepEqual(after.tags, VALID.tags); // 未传 → 保持原值
+  assert.equal(after.icon, VALID.icon);
+});
+
+test('更新版本：元数据非法（空名/超长/非法图标）→ 400', async () => {
+  const { svc, users, objects } = makeService();
+  const u = await users.createActiveUser({ id: 'u1', email: 'a@x.com', nickname: 'n', now: 1 });
+  const c = await svc.create(u.id, VALID);
+  objects.set(c.uploads[0]!.key, 1); objects.set(c.uploads[1]!.key, 1);
+  await svc.confirm(u.id, c.listingId);
+  const badCases = [
+    { name: 'x'.repeat(31) },
+    { summary: '' },
+    { icon: '🚀' },
+    { tags: ['x'.repeat(11)] },
+    { tags: ['a', 'b', 'c', 'd'] }, // 超 3 个
+  ];
+  for (const bc of badCases) {
+    await assert.rejects(
+      svc.update(u.id, c.listingId, { previews: [], ...bc }),
+      (e: unknown) => (e as MarketServiceError).code === 'invalid_metadata',
+    );
+  }
+});

--- a/apps/daemon/src/core/market/client.ts
+++ b/apps/daemon/src/core/market/client.ts
@@ -98,7 +98,7 @@ export class MarketClient {
     return (await this.req('POST', `/listings/${id}/confirm`, { auth: true })).json();
   }
 
-  async update(id: string, previews: { ext: string; size: number }[], extra?: { priceCents?: number }): Promise<MarketCreateResponse> {
+  async update(id: string, previews: { ext: string; size: number }[], extra?: { priceCents?: number; name?: string; summary?: string; icon?: string; tags?: string[] }): Promise<MarketCreateResponse> {
     return (await (
       await this.req('POST', `/listings/${id}/update`, { auth: true, body: { previews, ...extra } })
     ).json()) as MarketCreateResponse;

--- a/apps/daemon/src/routes/market.ts
+++ b/apps/daemon/src/routes/market.ts
@@ -91,7 +91,15 @@ export function marketRoutes(db: Database.Database, auth: AuthClient, opts: Mark
     try { return c.json(await client.download(c.req.param('id'))); } catch (e) { return cloudError(c, e); }
   });
   app.get('/my', async (c) => {
-    try { return c.json(await client.my()); } catch (e) { return cloudError(c, e); }
+    try {
+      const body = await client.my();
+      // 补充 daemon 本地 market_local 映射的 vaultId（云端不感知）
+      const enriched = body.listings.map((l) => {
+        const local = db.prepare('SELECT vault_id FROM market_local WHERE listing_id = ?').get(l.id) as { vault_id: string } | undefined;
+        return { ...l, vaultId: local?.vault_id };
+      });
+      return c.json({ ...body, listings: enriched });
+    } catch (e) { return cloudError(c, e); }
   });
 
   // ── 写侧：multipart 编排 ──
@@ -203,7 +211,13 @@ export function marketRoutes(db: Database.Database, auth: AuthClient, opts: Mark
       const upd = await client.update(
         id,
         previews.map((p) => ({ ext: p.ext, size: p.size })),
-        { priceCents: parsePriceCents(parsed?.['price']) },
+        {
+          priceCents: parsePriceCents(parsed?.['price']),
+          ...(parsed && typeof parsed['name'] === 'string' && parsed['name'].trim() ? { name: parsed['name'] } : {}),
+          ...(parsed && typeof parsed['summary'] === 'string' && parsed['summary'].trim() ? { summary: parsed['summary'] } : {}),
+          ...(parsed && typeof parsed['icon'] === 'string' && parsed['icon'] ? { icon: parsed['icon'] } : {}),
+          ...(parsed && typeof parsed['tags'] === 'string' ? { tags: JSON.parse(parsed['tags']) as string[] } : {}),
+        },
       );
       await putDirect(upd.uploads[0]!, new Uint8Array(fs.readFileSync(pack.zipPath)));
       for (let i = 0; i < previews.length; i++) await putDirect(upd.uploads[i + 1]!, previews[i]!.buf);

--- a/apps/web/src/components/resources/MyListingsPanel.tsx
+++ b/apps/web/src/components/resources/MyListingsPanel.tsx
@@ -10,7 +10,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { MarketMyListing } from '@molio/contracts';
 import { useI18n } from '../../i18n';
-import { PublishWizard } from './PublishWizard';
 
 interface MyListingsPanelProps {
   onClose: () => void;
@@ -20,7 +19,6 @@ export function MyListingsPanel({ onClose }: MyListingsPanelProps) {
   const { t } = useI18n();
   const [listings, setListings] = useState<MarketMyListing[] | null>(null); // null = 加载中
   const [error, setError] = useState<string | null>(null);
-  const [updateTarget, setUpdateTarget] = useState<MarketMyListing | null>(null);
   const [removeTarget, setRemoveTarget] = useState<MarketMyListing | null>(null);
   const [restoreTarget, setRestoreTarget] = useState<MarketMyListing | null>(null);
   const [removing, setRemoving] = useState(false);
@@ -119,9 +117,6 @@ export function MyListingsPanel({ onClose }: MyListingsPanelProps) {
                     </a>
                     {l.status === 'active' && (
                       <>
-                        <button type="button" className="mylistings-action" onClick={() => setUpdateTarget(l)}>
-                          {t('myListings.update')}
-                        </button>
                         <button
                           type="button"
                           className="mylistings-action is-danger"
@@ -175,16 +170,6 @@ export function MyListingsPanel({ onClose }: MyListingsPanelProps) {
           </div>
         )}
       </div>
-
-      {updateTarget && (
-        <PublishWizard
-          vaultName={updateTarget.name}
-          updateListingId={updateTarget.id}
-          listing={updateTarget}
-          onClose={() => setUpdateTarget(null)}
-          onPublished={() => { void load(); }}
-        />
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/resources/PublishForm.tsx
+++ b/apps/web/src/components/resources/PublishForm.tsx
@@ -1,7 +1,10 @@
 /**
  * 发布表单 —— 双外壳共享组件（modal / page 两个 variant）：
- * - variant="modal"：overlay 弹窗（PublishWizard shim 沿用，「我的上架」更新模式）。
- * - variant="page"：KB 页内独立 tab 页（首发入口）。
+ * - variant="modal"：overlay 弹窗（PublishWizard shim 沿用）。
+ * - variant="page"：KB 页内独立 tab 页（首发 + 更新入口）。
+ *
+ * page 模式下顶部显示已上架条目选择器：选中某条目 → 切换为更新模式，
+ * 用当前 vault 内容打包上传；未选中 → 首发模式。
  *
  * AI 起草（名称/简介/标签/图标）由用户**主动点击**「AI 一键配置」触发
  * （POST /api/market/publish-suggest，见 daemon core/market/suggest.ts），
@@ -10,9 +13,8 @@
  * 效果图一律用户手动上传（1-4 张，前端预检），无任何图片生成。
  *
  * 提交：元数据 + 效果图 → POST /api/market/publish。
- * 更新模式（updateListingId）：元数据只读回显、效果图可选，
- * 走 POST /api/market/listings/:id/update；vaultId 缺省时由 daemon 回退
- * market_local 本地映射（见 apps/daemon/src/routes/market.ts）。
+ * 更新模式：元数据可编辑、效果图可选，
+ * 走 POST /api/market/listings/:id/update。
  * 错误码优先映射 t('publish.error.' + code)，未命中回落原始码。
  *
  * modal 外壳骨架沿用 kb-modal 惯例（见 AccountModal/KbModals），overlay 用
@@ -63,20 +65,58 @@ type GenPhase = 'idle' | 'loading' | 'done' | 'failed';
 
 export function PublishForm(props: PublishFormProps) {
   const { t } = useI18n();
-  const isUpdate = props.updateListingId !== undefined;
-  const [name, setName] = useState(props.initialData?.name ?? '');
-  const [summary, setSummary] = useState(props.initialData?.summary ?? '');
-  const [icon, setIcon] = useState<string>(props.initialData?.icon ?? MARKET_ICONS[0]);
-  const [tags, setTags] = useState<string[]>(props.initialData?.tags ?? []);
+
+  // ── page 模式：已上架条目选择器（选中 → 更新模式，用当前 vault 打包）──
+  const [myListings, setMyListings] = useState<MarketMyListing[]>([]);
+  const [selectedListingId, setSelectedListingId] = useState<string | null>(null);
+  useEffect(() => {
+    if (props.variant !== 'page') return;
+    let alive = true;
+    fetch('/api/market/my')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((m: { listings?: MarketMyListing[] } | null) => {
+        if (alive && m) setMyListings(m.listings ?? []);
+      })
+      .catch(() => { /* 未登录/失败：不显示选择器 */ });
+    return () => { alive = false; };
+  }, [props.variant]);
+
+  // 有效 listing：props 传入（modal）或 page 内选择
+  const selectedListing = myListings.find((l) => l.id === selectedListingId) ?? null;
+  const effectiveListing = props.listing ?? selectedListing;
+  const isUpdate = props.updateListingId !== undefined || selectedListingId !== null;
+  const effectiveUpdateListingId = props.updateListingId ?? selectedListingId ?? undefined;
+
+  const [name, setName] = useState(props.initialData?.name ?? props.listing?.name ?? '');
+  const [summary, setSummary] = useState(props.initialData?.summary ?? props.listing?.summary ?? '');
+  const [icon, setIcon] = useState<string>(props.initialData?.icon ?? props.listing?.icon ?? MARKET_ICONS[0]);
+  const [tags, setTags] = useState<string[]>(props.initialData?.tags ?? props.listing?.tags ?? []);
   const [tagInput, setTagInput] = useState(''); // 自定义标签输入
   const [previews, setPreviews] = useState<File[]>([]);
   const [agreed, setAgreed] = useState(false);
   const [phase, setPhase] = useState<'form' | 'working' | 'done'>('form');
   const [error, setError] = useState<string | null>(null);
 
+  // page 模式切换 listing 时，重置表单为所选 listing 的元数据
+  useEffect(() => {
+    if (!selectedListing) return;
+    setName(selectedListing.name);
+    setSummary(selectedListing.summary);
+    setIcon(selectedListing.icon);
+    setTags(selectedListing.tags);
+    setPrice(selectedListing.priceCents > 0 ? String(selectedListing.priceCents / 100) : '');
+    setPreviews([]);
+    setAgreed(false);
+    setPhase('form');
+    setError(null);
+  }, [selectedListingId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // ── 定价（Model A：仅管理员可设 >0 + 外链 payUrl；非管理员固定 0 元不可交互）──
   const [isAdmin, setIsAdmin] = useState(false);
-  const [price, setPrice] = useState<string>(() => (props.listing && props.listing.priceCents > 0 ? String(props.listing.priceCents / 100) : ''));
+  const [price, setPrice] = useState<string>(() => {
+    const l = props.listing ?? null;
+    return l && l.priceCents > 0 ? String(l.priceCents / 100) : '';
+  });
   useEffect(() => {
     let alive = true;
     fetch('/api/market/my')
@@ -91,10 +131,10 @@ export function PublishForm(props: PublishFormProps) {
   const [selectedDirs, setSelectedDirs] = useState<string[]>(props.initialData?.selectedDirs ?? ['wiki', '.molio']);
 
   useEffect(() => {
+    // 升版不显示目录选择（打包整个 vault），仅首发需要
     if (!props.vaultId || isUpdate) return;
     api.getTopDirs(props.vaultId).then((dirs) => {
       setTopDirs(dirs);
-      // 如果有初始数据，沿用其选择；否则默认选 wiki 和 .molio
       if (!props.initialData) {
         setSelectedDirs(dirs.filter((d) => d === 'wiki' || d === '.molio'));
       }
@@ -177,11 +217,9 @@ export function PublishForm(props: PublishFormProps) {
 
   const submit = async () => {
     setError(null);
-    if (!isUpdate) {
-      if (!name.trim() || !summary.trim()) { setError(t('publish.error.required')); return; }
-      if (previews.length < 1) { setError(t('publish.error.previewRequired')); return; }
-      if (!agreed) { setError(t('publish.error.agreement')); return; }
-    }
+    if (!name.trim() || !summary.trim()) { setError(t('publish.error.required')); return; }
+    if (!isUpdate && previews.length < 1) { setError(t('publish.error.previewRequired')); return; }
+    if (!agreed) { setError(t('publish.error.agreement')); return; }
     if (isAdmin) {
       const pn = Number(price);
       if (price.trim() && !Number.isFinite(pn)) { setError(t('publish.error.priceInvalid')); return; }
@@ -189,14 +227,12 @@ export function PublishForm(props: PublishFormProps) {
     setPhase('working');
     const form = new FormData();
     if (props.vaultId) form.set('vaultId', props.vaultId);
-    if (!isUpdate) {
-      form.set('name', name.trim());
-      form.set('summary', summary.trim());
-      form.set('icon', icon);
-      form.set('tags', JSON.stringify(tags));
-      // 目录选择：始终传递（即使全选也不依赖默认值，保持显式语义）
-      if (selectedDirs.length > 0) form.set('include', JSON.stringify(selectedDirs));
-    }
+    form.set('name', name.trim());
+    form.set('summary', summary.trim());
+    form.set('icon', icon);
+    form.set('tags', JSON.stringify(tags));
+    // 目录选择：仅首发传递；升版不传 include（daemon 打包整个 vault）
+    if (!isUpdate && selectedDirs.length > 0) form.set('include', JSON.stringify(selectedDirs));
     // 定价：仅管理员透传，云端对非管理员强制 0
     if (isAdmin) {
       if (price.trim()) form.set('price', price.trim());
@@ -204,7 +240,7 @@ export function PublishForm(props: PublishFormProps) {
     // 更新模式效果图可选：不传即沿用旧图（daemon 侧语义）
     previews.forEach((f) => form.append('previews', f));
     const url = isUpdate
-      ? `/api/market/listings/${props.updateListingId}/update`
+      ? `/api/market/listings/${effectiveUpdateListingId}/update`
       : '/api/market/publish';
     try {
       const res = await fetch(url, { method: 'POST', body: form });
@@ -285,47 +321,65 @@ export function PublishForm(props: PublishFormProps) {
   const bodyContent = (
     <>
       <p className="publish-vault">{icon} {props.vaultName}</p>
-      {!isUpdate && (
-        <div className="publish-ai" aria-live="polite">
-          {(genPhase === 'idle' || genPhase === 'failed') && (
-            <>
-              <button
-                type="button"
-                className="kb-btn kb-btn-primary publish-ai-btn"
-                data-testid="publish-ai-btn"
-                disabled={phase !== 'form'}
-                onClick={() => generateSuggestion(false)}
-              >
-                {genPhase === 'failed' ? t('publish.aiRetry') : t('publish.aiConfig')}
-              </button>
-              <span className="publish-ai-hint">{t('publish.aiConfigHint')}</span>
-              {genPhase === 'failed' && <span className="publish-ai-failed">{t('publish.aiFailed')}</span>}
-            </>
-          )}
-          {genPhase === 'loading' && (
-            <>
-              <span className="publish-working-spinner publish-ai-spinner" aria-hidden="true" />
-              <span>{t('publish.aiGenerating')}</span>
-            </>
-          )}
-          {genPhase === 'done' && (
-            <>
-              <span>{t('publish.aiHint')}</span>
-              <button
-                type="button"
-                className="publish-ai-regen"
-                data-testid="publish-ai-regen"
-                disabled={phase !== 'form'}
-                onClick={() => generateSuggestion(true)}
-              >
-                {t('publish.aiRegenerate')}
-              </button>
-            </>
-          )}
+      {props.variant === 'page' && myListings.length > 0 && (
+        <div className="publish-listing-select">
+          <label className="publish-field">
+            <span>{t('publish.selectListing')}</span>
+            <select
+              value={selectedListingId ?? ''}
+              onChange={(e) => setSelectedListingId(e.target.value || null)}
+            >
+              <option value="">{t('publish.newListing')}</option>
+              {myListings.filter((l) => l.status === 'active').map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.icon} {l.name} ({l.version})
+                </option>
+              ))}
+            </select>
+          </label>
         </div>
       )}
-      {phase === 'form' && !isUpdate && (
+      {phase === 'form' && (
         <div className="publish-form">
+          {!isUpdate && (
+            <div className="publish-ai" aria-live="polite">
+              {(genPhase === 'idle' || genPhase === 'failed') && (
+                <>
+                  <button
+                    type="button"
+                    className="kb-btn kb-btn-primary publish-ai-btn"
+                    data-testid="publish-ai-btn"
+                    disabled={phase !== 'form'}
+                    onClick={() => generateSuggestion(false)}
+                  >
+                    {genPhase === 'failed' ? t('publish.aiRetry') : t('publish.aiConfig')}
+                  </button>
+                  <span className="publish-ai-hint">{t('publish.aiConfigHint')}</span>
+                  {genPhase === 'failed' && <span className="publish-ai-failed">{t('publish.aiFailed')}</span>}
+                </>
+              )}
+              {genPhase === 'loading' && (
+                <>
+                  <span className="publish-working-spinner publish-ai-spinner" aria-hidden="true" />
+                  <span>{t('publish.aiGenerating')}</span>
+                </>
+              )}
+              {genPhase === 'done' && (
+                <>
+                  <span>{t('publish.aiHint')}</span>
+                  <button
+                    type="button"
+                    className="publish-ai-regen"
+                    data-testid="publish-ai-regen"
+                    disabled={phase !== 'form'}
+                    onClick={() => generateSuggestion(true)}
+                  >
+                    {t('publish.aiRegenerate')}
+                  </button>
+                </>
+              )}
+            </div>
+          )}
           <label className="publish-field">
             <span>{t('publish.name')}</span>
             <input value={name} maxLength={30} onChange={(e) => setName(e.target.value)} />
@@ -338,7 +392,6 @@ export function PublishForm(props: PublishFormProps) {
           <div className="publish-field">
             <span>{t('publish.tags')}</span>
             <div className="publish-tags" aria-label={t('publish.tags')}>
-              {/* 标签由 AI 起草（≤2 个），点击移除；自定义标签同样可移除 */}
               {tags.map((tg) => (
                 <button
                   key={tg}
@@ -385,42 +438,7 @@ export function PublishForm(props: PublishFormProps) {
             </div>
           )}
           <div className="publish-previews">
-            <p>{t('publish.previews')}</p>
-            {previewGrid}
-          </div>
-          {priceFields}
-          <label className="publish-agreement">
-            <input type="checkbox" checked={agreed} onChange={(e) => setAgreed(e.target.checked)} />
-            <span>{t('publish.agreement')}</span>
-          </label>
-        </div>
-      )}
-      {phase === 'form' && isUpdate && (
-        <div className="publish-form">
-          {props.listing && (
-            <div className="publish-meta">
-              <div className="publish-meta-row">
-                <span className="k">{t('publish.name')}</span>
-                <span className="v">{props.listing.icon} {props.listing.name}</span>
-              </div>
-              <div className="publish-meta-row">
-                <span className="k">{t('publish.summary')}</span>
-                <span className="v">{props.listing.summary}</span>
-              </div>
-              {props.listing.tags.length > 0 && (
-                <div className="publish-meta-row">
-                  <span className="k">{t('publish.tags')}</span>
-                  <span className="v">{props.listing.tags.join(' · ')}</span>
-                </div>
-              )}
-              <div className="publish-meta-row">
-                <span className="k">{t('resources.info.version')}</span>
-                <span className="v">{props.listing.version}</span>
-              </div>
-            </div>
-          )}
-          <div className="publish-previews">
-            <p>{t('publish.previewsUpdate')}</p>
+            <p>{isUpdate ? t('publish.previewsUpdate') : t('publish.previews')}</p>
             {previewGrid}
           </div>
           {priceFields}

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -715,6 +715,8 @@ const en: Record<string, string> = {
   'publish.agreement': 'I confirm I have the right to publicly share this content, and understand it will be listed immediately and downloadable by any user',
   'publish.submit': 'Publish',
   'publish.submitUpdate': 'Update',
+  'publish.selectListing': 'Update existing listing',
+  'publish.newListing': 'Publish new listing',
   'publish.working': 'Packing and uploading…',
   'publish.done': 'Published successfully',
   'publish.paidCta': 'Want to sell a knowledge base? Contact us',

--- a/apps/web/src/i18n/locales/zh.ts
+++ b/apps/web/src/i18n/locales/zh.ts
@@ -715,6 +715,8 @@ const zh: Record<string, string> = {
   'publish.agreement': '我确认对以上内容拥有公开分享的权利，并知晓发布后将立即公开上架、任何用户可下载',
   'publish.submit': '发布',
   'publish.submitUpdate': '更新',
+  'publish.selectListing': '更新已有资源',
+  'publish.newListing': '发布新资源',
   'publish.working': '正在打包并上传…',
   'publish.done': '发布成功',
   'publish.paidCta': '想上架收费知识库？联系我们',

--- a/packages/contracts/src/market.ts
+++ b/packages/contracts/src/market.ts
@@ -56,6 +56,8 @@ export interface MarketListing {
 export interface MarketMyListing extends MarketListing {
   status: MarketListingStatus;
   removedReason: string | null;
+  /** daemon 本地 market_local 映射的 vault id（云端不感知，仅 /api/market/my 回传） */
+  vaultId?: string;
 }
 
 /** 单个上传目标（预签名） */


### PR DESCRIPTION
## 改动内容

### 升版表单与发布对齐
- 升版时可编辑名称/摘要/标签/图标（元数据经 pendingUpdate 暂存，confirm 时应用）
- 升版时 publishedAt 同步更新（资源列表按最新更新时间排序）
- 效果图仍可选（不传沿用旧图）

### 更新入口移到 KB 页
- 更新入口从「我的上架」移到 KB 页发布 tab（用当前 vault 打包，消除 vault 归属歧义）
- KB 页发布 tab 顶部加 listing 选择器，选中即切更新模式
- MyListingsPanel 移除「更新版本」按钮

### 全链路透传
- MarketPendingUpdate 加 name/summary/icon/tags
- cloud update() 校验+暂存元数据，confirmUpdate() 应用
- daemon 路由 + 客户端透传新字段
- MarketMyListing 加 vaultId（daemon /api/market/my 从 market_local 补充）

### 测试
- 新增 3 个云端测试（元数据修改/部分更新/非法校验）
- cloud 148 测试全通过

## 部署注意
- 需要部署 cloud 到 FC 才能在生产生效：node apps/cloud/scripts/deploy-package.mjs
- 部署包已生成：apps/cloud/molio-cloud-deploy.zip（52.1MB）
- 部署前升版只能换资源包+版本号，改元数据会被云端忽略

🤖 Generated with [Claude Code](https://claude.com/claude-code)