### PR TITLE
fix(web): 深色模式下文档区整片发白 —— 图谱底色硬编码 #FAFAFA

### DIFF
--- a/apps/web/e2e/graph.spec.ts
+++ b/apps/web/e2e/graph.spec.ts
@@ -54,4 +54,28 @@ test.describe('Graph as tab', () => {
     // 图谱 pane 仍在 DOM（挂载、隐藏），证明 keep-alive 而非 re-mount
     await expect(page.locator('.graph-page')).toHaveCount(1);
   });
+
+  test('dark theme: hidden (keep-alive) graph tab must not repaint the main area light', async ({ page }) => {
+    // 深色主题在应用加载前写入 localStorage（否则首帧是浅色）
+    await page.addInitScript(() => localStorage.setItem('molio.theme', 'dark'));
+    await page.goto(`http://localhost:5173/knowledge?vault=${vault.id}`);
+    await expect(page.locator('.kb-shell')).toBeVisible({ timeout: 10_000 });
+
+    const alpha = page.locator('.kb-tree-item').filter({ hasText: 'alpha.md' });
+    await expect(alpha).toBeVisible({ timeout: 10_000 });
+    await alpha.click();
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('alpha.md', { timeout: 5_000 });
+
+    // 图谱标签 keep-alive 常驻：切回文档后 .graph-page 仍在 DOM（仅 visibility:hidden）
+    await clickNav(page, 'graph');
+    await expect(page.locator('.graph-page')).toBeVisible({ timeout: 10_000 });
+    await alpha.click();
+    await expect(page.locator('.kb-wtab.is-active')).toContainText('alpha.md', { timeout: 5_000 });
+    await expect(page.locator('.graph-page')).toHaveCount(1);
+
+    // 回归：图谱画布底曾把 .entry-main 硬编码成 #FAFAFA，且 :has() 只看 DOM 存在性，
+    // 于是隐藏的图谱标签也会让文档区整片发白。文档 pane 各层透明，底色就是 .entry-main。
+    const bg = await page.locator('.entry-main').evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).toBe('rgb(24, 24, 22)'); // --bg（深色）= #181816
+  });
 });

--- a/apps/web/e2e/split-view.spec.ts
+++ b/apps/web/e2e/split-view.spec.ts
@@ -67,6 +67,18 @@ test.describe('KB split view', () => {
     await expect(companion.locator('[data-testid="kb-nav-navigation"]')).toHaveCount(0);
   });
 
+  test('dark theme: companion pane follows the theme (no white pane)', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('molio.theme', 'dark'));
+    await openAlpha(page);
+    await splitViaContextMenu(page, 'tab-split-copy');
+
+    const companion = page.locator('[data-testid="kb-companion-pane"]');
+    await expect(companion).toBeVisible();
+    // 回归：副格底色曾硬编码 #FAFAFA（对齐图谱画布），深色模式下整格发白
+    const bg = await companion.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).toBe('rgb(24, 24, 22)'); // --bg（深色）= #181816
+  });
+
   test('文件对照: picker opens and cancel works', async ({ page }) => {
     await openAlpha(page);
     await splitViaContextMenu(page, 'tab-split-file');

--- a/apps/web/src/styles/graph.css
+++ b/apps/web/src/styles/graph.css
@@ -1,10 +1,13 @@
 /* ── Graph Page Layout ── */
 
-/* When graph page is active, make .entry-main a positioning container */
+/* When graph page is active, make .entry-main a positioning container.
+   不设背景：画布底色由 Pixi 引擎按图谱主题自绘（getThemeColors().bg），
+   loading/empty/error 各自有覆盖层。这里曾硬编码 #FAFAFA，而 :has() 只看 DOM
+   存在性——图谱标签是 keep-alive 的，隐藏时也会把整个主区域刷成浅色，
+   深色模式下文档区因此整片发白。底色跟随主题（rail.css 的 --bg）。 */
 .entry-main:has(.graph-page) {
   position: relative;
   overflow: hidden;
-  background: #FAFAFA;
 }
 
 .graph-page {

--- a/apps/web/src/styles/knowledge.css
+++ b/apps/web/src/styles/knowledge.css
@@ -2462,8 +2462,9 @@
   /* 覆盖 .kb-pane 的 inset:0 —— left 由 inline style（ratio）驱动 */
   right: 0;
   border-left: 1px solid var(--border);
-  /* 与图谱页背景一致（graph.css 用 #FAFAFA 硬编码），避免 GraphPage 副格透底 */
-  background: #FAFAFA;
+  /* 底色跟随主题（曾硬编码 #FAFAFA 对齐图谱画布，深色模式下副格整片发白）。
+     图谱画布自绘底色，不需要这层兜底。 */
+  background: var(--bg);
   min-width: 240px;
 }
 


### PR DESCRIPTION
## 现象

深色模式下打开文档，偶尔整片白底（属性卡片仍是深色，割裂感明显）。

## 根因

`apps/web/src/styles/graph.css`:

```css
.entry-main:has(.graph-page) { background: #FAFAFA; }   /* 硬编码 */
```

- `:has()` 只看 **DOM 存在性**，不看可见性；而图谱标签是 **keep-alive** 的（`kb-pane--closed` 只是 `visibility: hidden`，GraphPage 始终挂载）。
- 于是**本会话只要开过一次图谱**，`.entry-main` 就被刷成 `#FAFAFA`——即使图谱标签已经切走。
- 文档 pane 各层（`.kb-pane` → `.kb-content-area` → `#output`）都是透明，底色直接透出 `.entry-main`，所以正文整片发白。
- 这就是「偶尔」的来源：与打开文档本身无关，取决于此前是否开过图谱标签。

同一处硬编码的另一面：`.kb-pane--companion { background: #FAFAFA }` —— 左右分屏在深色模式下整格发白。

## 修复

底色跟随主题：

- `.entry-main:has(.graph-page)` 不再设背景。图谱画布本就由 Pixi 按**图谱主题**自绘（`getThemeColors().bg`，容器 `background: transparent`），`loading/empty/error` 各自有覆盖层，这层兜底早已多余。
- `.kb-pane--companion` 改用 `--bg`。

## 验证

E2E 回归两例，均**先复现失败再转绿**：

- `graph.spec.ts` — 深色 + 图谱标签 keep-alive 隐藏 → `.entry-main` 必须是深色（修复前 `rgb(250,250,250)`）
- `split-view.spec.ts` — 深色 + 左右分屏 → 副格底色必须是深色（修复前 `rgb(250,250,250)`）

受影响全量 spec 本地跑通：graph / graph-settings / knowledge / split-view **27 passed**。
`pnpm typecheck` 全包通过；`apps/web` 单测 121/121 通过。

## 未处理（同一类遗留，图谱视图内）

`graph.css` 的 `.graph-loading` / `.graph-empty` / `.graph-error` 仍是硬编码 `#FAFAFA`，深色模式下图谱加载/空/错误态会闪白。属图谱视图内部，与本次报告的「文档区发白」不同入口，未纳入本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)