### PR TITLE
fix(web): pdf.js v6 在 Electron 40/Chromium 144 中文乱码 —— polyfill Math.sumPrecise

### DIFF
--- a/apps/web/src/components/kb/map-polyfills.test.ts
+++ b/apps/web/src/components/kb/map-polyfills.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { installMapPolyfills } from './map-polyfills.ts';
+
+// 导入 map-polyfills 即触发副作用 installMapPolyfills()（文件底部）——Node 24 恰好没有
+// Math.sumPrecise / Map.prototype.getOrInsert*（等同 Electron 40 / Chromium 144 缺失场景），
+// 因此这里测到的正是 polyfill 本身，而非引擎原生实现。
+
+test('map-polyfills 补齐 Math.sumPrecise 且求和语义正确', () => {
+  installMapPolyfills();
+  assert.equal(typeof Math.sumPrecise, 'function');
+  assert.equal(Math.sumPrecise([1, 2, 3]), 6);
+  assert.equal(Math.sumPrecise([0.1, 0.2]), 0.1 + 0.2); // IEEE 754 浮点累加
+  assert.equal(Math.sumPrecise([]), 0);
+  // pdf.js 用它求缓冲长度：传入的都是小整数
+  assert.equal(Math.sumPrecise([1024, 512, 256]), 1792);
+});
+
+test('installMapPolyfills 幂等：已存在时不覆盖', () => {
+  const sp = Math.sumPrecise;
+  assert.equal(typeof sp, 'function');
+  installMapPolyfills();
+  installMapPolyfills();
+  assert.equal(typeof Math.sumPrecise, 'function');
+  assert.equal(Math.sumPrecise, sp, '已存在的 sumPrecise 不应被覆盖');
+});
+
+test('installMapPolyfills 补齐 Map.prototype.getOrInsert / getOrInsertComputed', () => {
+  installMapPolyfills();
+  assert.equal(typeof Map.prototype.getOrInsert, 'function');
+  assert.equal(typeof Map.prototype.getOrInsertComputed, 'function');
+  const m = new Map<string, number>();
+  m.getOrInsert('k', 1);
+  assert.equal(m.getOrInsert('k', 2), 1, 'getOrInsert 应保留现值');
+  assert.equal(m.getOrInsertComputed('c', (k) => k.length), 1);
+  assert.equal(m.getOrInsertComputed('c', () => 99), 1, 'getOrInsertComputed 应命中缓存');
+});

--- a/apps/web/src/components/kb/map-polyfills.ts
+++ b/apps/web/src/components/kb/map-polyfills.ts
@@ -1,12 +1,14 @@
 /**
- * ES2025 `Map` 补充方法 polyfill。
+ * pdf.js v6 所需、而 Electron 40（内置 Chromium 144）缺失的补充 polyfill。
  *
- * pdf.js v6 依赖 `Map.prototype.getOrInsert` / `getOrInsertComputed`
- * （ES2025，Chromium 145+ 才落地）。Electron 40 内置 Chromium 144 尚未实现，
- * 直接运行会抛 `this._requestsByChunk.getOrInsertComputed is not a function`，
- * 导致所有 PDF 加载失败（主线程 getDocument 与 worker 页面渲染都会踩到）。
+ * 缺一即破坏 PDF 渲染：
+ * - `Map.prototype.getOrInsert` / `getOrInsertComputed`（ES2025，Chromium 145+）
+ *   缺失会抛 `this._requestsByChunk.getOrInsertComputed is not a function`，所有 PDF 加载失败。
+ * - `Math.sumPrecise`（TC39 ULP 求和提案，Chromium 145+）缺失会被 pdf.js 的字节流读取
+ *   路径吞成 Warning，导致缓冲长度算错、非内嵌字体（如微软雅黑）渲染成 `!"#$%` 乱码
+ *   （页面图像正常、canvas 文字乱码，但文本层抽取的 Unicode/复制/搜索仍正确）。
  *
- * 这两个方法都是纯 JS 语义（无引擎内部依赖），可以安全 polyfill。
+ * 这些方法都是纯 JS 语义（无引擎内部依赖），可以安全 polyfill。
  * 必须在 pdfjs-dist 及其 worker 加载前执行：
  *   - 主线程：main.tsx（应用入口）导入本模块
  *   - worker：pdf-worker.mjs（worker 包装入口）导入本模块
@@ -18,6 +20,10 @@ declare global {
     getOrInsert(key: K, value: V): V;
     /** 若 key 已存在返回现值，否则调用 callback(key) 得到值并插入返回（ES2025）。 */
     getOrInsertComputed(key: K, callback: (key: K) => V): V;
+  }
+  interface Math {
+    /** TC39 ULP 求和（Chromium 145+/Node 25+；本库需 polyfill 以支撑 pdf.js v6）。 */
+    sumPrecise(values: Iterable<number>): number;
   }
 }
 
@@ -36,6 +42,15 @@ export function installMapPolyfills(): void {
     ): V {
       if (!this.has(key)) this.set(key, callback(key));
       return this.get(key)!;
+    };
+  }
+  // `Math.sumPrecise`（见文件头注释）：pdf.js 读 PDF 字节流时用它求缓冲长度。
+  // 简单累加即可满足求和语义（缓冲长度都是小整数）。
+  if (typeof Math.sumPrecise !== 'function') {
+    Math.sumPrecise = function sumPrecise(values: Iterable<number>): number {
+      let sum = 0;
+      for (const v of values) sum += Number(v);
+      return sum;
     };
   }
 }


### PR DESCRIPTION
## 问题

用户桌面端（Electron 40 / Chromium 144）打开知识库里的中文 PDF（艾瑞 72 页），**页面图像正常、canvas 上的文字乱码（显示成 `!"#$%` 符号），但选中/复制/搜索出的文字正常**。

## 排查与根因（已在本机 Electron 40 复现确认）

多环境验证 pdf.js 渲染：Node legacy、Chromium 148 均正常；**Electron 40 复现乱码**。控制台出现两条 Chromium 148 没有的告警：
- `Warning: Cannot load system font: MicrosoftYaHei`
- `Warning: TypeError: Math.sumPrecise is not a function`

根因：**Chromium 144 缺 `Math.sumPrecise`**（TC39 ULP 求和提案，Chromium 145+ / Node 25+ 才有）。pdf.js v6 读 PDF 字节流时用它求缓冲长度（`build/pdf.mjs:21479`），144 里调用抛该 TypeError（被 pdf.js 吞成 Warning），导致缓冲长度算错、非内嵌字体（如微软雅黑）解析错乱 → 渲染成 `!"#$%` 乱码。文本层抽取的 Unicode 不受影响，故复制/搜索正常。

## 修复

`apps/web/src/components/kb/map-polyfills.ts` 增加 `Math.sumPrecise` polyfill（该文件已覆盖 `Map.prototype.getOrInsert/getOrInsertComputed`），主线程与 worker 均在 pdfjs 加载前注入。

## 验证

- **复现确认**：Electron 40.10.2（Chromium 144）+ 真实 daemon + 真实 PDF，加 polyfill 前 canvas 为 `!"#$%` 乱码，加后正确渲染中文；Chromium 148 不受影响。
- `pnpm --filter @molio/web typecheck` ✅
- 新增 `src/components/kb/map-polyfills.test.ts`（node:test，3 用例全过）：Node 24 恰缺 `Math.sumPrecise`（等同 Chromium 144），导入即触发副作用补齐，据此验证求和语义/幂等/Map 方法。
- E2E 无心智负担：乱码是 Chromium 144 特性，CI（Chromium 148）无法复现，故用 node:test 单元测试守卫 polyfill 语义；现有 `pdf-preview.spec.ts` 覆盖渲染无回归。
