### PR TITLE
feat(daemon): 图谱局部接口 —— file/dir scope 局部图后端 + getLocalGraph client

### DIFF
--- a/apps/daemon/CLAUDE.md
+++ b/apps/daemon/CLAUDE.md
@@ -84,7 +84,7 @@ src/
     projects.ts       CRUD /api/projects — 项目管理
     knowledge.ts      CRUD /api/knowledge — 知识库管理
     publish.ts        POST /api/publish — 发布到内容平台
-    graph.ts          GET /api/graph — 知识图谱数据
+    graph.ts          GET /api/graph/:vaultId 全量图 + /:vaultId/local 局部子图（buildLocalGraph，scope=file|dir，返回含 focusNodes）
     maintenance.ts    POST /api/maintenance/rebuild-fts — 重建 FTS 索引（灾难恢复）
     weixin.ts         POST /api/weixin — 微信回调
     feishu.ts         GET/POST /api/feishu/* — 飞书渠道 (status/start/stop/disconnect/config)
@@ -132,7 +132,8 @@ pnpm typecheck    # tsc --noEmit
 | POST | `/api/maintenance/rebuild-fts` | 重建 messages_fts 索引（灾难恢复） |
 | GET/POST/PUT/DELETE | `/api/knowledge` | 知识库管理 |
 | POST | `/api/publish` | 发布到内容平台 |
-| GET | `/api/graph` | 知识图谱数据 |
+| GET | `/api/graph/:vaultId` | 知识图谱数据（全量） |
+| GET | `/api/graph/:vaultId/local` | 局部子图（?scope=file\|dir&path=&depth=，返回含 focusNodes） |
 | POST | `/api/weixin` | 微信回调 |
 | GET | `/api/feishu/status` | 飞书通道状态 |
 | POST | `/api/feishu/start` | 启动飞书 WebSocket 长连接 |

--- a/apps/daemon/src/routes/graph.ts
+++ b/apps/daemon/src/routes/graph.ts
@@ -69,6 +69,53 @@ export function graphRoutes(db: Database.Database): Hono {
     }
   });
 
+  // GET /api/graph/:vaultId/local — scoped sub-graph（file=1跳邻域 / dir=文件夹子图）
+  app.get('/:vaultId/local', (c) => {
+    const vault = getVault(db, c.req.param('vaultId'));
+    if (!vault) {
+      return c.json({ error: { code: 'NOT_FOUND', message: 'Vault not found' } }, 404);
+    }
+
+    const scopeType = c.req.query('scope');
+    if (scopeType !== 'file' && scopeType !== 'dir') {
+      return c.json(
+        { error: { code: 'BAD_REQUEST', message: "query 'scope' must be 'file' or 'dir'" } },
+        400,
+      );
+    }
+    const scopePath = (c.req.query('path') ?? '').trim().replace(/\/+$/, '');
+    if (!scopePath) {
+      return c.json({ error: { code: 'BAD_REQUEST', message: "query 'path' is required" } }, 400);
+    }
+    const depthRaw = c.req.query('depth');
+    let depth = 1;
+    if (depthRaw != null && depthRaw !== '') {
+      depth = Number(depthRaw);
+      if (!Number.isInteger(depth) || depth < 1) {
+        return c.json(
+          { error: { code: 'BAD_REQUEST', message: "query 'depth' must be a positive integer" } },
+          400,
+        );
+      }
+      if (depth > 1) {
+        return c.json(
+          { error: { code: 'BAD_REQUEST', message: 'depth > 1 is not supported yet' } },
+          400,
+        );
+      }
+    }
+
+    try {
+      const scope: GraphScope =
+        scopeType === 'file' ? { type: 'file', path: scopePath, depth } : { type: 'dir', path: scopePath };
+      const graphData = buildLocalGraph(vault.path, scope);
+      return c.json(graphData);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to build local graph';
+      return c.json({ error: { code: 'INTERNAL', message } }, 500);
+    }
+  });
+
   return app;
 }
 

--- a/apps/daemon/src/routes/graph.ts
+++ b/apps/daemon/src/routes/graph.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 import type Database from 'better-sqlite3';
 import { getVault } from '../core/db.js';
 import { scanTree, resolveFilePath } from '../core/knowledge.js';
-import type { GraphNode, GraphEdge, GraphData, DeadLinkInfo } from '@molio/contracts';
+import type { GraphNode, GraphEdge, GraphData, DeadLinkInfo, GraphScope } from '@molio/contracts';
 
 /**
  * 从知识图谱中剔除的文件名：index/log 这类文件只是导航/索引页，不代表知识点，
@@ -208,6 +208,58 @@ export function buildGraph(vaultPath: string): GraphData {
   });
 
   return { nodes, edges: edgeList, deadLinks: deadLinksList };
+}
+
+/**
+ * Build a scoped sub-graph from the full vault graph（设计 docs/2026-09-04-local-graph-scope-design.md §3）.
+ *
+ * - file scope：圆心（path 精确匹配）+ 1 跳闭邻域 + 诱导边；圆心不存在/被剔除/孤立（linkCount===0）→ 空图
+ * - dir scope：目录前缀下全部 .md 节点 + 它们之间的边；目录内节点引用的目录外死链目标并入；跨目录真实文件边界不含
+ * 返回必含 focusNodes：file=圆心单点；dir=子图全部节点；空图=[]（全量图接口不回填该字段）。
+ */
+// 返回类型收窄：局部图必含 focusNodes（GraphData 里是可选字段，全量图接口才不回填）
+export function buildLocalGraph(vaultPath: string, scope: GraphScope): GraphData & { focusNodes: string[] } {
+  const full = buildGraph(vaultPath);
+  const inSet = new Set<string>();
+  let focus: string[] = [];
+
+  if (scope.type === 'file') {
+    const center = full.nodes.find((n) => !n.deadLink && n.path === scope.path);
+    if (!center || center.linkCount === 0) {
+      return { nodes: [], edges: [], deadLinks: [], focusNodes: [] };
+    }
+    inSet.add(center.key);
+    for (const e of full.edges) {
+      if (e.source === center.key) inSet.add(e.target);
+      else if (e.target === center.key) inSet.add(e.source);
+    }
+    focus = [center.key];
+  } else {
+    const prefix = `${scope.path.replace(/\/+$/, '')}/`;
+    for (const n of full.nodes) {
+      if (!n.deadLink && n.path.startsWith(prefix)) inSet.add(n.key);
+    }
+    if (inSet.size === 0) {
+      return { nodes: [], edges: [], deadLinks: [], focusNodes: [] };
+    }
+    // 目录内节点链到目录外死链目标 → 死链节点并入（点它可新建页面）；
+    // 真实文件的跨目录边界不含（后续增强）。死链节点无出边，不会级联扩散。
+    for (const e of full.edges) {
+      const sIn = inSet.has(e.source);
+      const tIn = inSet.has(e.target);
+      if (sIn === tIn) continue;
+      const otherKey = sIn ? e.target : e.source;
+      if (full.nodes.some((n) => n.key === otherKey && n.deadLink)) inSet.add(otherKey);
+    }
+    focus = Array.from(inSet);
+  }
+
+  const nodes = full.nodes.filter((n) => inSet.has(n.key));
+  const keys = new Set(nodes.map((n) => n.key));
+  const edges = full.edges.filter((e) => keys.has(e.source) && keys.has(e.target));
+  // deadLinks 元数据按「死链节点在子图内」过滤（不按 sourceFile——首见 source 可能不在子图）
+  const deadLinks = full.deadLinks.filter((d) => keys.has(`__dead__${d.targetName.toLowerCase()}`));
+  return { nodes, edges, deadLinks, focusNodes: focus };
 }
 
 /**

--- a/apps/daemon/test/routes/graph-local.test.ts
+++ b/apps/daemon/test/routes/graph-local.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { Hono } from 'hono';
+import { buildLocalGraph, graphRoutes } from '../../src/routes/graph.js';
+import { openDatabase, closeDatabase, createVault } from '../../src/core/db.js';
+import type { GraphScope } from '@molio/contracts';
+
+/**
+ * 局部图谱单测（buildLocalGraph + GET /api/graph/:vaultId/local）。
+ *
+ * 设计：docs/2026-09-04-local-graph-scope-design.md §3 / §七
+ * - file scope：圆心 + 1 跳邻居（含死链目标）+ 诱导边；圆心不存在/孤立 → 空图
+ * - dir scope：目录前缀下全部 .md + 内部边 + 邻接死链；跨目录真实边界不含
+ * 每个用例独立临时 vault，互不污染。
+ */
+
+const dirs: string[] = [];
+
+function makeVault(...files: Array<[rel: string, content: string]>): string {
+  const d = mkdtempSync(join(tmpdir(), 'molio-graph-local-test-'));
+  dirs.push(d);
+  for (const [rel, content] of files) {
+    const abs = join(d, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content, { encoding: 'utf-8' });
+  }
+  return d;
+}
+
+after(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+describe('buildLocalGraph — file scope（1 跳邻域）', () => {
+  it('圆心 + 入边/出边邻居 + 诱导边，不含 2 跳', () => {
+    // x ← a → b → d（d 是 2 跳）；a → c
+    const g = buildLocalGraph(
+      makeVault(
+        ['a.md', '# A\n\n[[x]] [[b]] [[c]]\n'],
+        ['b.md', '# B\n\n[[d]]\n'],
+        ['c.md', '# C\n'],
+        ['d.md', '# D\n'],
+        ['x.md', '# X\n'],
+      ),
+      { type: 'file', path: 'a.md' },
+    );
+    assert.deepStrictEqual(
+      g.nodes.map((n) => n.key).sort(),
+      ['a.md', 'b.md', 'c.md', 'x.md'],
+      '2 跳 d.md 不入选',
+    );
+    assert.strictEqual(g.edges.length, 3, 'x-a / a-b / a-c');
+    assert.deepStrictEqual(g.focusNodes, ['a.md']);
+  });
+
+  it('邻居之间的诱导边包含在内', () => {
+    // a → b, a → c, b → c
+    const g = buildLocalGraph(
+      makeVault(
+        ['a.md', '# A\n\n[[b]] [[c]]\n'],
+        ['b.md', '# B\n\n[[c]]\n'],
+        ['c.md', '# C\n'],
+      ),
+      { type: 'file', path: 'a.md' },
+    );
+    assert.strictEqual(g.nodes.length, 3);
+    assert.strictEqual(g.edges.length, 3, 'b-c 边两端都在节点集内 → 保留');
+  });
+
+  it('死链目标作为 1 跳 deadLink 邻居并入', () => {
+    const g = buildLocalGraph(makeVault(['a.md', '# A\n\n[[ghost]]\n']), {
+      type: 'file',
+      path: 'a.md',
+    });
+    const ghost = g.nodes.find((n) => n.deadLink);
+    assert.ok(ghost, '死链节点存在');
+    assert.strictEqual(ghost!.label, 'ghost');
+    assert.strictEqual(g.edges.length, 1);
+    assert.strictEqual(g.deadLinks.length, 1);
+    assert.deepStrictEqual(g.focusNodes, ['a.md']);
+  });
+
+  it('孤立文档（无任何链接）→ 空图', () => {
+    const g = buildLocalGraph(makeVault(['lone.md', '# Lone\n']), { type: 'file', path: 'lone.md' });
+    assert.strictEqual(g.nodes.length, 0);
+    assert.strictEqual(g.edges.length, 0);
+    assert.deepStrictEqual(g.focusNodes, []);
+  });
+
+  it('不存在的 path / 被剔除名（index.md）→ 空图', () => {
+    const vault = makeVault(['a.md', '# A\n'], ['index.md', '# idx\n']);
+    for (const p of ['nope.md', 'index.md']) {
+      const g = buildLocalGraph(vault, { type: 'file', path: p });
+      assert.strictEqual(g.nodes.length, 0, p);
+      assert.deepStrictEqual(g.focusNodes, []);
+    }
+  });
+});
+
+describe('buildLocalGraph — dir scope（文件夹子图）', () => {
+  it('目录递归下全部 .md + 内部诱导边，跨目录真实边界不含', () => {
+    const g = buildLocalGraph(
+      makeVault(
+        ['wiki/x/p.md', '# P\n\n[[q]] [[sub/r]] [[outside]]\n'],
+        ['wiki/x/q.md', '# Q\n'],
+        ['wiki/x/sub/r.md', '# R\n'],
+        ['outside.md', '# O\n'],
+      ),
+      { type: 'dir', path: 'wiki/x' },
+    );
+    assert.deepStrictEqual(
+      g.nodes.map((n) => n.key).sort(),
+      ['wiki/x/p.md', 'wiki/x/q.md', 'wiki/x/sub/r.md'],
+      '递归覆盖 sub/；真实文件 outside.md 是边界，不含',
+    );
+    assert.strictEqual(g.edges.length, 2, 'p-q / p-r；p-outside 剔除');
+    assert.strictEqual(g.focusNodes.length, 3, 'dir scope focusNodes=全部节点');
+  });
+
+  it('目录内节点链到目录外死链 → 死链节点并入', () => {
+    const g = buildLocalGraph(
+      makeVault(['wiki/x/p.md', '# P\n\n[[ghost]]\n'], ['wiki/x/q.md', '# Q\n']),
+      { type: 'dir', path: 'wiki/x' },
+    );
+    const ghost = g.nodes.find((n) => n.deadLink);
+    assert.ok(ghost, '目录外死链目标并入');
+    assert.strictEqual(g.edges.length, 1, 'p-ghost');
+  });
+
+  it('空目录 / 无 .md 目录 / 不存在目录 → 空图', () => {
+    const vault = makeVault(['wiki/x/img.png', 'x'], ['other.md', '# O\n']);
+    for (const p of ['wiki/x', 'wiki/none']) {
+      const g = buildLocalGraph(vault, { type: 'dir', path: p });
+      assert.strictEqual(g.nodes.length, 0, p);
+      assert.deepStrictEqual(g.focusNodes, []);
+    }
+  });
+});
+
+describe('GET /api/graph/:vaultId/local', () => {
+  let app: Hono;
+  let vaultId: string;
+  let tempDir: string;
+
+  before(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'molio-graph-local-route-'));
+    dirs.push(tempDir);
+    const vaultDir = join(tempDir, 'vault');
+    mkdirSync(vaultDir, { recursive: true });
+    writeFileSync(join(vaultDir, 'a.md'), '# A\n\n[[b]]\n', 'utf-8');
+    writeFileSync(join(vaultDir, 'b.md'), '# B\n', 'utf-8');
+    mkdirSync(join(vaultDir, 'wiki', '易经'), { recursive: true });
+    writeFileSync(join(vaultDir, 'wiki', '易经', 'p.md'), '# P\n\n[[q]]\n', 'utf-8');
+    writeFileSync(join(vaultDir, 'wiki', '易经', 'q.md'), '# Q\n', 'utf-8');
+    writeFileSync(join(vaultDir, 'outside.md'), '# O\n', 'utf-8');
+    const db = openDatabase(tempDir);
+    const vault = createVault(db, 'graph-local-vault', vaultDir);
+    vaultId = vault.id;
+    const root = new Hono();
+    root.route('/api/graph', graphRoutes(db));
+    app = root;
+  });
+
+  after(() => {
+    closeDatabase();
+  });
+
+  it('file scope：圆心 + 1 跳邻居 + focusNodes', async () => {
+    const res = await app.request(`/api/graph/${vaultId}/local?scope=file&path=a.md`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { nodes: { key: string }[]; edges: unknown[]; focusNodes: string[] };
+    assert.deepEqual(body.focusNodes, ['a.md']);
+    assert.deepEqual(
+      body.nodes.map((n) => n.key).sort(),
+      ['a.md', 'b.md'],
+    );
+    assert.equal(body.edges.length, 1);
+  });
+
+  it('dir scope：中文目录（URL 编码）返回目录子图', async () => {
+    const res = await app.request(
+      `/api/graph/${vaultId}/local?scope=dir&path=${encodeURIComponent('wiki/易经')}`,
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { nodes: { key: string }[]; focusNodes: string[] };
+    assert.deepEqual(body.nodes.map((n) => n.key).sort(), ['wiki/易经/p.md', 'wiki/易经/q.md']);
+    assert.equal(body.focusNodes.length, 2);
+  });
+
+  it('scope 非法 → 400', async () => {
+    const res = await app.request(`/api/graph/${vaultId}/local?scope=both&path=a.md`);
+    assert.equal(res.status, 400);
+  });
+
+  it('缺 path → 400', async () => {
+    const res = await app.request(`/api/graph/${vaultId}/local?scope=file`);
+    assert.equal(res.status, 400);
+  });
+
+  it('depth > 1 → 400（本轮仅支持 1）', async () => {
+    const res = await app.request(`/api/graph/${vaultId}/local?scope=file&path=a.md&depth=2`);
+    assert.equal(res.status, 400);
+  });
+
+  it('vault 不存在 → 404', async () => {
+    const res = await app.request('/api/graph/nope/local?scope=file&path=a.md');
+    assert.equal(res.status, 404);
+  });
+});

--- a/apps/daemon/test/routes/graph-local.test.ts
+++ b/apps/daemon/test/routes/graph-local.test.ts
@@ -4,9 +4,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { Hono } from 'hono';
-import { buildLocalGraph, graphRoutes } from '../../src/routes/graph.js';
+import { buildGraph, buildLocalGraph, graphRoutes } from '../../src/routes/graph.js';
 import { openDatabase, closeDatabase, createVault } from '../../src/core/db.js';
-import type { GraphScope } from '@molio/contracts';
 
 /**
  * 局部图谱单测（buildLocalGraph + GET /api/graph/:vaultId/local）。
@@ -90,9 +89,9 @@ describe('buildLocalGraph — file scope（1 跳邻域）', () => {
     assert.deepStrictEqual(g.focusNodes, []);
   });
 
-  it('不存在的 path / 被剔除名（index.md）→ 空图', () => {
-    const vault = makeVault(['a.md', '# A\n'], ['index.md', '# idx\n']);
-    for (const p of ['nope.md', 'index.md']) {
+  it('不存在的 path / 被剔除名（index.md）/ 非 .md 目标 → 空图', () => {
+    const vault = makeVault(['a.md', '# A\n'], ['index.md', '# idx\n'], ['img.png', 'not-md']);
+    for (const p of ['nope.md', 'index.md', 'img.png']) {
       const g = buildLocalGraph(vault, { type: 'file', path: p });
       assert.strictEqual(g.nodes.length, 0, p);
       assert.deepStrictEqual(g.focusNodes, []);
@@ -137,6 +136,13 @@ describe('buildLocalGraph — dir scope（文件夹子图）', () => {
       assert.strictEqual(g.nodes.length, 0, p);
       assert.deepStrictEqual(g.focusNodes, []);
     }
+  });
+});
+
+describe('buildGraph 全量图不受 focusNodes 污染', () => {
+  it('全量图输出不含 focusNodes 字段', () => {
+    const g = buildGraph(makeVault(['a.md', '# A\n\n[[b]]\n'], ['b.md', '# B\n']));
+    assert.ok(!('focusNodes' in g));
   });
 });
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -4,7 +4,7 @@ import type {
   ConversationHistoryPage, ListHistoryQuery,
   Vault, TreeNode, FileContent, KbHistoryEntry, CreateVaultRequest,
   WikiStatusResponse,
-  GraphData, SearchResult, SearchResponse,
+  GraphData, GraphScope, SearchResult, SearchResponse,
   AuthStatus, SendCodeResponse, User, MeResponse,
   SkillManifestEntry, SkillDetailResponse, CreateSkillRequest, UpdateSkillRequest,
   ImportSkillRequest, PrefillResult,
@@ -910,6 +910,15 @@ export const api = {
   async getGraph(vaultId: string): Promise<GraphData> {
     const res = await fetch(`${BASE}/graph/${vaultId}`);
     if (!res.ok) throw new Error(`Failed to fetch graph: ${res.status}`);
+    return res.json();
+  },
+
+  /** 局部图谱：scope=file 单文档 1 跳邻域 / scope=dir 文件夹子图；返回含 focusNodes。 */
+  async getLocalGraph(vaultId: string, scope: GraphScope): Promise<GraphData> {
+    const params = new URLSearchParams({ scope: scope.type, path: scope.path });
+    if (scope.type === 'file' && scope.depth != null) params.set('depth', String(scope.depth));
+    const res = await fetch(`${BASE}/graph/${vaultId}/local?${params.toString()}`);
+    if (!res.ok) throw new Error(`Failed to fetch local graph: ${res.status}`);
     return res.json();
   },
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -914,7 +914,7 @@ export const api = {
   },
 
   /** 局部图谱：scope=file 单文档 1 跳邻域 / scope=dir 文件夹子图；返回含 focusNodes。 */
-  async getLocalGraph(vaultId: string, scope: GraphScope): Promise<GraphData> {
+  async getLocalGraph(vaultId: string, scope: GraphScope): Promise<GraphData & { focusNodes: string[] }> {
     const params = new URLSearchParams({ scope: scope.type, path: scope.path });
     if (scope.type === 'file' && scope.depth != null) params.set('depth', String(scope.depth));
     const res = await fetch(`${BASE}/graph/${vaultId}/local?${params.toString()}`);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -103,6 +103,7 @@ export type {
   GraphNode,
   GraphEdge,
   GraphData,
+  GraphScope,
   DeadLinkInfo,
   // Search
   SearchResult,

--- a/packages/contracts/src/knowledge.ts
+++ b/packages/contracts/src/knowledge.ts
@@ -139,10 +139,21 @@ export interface DeadLinkInfo {
   targetName: string;
 }
 
+/**
+ * 局部图 scope：
+ * - file：单文档 1 跳邻域（depth 预留，当前仅支持 1）
+ * - dir：文件夹（递归）子图
+ */
+export type GraphScope =
+  | { type: 'file'; path: string; depth?: number }
+  | { type: 'dir'; path: string };
+
 export interface GraphData {
   nodes: GraphNode[];
   edges: GraphEdge[];
   deadLinks: DeadLinkInfo[];
+  /** 仅局部图接口回填：file=圆心单点；dir=子图全部节点；空图=[]。全量图不设。 */
+  focusNodes?: string[];
 }
 
 // ─── Search ───


### PR DESCRIPTION
## 概述

实现图谱 scope 机制设计（本地文档 `docs/2026-09-04-local-graph-scope-design.md`，未随库提交——关键决策在下方重述）的**后端部分**：

- **contracts**：`GraphScope` 类型（`{type:'file'; path; depth?} | {type:'dir'; path}`）+ `GraphData.focusNodes?: string[]`（仅局部接口回填，全量图不变）
- **daemon**：`buildLocalGraph(vaultPath, scope)`（复用 buildGraph 全量输出裁子集，不二次扫盘）+ `GET /api/graph/:vaultId/local?scope=file|dir&path=&depth=`
  - file scope：圆心（path 精确匹配）+ 1 跳闭邻域 + 诱导边；圆心不存在/被剔除/孤立 → 空图；死链目标并入
  - dir scope：目录（递归）全部 .md + 内部边；目录内引用的目录外死链并入；跨目录真实文件边界不含
  - depth 参数预留，>1 → 400（本轮仅支持 1，显式报错不静默忽略）
- **web**：`api.getLocalGraph(vaultId, scope)`，返回 `Promise<GraphData & { focusNodes: string[] }>`

## 决策点（供 review 关注）

1. **dir-scope 不剔孤立节点**（设计 §3.1「所有 .md 文件节点」字面执行）；file-scope 孤立圆心 → 空图——两规则不同是有意的
2. **deadLinks 元数据按「死链节点在子图内」过滤**，不按 sourceFile（首见 source 可能不在子图但死链节点在）
3. **buildLocalGraph / getLocalGraph 返回类型收窄** `GraphData & { focusNodes: string[] }`——局部图响应必含 focusNodes；前端 PR 靠其存在性区分局部/全量（已有保护测试钉住全量图不含该字段）
4. depth>1 对 dir scope 同样 400（统一校验，显式报错）

## 范围边界

前端接线（GraphPage `graphScope` prop / KBP 副视图 / E2E graph-local.spec）**不在本 PR**——硬依赖 #248（单库分屏），合并后另开 PR。已验证 #248（feat/kb-split-view）与本 PR 文件零交集。

## 测试

- **daemon 单测**（node:test，TDD 先红后绿）：`apps/daemon/test/routes/graph-local.test.ts`，14 用例
  - file scope：1 跳邻域 / 诱导边 / 死链并入 / 孤立空图 / 不存在与被剔除名与非 .md 目标
  - dir scope：递归+诱导边+边界剔除 / 目录外死链并入 / 空目录
  - 全量图无 focusNodes 污染保护测试
  - 端点：file/dir（含中文路径 URL 编码）/400×3/404
- daemon 全量 **1385 tests / 0 fail**（5 skipped 为既有平台条件跳过）；`pnpm typecheck` 全仓绿
- **全量 Playwright E2E**（client.ts 在核心流程保护列表）：**352 passed / 1 failed / 12 skipped** —— 唯一失败 `resources.spec:25`（页面 0 卡片但 `/api/market/listings` 返回 11 条）经 A/B 对照在 **main 代码上同样失败**，且本 PR diff 零接触 resources/market 链路，判定为本地预存环境问题（与 #236 时期记录一致），与本 PR 无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)